### PR TITLE
feat(workflows): add rung-2 AI semantic review via GitHub Models

### DIFF
--- a/.github/scripts/ai_review_build_prompt.py
+++ b/.github/scripts/ai_review_build_prompt.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+Build the review prompt for the AI semantic-review step.
+
+Reads:
+- Env: BASE_SHA, HEAD_SHA
+- Git: registry.yaml at both refs
+
+Writes:
+- stdout: the model prompt (markdown text)
+- file:   .ai-review-entries.json — the list of entry IDs being reviewed
+          (used by the post-comment step to title the review)
+
+Side-effect-free w.r.t. the network. The actual model call happens in a
+separate workflow step (actions/ai-inference).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REGISTRY_PATH = ".github/skills/maf-obsolete-api-registry/registry.yaml"
+ENTRIES_OUT = Path(".ai-review-entries.json")
+
+SYSTEM_INSTRUCTIONS = textwrap.dedent("""
+You are reviewing entries in a Microsoft Agent Framework (MAF) breaking-change
+registry. A Coding Agent just filled in human-readable fields based on a raw
+`dotnet-inspect` diff embedded in each entry's `notes:` field. Your job is to
+catch semantic contradictions between the diff and the fills.
+
+For each entry, evaluate these checks:
+
+C1. example_before authenticity: does it actually use the obsolete API mentioned
+    in obsolete_signature / notes? If it uses a type the diff says is NEW
+    (replacement-side), it's wrong.
+C2. example_after authenticity: does it use the replacement API? It must NOT
+    reference any identifier the diff says was removed.
+C3. non-noop: example_before must materially differ from example_after.
+C4. fix_description matches the actual change: prose can't contradict notes
+    (e.g. claims rename when notes show signature change).
+C5. category is correct: TYPE-REMOVED / METHOD-RENAMED / SIGNATURE-CHANGED /
+    BEHAVIOR-CHANGED / ATTRIBUTE-REMOVED inferred from cs_warning + diff.
+C6. guide_section: must be a real section ID or "N/A" (not "TBD" / "TODO" /
+    invented).
+C7. code parses: balanced {}, (), valid statement terminators.
+
+Verdict per entry:
+- FAIL if any of C1-C5 fails (a real semantic contradiction).
+- WARN if C6 or C7 fails, or fix_description is generic / unspecific.
+- PASS otherwise.
+
+OUTPUT FORMAT — return a single JSON object, no markdown fences, no prose:
+
+{
+  "entries": [
+    {
+      "id": "MAFXXX-YYY-NNN",
+      "verdict": "PASS" | "WARN" | "FAIL",
+      "findings": ["short bullet 1", "short bullet 2"]
+    }
+  ]
+}
+
+Each "findings" entry should be one sentence, naming the failing check (e.g.
+"C2: example_after references `WorkflowEvaluationExtensions` which the diff
+says was removed").
+
+If an entry passes all checks, use "verdict": "PASS" and "findings": [].
+""").strip()
+
+
+def run(cmd: list[str]) -> str:
+    return subprocess.check_output(cmd, text=True, encoding="utf-8")
+
+
+def load_at_ref(ref: str) -> dict[str, Any]:
+    try:
+        raw = run(["git", "show", f"{ref}:{REGISTRY_PATH}"])
+    except subprocess.CalledProcessError:
+        return {}
+    return yaml.safe_load(raw) or {}
+
+
+def find_changed(base_sha: str, head_sha: str) -> list[dict[str, Any]]:
+    base = {e["id"]: e for e in load_at_ref(base_sha).get("entries", [])}
+    head = {e["id"]: e for e in load_at_ref(head_sha).get("entries", [])}
+    changed = []
+    for eid, entry in head.items():
+        if eid not in base:
+            changed.append(entry)
+        elif json.dumps(entry, sort_keys=True) != json.dumps(base[eid], sort_keys=True):
+            changed.append(entry)
+    return changed
+
+
+def main() -> int:
+    base = os.environ.get("BASE_SHA", "").strip()
+    head = os.environ.get("HEAD_SHA", "").strip()
+    if not base or not head:
+        print("ERROR: BASE_SHA and HEAD_SHA env vars required", file=sys.stderr)
+        return 1
+
+    entries = find_changed(base, head)
+    ENTRIES_OUT.write_text(
+        json.dumps([e["id"] for e in entries]),
+        encoding="utf-8",
+    )
+    print(f"# Found {len(entries)} changed entries: "
+          f"{[e['id'] for e in entries]}", file=sys.stderr)
+
+    if not entries:
+        # Emit an empty prompt — workflow step will skip the AI call.
+        return 0
+
+    parts = [SYSTEM_INSTRUCTIONS, "", "---", "", "Here are the entries to review:", ""]
+    for e in entries:
+        parts.append("```yaml")
+        parts.append(yaml.safe_dump(e, sort_keys=False, allow_unicode=True).rstrip())
+        parts.append("```")
+        parts.append("")
+
+    sys.stdout.buffer.write("\n".join(parts).encode("utf-8"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/ai_review_post_comment.py
+++ b/.github/scripts/ai_review_post_comment.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Parse the AI semantic-review response and post a single review comment on
+the PR.
+
+Reads:
+- Env: PR_NUMBER, GH_TOKEN, GITHUB_REPOSITORY, AI_RESPONSE
+- File: .ai-review-entries.json (list of IDs from the build-prompt step)
+
+Posts a PR review with event=COMMENT. Always exits 0 in COMMENT-ONLY mode;
+flip COMMENT_ONLY_MODE to False below to make the workflow fail when the
+model returns FAIL verdicts (rung-3 — gate mode).
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+COMMENT_ONLY_MODE = True
+ENTRIES_FILE = Path(".ai-review-entries.json")
+
+
+def parse_response(raw: str) -> dict[str, Any] | None:
+    """Parse the model output as JSON. Handles markdown fences, leading prose."""
+    s = raw.strip()
+    if "```" in s:
+        # Strip any markdown code fence wrapping.
+        parts = s.split("```")
+        if len(parts) >= 3:
+            inner = parts[1]
+            if inner.startswith("json\n"):
+                inner = inner[5:]
+            elif inner.startswith("json"):
+                inner = inner[4:].lstrip()
+            s = inner.strip()
+    # Some models prepend prose before the JSON; find the first '{'.
+    if not s.startswith("{"):
+        idx = s.find("{")
+        if idx >= 0:
+            s = s[idx:]
+    try:
+        return json.loads(s)
+    except json.JSONDecodeError:
+        return None
+
+
+def render_body(parsed: dict[str, Any] | None, raw: str, ids: list[str]) -> tuple[str, str]:
+    """Render the markdown review body + overall verdict."""
+    if parsed is None or "entries" not in parsed:
+        body = (
+            "## :warning: AI Semantic Review — verdict: **WARN**\n\n"
+            "The model returned output that didn't parse as the expected JSON "
+            "shape. Falling back to raw output below.\n\n"
+            "_This is comment-only mode; the human still makes the merge call._\n\n"
+            "---\n\n"
+            "```\n"
+            + raw[:3500]
+            + ("\n... (truncated)" if len(raw) > 3500 else "")
+            + "\n```"
+        )
+        return body, "WARN"
+
+    entries = parsed.get("entries", [])
+    pass_n = sum(1 for e in entries if e.get("verdict") == "PASS")
+    warn_n = sum(1 for e in entries if e.get("verdict") == "WARN")
+    fail_n = sum(1 for e in entries if e.get("verdict") == "FAIL")
+
+    if fail_n:
+        overall, emoji = "FAIL", ":x:"
+        header = ("**One or more entries contradict the dotnet-inspect diff** "
+                  "preserved in their `notes:` field. See per-entry findings.")
+    elif warn_n:
+        overall, emoji = "WARN", ":warning:"
+        header = ("Entries are structurally consistent with the diff, but some "
+                  "have minor smells (generic phrasing, missing section IDs, "
+                  "etc.). Review the findings below.")
+    else:
+        overall, emoji = "PASS", ":white_check_mark:"
+        header = ("All filled entries are semantically consistent with the "
+                  "`dotnet-inspect` diff captured in their `notes:` field.")
+
+    lines = [
+        f"## {emoji} AI Semantic Review — verdict: **{overall}**",
+        "",
+        f"Reviewed **{len(entries)}** changed registry entr"
+        f"{'y' if len(entries) == 1 else 'ies'}: "
+        f"`PASS={pass_n}`, `WARN={warn_n}`, `FAIL={fail_n}`.",
+        "",
+        header,
+        "",
+        "_This is rung-2 of the AI trust ladder (comment-only). The human "
+        "still merges. To turn this into a hard gate, flip "
+        "`COMMENT_ONLY_MODE` in `.github/scripts/ai_review_post_comment.py`._",
+        "",
+        "---",
+        "",
+    ]
+
+    by_id = {e.get("id"): e for e in entries}
+    for eid in ids:
+        e = by_id.get(eid)
+        if not e:
+            lines.append(f"### :grey_question: `{eid}` — not reviewed (missing from model output)")
+            lines.append("")
+            continue
+        v = e.get("verdict", "?")
+        ve = {"PASS": ":white_check_mark:", "WARN": ":warning:", "FAIL": ":x:"}.get(v, ":grey_question:")
+        lines.append(f"### {ve} `{eid}` — {v}")
+        findings = e.get("findings", [])
+        if findings:
+            for f in findings:
+                lines.append(f"- {f}")
+        else:
+            lines.append("- _No issues found._")
+        lines.append("")
+
+    return "\n".join(lines), overall
+
+
+def post_review(owner: str, repo: str, pr: int, body: str, token: str) -> None:
+    url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr}/reviews"
+    req = urllib.request.Request(
+        url,
+        data=json.dumps({"body": body, "event": "COMMENT"}).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        if resp.status >= 300:
+            raise RuntimeError(f"Posting review failed: HTTP {resp.status}")
+
+
+def main() -> int:
+    raw = os.environ.get("AI_RESPONSE", "")
+    pr = os.environ.get("PR_NUMBER", "").strip()
+    token = os.environ.get("GH_TOKEN", "").strip()
+    repo_full = os.environ.get("GITHUB_REPOSITORY", "").strip()
+
+    missing = [n for n, v in [
+        ("AI_RESPONSE", raw),
+        ("PR_NUMBER", pr),
+        ("GH_TOKEN", token),
+        ("GITHUB_REPOSITORY", repo_full),
+    ] if not v]
+    if missing:
+        print(f"ERROR: missing env vars: {', '.join(missing)}", file=sys.stderr)
+        return 1
+    owner, _, repo = repo_full.partition("/")
+
+    ids: list[str] = []
+    if ENTRIES_FILE.is_file():
+        try:
+            ids = json.loads(ENTRIES_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            ids = []
+
+    parsed = parse_response(raw)
+    body, overall = render_body(parsed, raw, ids)
+
+    print("--- Review body (preview, first 800 chars) ---")
+    print(body[:800])
+    print("--- end preview ---")
+    print(f"Overall verdict: {overall}")
+
+    try:
+        post_review(owner, repo, int(pr), body, token)
+        print(f"Posted review to PR #{pr}.")
+    except Exception as exc:
+        print(f"ERROR posting review: {exc!r}", file=sys.stderr)
+        return 0 if COMMENT_ONLY_MODE else 1
+
+    if not COMMENT_ONLY_MODE and overall == "FAIL":
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/maf-ai-semantic-review.yml
+++ b/.github/workflows/maf-ai-semantic-review.yml
@@ -1,0 +1,125 @@
+name: MAF AI Semantic Review
+
+# Rung-2 of the trust ladder for ai-fill PRs (rung-1 is the deterministic
+# `verify-registry` mechanical check). When an ai-fill PR is marked ready for
+# review, this workflow calls a Claude / GPT-4 model via the GitHub Models
+# inference endpoint, asks it to check each changed registry entry against
+# the raw `dotnet-inspect` diff (preserved in `notes:`), and posts the
+# findings as a single PR review comment.
+#
+# Uses your Copilot subscription's GitHub Models quota — no extra secret,
+# no Anthropic / OpenAI account, no third-party API key. The only auth is
+# the workflow's GITHUB_TOKEN with `models: read` permission.
+#
+# Currently in COMMENT-ONLY mode: the verdict is in the comment; the
+# human still merges. To make it a hard gate (rung-3), flip
+# COMMENT_ONLY_MODE = False in ai_review_post_comment.py and add this
+# workflow as a required status check in branch protection settings.
+
+on:
+  pull_request:
+    types: [ready_for_review, reopened, synchronize]
+    paths:
+      - '.github/skills/maf-obsolete-api-registry/registry.yaml'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to review (manual re-run)'
+        required: true
+      model:
+        description: 'Override the model (e.g. openai/gpt-4o, openai/gpt-4o-mini)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  pull-requests: write
+  models: read
+
+jobs:
+  semantic-review:
+    # Only run on PRs that look like ai-fill output — `ai-fill` label OR a
+    # head branch from one of the Coding Agent bots. Skip during draft
+    # iterations to avoid wasting model quota on every push.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.draft == false &&
+        (
+          contains(github.event.pull_request.labels.*.name, 'ai-fill') ||
+          startsWith(github.head_ref, 'claude/') ||
+          startsWith(github.head_ref, 'copilot/') ||
+          startsWith(github.head_ref, 'codex/')
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR coordinates
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUM="${{ inputs.pr_number }}"
+            DATA=$(gh pr view "$PR_NUM" --json baseRefOid,headRefOid)
+            BASE=$(echo "$DATA" | jq -r .baseRefOid)
+            HEAD=$(echo "$DATA" | jq -r .headRefOid)
+          else
+            PR_NUM="${{ github.event.pull_request.number }}"
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          fi
+          echo "pr_number=$PR_NUM" >> $GITHUB_OUTPUT
+          echo "base=$BASE" >> $GITHUB_OUTPUT
+          echo "head=$HEAD" >> $GITHUB_OUTPUT
+          echo "Resolved: PR #$PR_NUM (base=$BASE head=$HEAD)"
+
+      - name: Checkout (full history so we can git-show the base)
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.pr.outputs.head }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install deps
+        run: pip install pyyaml
+
+      - name: Build review prompt
+        id: build
+        env:
+          BASE_SHA: ${{ steps.pr.outputs.base }}
+          HEAD_SHA: ${{ steps.pr.outputs.head }}
+        run: |
+          python3 .github/scripts/ai_review_build_prompt.py > .ai-review-prompt.md
+          BYTES=$(wc -c < .ai-review-prompt.md | tr -d ' ')
+          ENTRIES_COUNT=$(jq length < .ai-review-entries.json)
+          echo "Prompt bytes: $BYTES; entries to review: $ENTRIES_COUNT"
+          if [ "$ENTRIES_COUNT" = "0" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "::notice title=No registry entries changed::Skipping AI review (no entries in scope)."
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: AI inference (GitHub Models)
+        if: steps.build.outputs.skip != 'true'
+        id: ai
+        uses: actions/ai-inference@v1
+        with:
+          model: ${{ inputs.model != '' && inputs.model || 'openai/gpt-4o' }}
+          prompt-file: .ai-review-prompt.md
+          max-tokens: 4000
+          # Auth is the workflow's GITHUB_TOKEN with models: read permission.
+          # No additional inputs needed; the action picks up the token from
+          # the environment.
+
+      - name: Post review comment to PR
+        if: steps.build.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          AI_RESPONSE: ${{ steps.ai.outputs.response }}
+        run: python3 .github/scripts/ai_review_post_comment.py

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,5 @@ desktop.ini
 # scratchpad.
 private/
 
+.ai-review-entries.json
+.ai-review-prompt.md


### PR DESCRIPTION
## Summary

Adds the **rung-2** of the AI trust ladder for MAF ai-fill PRs. After the filler bot (Copilot/Claude/Codex Coding Agent) opens a PR and marks it ready for review, this workflow:

1. Diffs `registry.yaml` between the PR base and head, finds changed entries.
2. Sends the changed entries to GPT-4o via the **GitHub Models** inference endpoint (uses the workflow's `GITHUB_TOKEN` with `models: read` permission — no third-party API key, $0 marginal cost via your Copilot subscription quota).
3. Parses the JSON response and posts a single PR review comment with PASS/WARN/FAIL verdicts per entry.

## Architecture decision: GH Models direct, not Cloud Agent reviewer

| | Cloud Agent reviewer | GH Models inference |
|---|---|---|
| Latency | 5–15 min | 10–30 sec |
| Output structure | Free-form, varies | JSON, deterministic |
| Failure modes | Many (junk commits, no response, wrong format) | One (API error → loud failure) |
| Fighting the tool | Yes — agents want to commit | No — single inference is exactly what GH Models is for |
| Path to rung-3 | Hard — can't gate inconsistent output | Trivial — exit code becomes a required check |
| Cost | $0 | $0 |

Rung-3 readiness is the killer point: a deterministic JSON-backed verdict can become a required status check. A free-form bot comment cannot.

## Current trust phase: COMMENT-ONLY

`COMMENT_ONLY_MODE = True` in `ai_review_post_comment.py` means the workflow always exits 0. The verdict is in the comment; the human still merges. After 3–5 MAF releases of calibration (does the AI flag the same things I would?), flip to `False` and add this workflow as a required status check in branch protection — that's rung-3 (auto-merge once mechanical + AI both pass).

## Files

- **`.github/workflows/maf-ai-semantic-review.yml`** — triggers on PR `ready_for_review` / `reopened` / `synchronize` for ai-fill PRs; also `workflow_dispatch` for manual re-runs with optional model override.
- **`.github/scripts/ai_review_build_prompt.py`** — diffs registry.yaml between PR base/head, emits prompt for inference.
- **`.github/scripts/ai_review_post_comment.py`** — parses the model JSON response, renders markdown, posts PR review with `event: COMMENT`.
- **`.gitignore`** — excludes the build-time temp files.

## Test plan

- [x] All 3 files lint clean (Python ast.parse, yaml.safe_load).
- [x] `ai_review_build_prompt.py` smoke-tested locally against PR #26's real base/head — correctly identifies 1 changed entry (`MAF161-EXTENSIO-001`) and emits a 4.8KB prompt.
- [x] `ai_review_post_comment.py` parser smoke-tested for plain JSON and JSON-with-prose cases.
- [ ] First production run: manual dispatch of `maf-ai-semantic-review.yml` against PR #26 after this merges.
- [ ] If GH Models endpoint or `actions/ai-inference@v1` API has shifted, iterate with quick fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)