### PR TITLE
fix(ai-review): pass --repo to gh pr view

### DIFF
--- a/.github/workflows/maf-ai-semantic-review.yml
+++ b/.github/workflows/maf-ai-semantic-review.yml
@@ -61,7 +61,9 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUM="${{ inputs.pr_number }}"
-            DATA=$(gh pr view "$PR_NUM" --json baseRefOid,headRefOid)
+            # --repo so gh doesn't try to infer from a not-yet-existent git context
+            # (this step runs before actions/checkout).
+            DATA=$(gh pr view "$PR_NUM" --repo "$GITHUB_REPOSITORY" --json baseRefOid,headRefOid)
             BASE=$(echo "$DATA" | jq -r .baseRefOid)
             HEAD=$(echo "$DATA" | jq -r .headRefOid)
           else


### PR DESCRIPTION
Resolve PR coordinates step runs before actions/checkout, so gh has no git context to infer the repo. Adding --repo $GITHUB_REPOSITORY fixes the workflow_dispatch path. The pull_request trigger reads from context directly so was unaffected.

Caught by test dispatch run 25998072982.