### PR TITLE
fix(verify): auto-trigger on bot branches

### DIFF
--- a/.github/workflows/maf-ai-fill-verify.yml
+++ b/.github/workflows/maf-ai-fill-verify.yml
@@ -32,10 +32,16 @@ permissions:
 
 jobs:
   verify:
-    # Only fire on PRs labelled `ai-fill`. Hand-written registry PRs from
-    # the maintainer skip this check (the maintainer has already eye-balled
-    # their own work).
-    if: contains(github.event.pull_request.labels.*.name, 'ai-fill')
+    # Only fire on PRs that look like bot-generated ai-fill output: either
+    # the `ai-fill` label OR a head branch from one of the Coding Agent
+    # bots. Hand-written registry PRs from the maintainer skip this check.
+    # (Pattern matches maf-ai-semantic-review.yml — keeps both rung-1 and
+    # rung-2 checks consistent.)
+    if: >
+      contains(github.event.pull_request.labels.*.name, 'ai-fill') ||
+      startsWith(github.head_ref, 'claude/') ||
+      startsWith(github.head_ref, 'copilot/') ||
+      startsWith(github.head_ref, 'codex/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Coding Agents don't carry over issue labels onto their PRs, so the verify workflow's ai-fill label requirement meant PR #26 never triggered it. Expanded the trigger condition to match maf-ai-semantic-review.yml — bot-branch names auto-qualify. Caught when setting up branch protection: 'verify' check was missing from the search box because it had never run.