### PR TITLE
feat(pipeline): harden fill chain — anti-dup prompt, cross-file verify, Claude default, audit scope, rung-2 trigger

### DIFF
--- a/.github/scripts/ai_fill_issue_prompt.md.tpl
+++ b/.github/scripts/ai_fill_issue_prompt.md.tpl
@@ -102,6 +102,19 @@ Run through this checklist on every entry you filled:
 - [ ] No invented section numbers in `guide_section` — only existing
   section IDs from the guide, OR the literal string `N/A`.
 
+**Cross-file checks** (the rung-1 verifier WILL fail your PR if any of
+these break):
+
+- [ ] `docs/compatibility-matrix.md` has exactly ONE `**{{TARGET}}**` row,
+  not two. Run `grep -c '^| \*\*{{TARGET}}\*\*' docs/compatibility-matrix.md`
+  — must print `1`.
+- [ ] `## Version Tracking` section's "Current tracked version" line says
+  `**`{{TARGET}}`**`, not an older version.
+- [ ] `guides/maf-{{TARGET}}-migration-guide.md` exists and its
+  AUTO-GENERATED sections are filled (no `TODO`).
+- [ ] `last-updated:` date in the compatibility-matrix HTML comment
+  is today's UTC date.
+
 The PR will be automatically checked against
 `maf-autopilot verify-registry` by the
 `.github/workflows/maf-ai-fill-verify.yml` workflow. The check
@@ -109,6 +122,18 @@ enforces the same items above. If any fail, the check fails and the
 PR is blocked from auto-merge.
 
 ## What to fill — compatibility matrix
+
+The watcher has ALREADY inserted a placeholder row at the top of the
+`## Compatibility Table` in `docs/compatibility-matrix.md`. It looks like:
+
+```
+| **{{TARGET}}** | `>= unknown` | `>= 8.0` | `>= unknown` | `{{TARGET}}` | Auto-detected — verify versions in PR review. |
+```
+
+**UPDATE THIS EXISTING ROW IN-PLACE. DO NOT ADD A NEW ROW.** A common
+failure mode (observed on the 2026-05-17 live-fire of PR #26) is the bot
+adding a new filled row *below* the placeholder, leaving the table with
+two `**{{TARGET}}**` rows. The verifier flags duplicate rows as FAIL.
 
 For the row `**{{TARGET}}**`:
 
@@ -122,6 +147,44 @@ Also at the top of `docs/compatibility-matrix.md` there is an HTML
 comment of the form
 `<!-- auto-updated-by: maf-release-watcher | last-updated: YYYY-MM-DD -->`.
 Update the date to today (UTC).
+
+## What to fill — Version Tracking section
+
+Lower in `docs/compatibility-matrix.md` there is a `## Version Tracking`
+section that contains a line:
+
+```
+Current tracked version: **`X.Y.Z`** (see `.maf-version`)
+```
+
+**UPDATE THIS LINE to match `.maf-version` = `{{TARGET}}`.** A common
+failure mode is leaving this line at the previous version. The cross-file
+consistency check flags this as FAIL.
+
+## Cross-file thoroughness — DO ALL of these
+
+The watcher commit touched MULTIPLE files. Before opening the PR, verify
+EACH of these is consistent with each other:
+
+1. `.maf-version` — already set to `{{TARGET}}` (don't touch).
+2. `.github/skills/maf-obsolete-api-registry/registry.yaml` — fill new
+   entries (Step 2 above).
+3. `docs/compatibility-matrix.md`:
+   - Top row updated, NOT duplicated.
+   - `last-updated:` date updated.
+   - Version Tracking section's "Current tracked version" updated.
+4. `guides/maf-{{TARGET}}-migration-guide.md` — fill the AUTO-GENERATED
+   sections (Step "What to fill — migration guide" above).
+
+Run a final consistency grep before opening the PR:
+
+```bash
+# Should find ONE row for {{TARGET}}, not two:
+grep -c '^| \*\*{{TARGET}}\*\*' docs/compatibility-matrix.md
+
+# Should print {{TARGET}}, not an older version:
+grep 'Current tracked version' docs/compatibility-matrix.md
+```
 
 ## What to fill — migration guide
 

--- a/.github/scripts/verify_crossfile_consistency.py
+++ b/.github/scripts/verify_crossfile_consistency.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+Cross-file consistency checks for MAF release artifacts.
+
+Runs AFTER `maf-autopilot verify-registry` (which checks registry.yaml
+entry-internal consistency). This script checks consistency ACROSS the
+files the release-watcher touches.
+
+Findings discovered 2026-05-17 on PR #26 that motivated these checks:
+- Bot ADDED a new `**1.6.1**` row to compat-matrix instead of UPDATING the
+  watcher-inserted placeholder row → duplicate version rows.
+- "Version Tracking" section still said the old version after a release.
+
+Checks performed:
+1. docs/compatibility-matrix.md has no DUPLICATE `**X.Y.Z**` rows.
+2. The TOP data row in the compat-matrix table matches `.maf-version`.
+3. "Version Tracking" section's "Current tracked version: **X.Y.Z**" line
+   matches `.maf-version`.
+4. `guides/maf-{VERSION}-migration-guide.md` exists for `.maf-version`.
+
+Exits 0 if all consistent, 1 if any check fails. Prints findings to stdout.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path.cwd()
+MAF_VERSION_FILE = ROOT / ".maf-version"
+COMPAT_MATRIX = ROOT / "docs" / "compatibility-matrix.md"
+GUIDES_DIR = ROOT / "guides"
+
+# A "version-stem" row in compat-matrix table starts with: | **X.Y.Z** | ...
+# Allow optional leading whitespace and a 2- or 3-part version.
+VERSION_ROW_RE = re.compile(
+    r'^\s*\|\s*\*\*(\d+\.\d+(?:\.\d+)?)\*\*\s*\|', re.MULTILINE
+)
+CURRENT_TRACKED_RE = re.compile(
+    r'Current tracked version:\s*\*\*`?(\d+\.\d+(?:\.\d+)?)`?\*\*',
+    re.IGNORECASE,
+)
+
+
+def find_duplicate_rows(text: str) -> list[str]:
+    """Return version strings that appear more than once as a row stem."""
+    versions = VERSION_ROW_RE.findall(text)
+    seen: set[str] = set()
+    dupes: list[str] = []
+    for v in versions:
+        if v in seen and v not in dupes:
+            dupes.append(v)
+        seen.add(v)
+    return dupes
+
+
+def top_version_row(text: str) -> str | None:
+    """Return the first matched version (the top row of the table), or None."""
+    m = VERSION_ROW_RE.search(text)
+    return m.group(1) if m else None
+
+
+def version_tracking_current(text: str) -> str | None:
+    """Return the version mentioned in 'Current tracked version: **X.Y.Z**'."""
+    m = CURRENT_TRACKED_RE.search(text)
+    return m.group(1) if m else None
+
+
+def main() -> int:
+    findings: list[str] = []
+
+    if not MAF_VERSION_FILE.is_file():
+        print(f"ERROR: {MAF_VERSION_FILE} not found.", file=sys.stderr)
+        return 1
+
+    current = MAF_VERSION_FILE.read_text(encoding="utf-8").strip()
+    print(f"Current .maf-version: {current}")
+
+    if not COMPAT_MATRIX.is_file():
+        findings.append(f"{COMPAT_MATRIX} not found.")
+    else:
+        text = COMPAT_MATRIX.read_text(encoding="utf-8")
+
+        dupes = find_duplicate_rows(text)
+        if dupes:
+            findings.append(
+                f"compatibility-matrix.md has DUPLICATE version rows: "
+                f"{', '.join(dupes)}. Each version must appear at most once "
+                f"as a `**X.Y.Z**` row. The watcher inserts a placeholder row "
+                f"at the top — the filler bot should UPDATE that row, not "
+                f"add a new one below."
+            )
+
+        top = top_version_row(text)
+        if top is None:
+            findings.append(
+                "compatibility-matrix.md: could not find any `**X.Y.Z**` "
+                "version row — table may be malformed."
+            )
+        elif top != current:
+            findings.append(
+                f"compatibility-matrix.md top data row is `**{top}**` but "
+                f".maf-version is `{current}`. The newest version should "
+                f"be at the top of the table."
+            )
+
+        tracked = version_tracking_current(text)
+        if tracked is None:
+            print(
+                "Note: no 'Current tracked version: **X.Y.Z**' line found in "
+                "compatibility-matrix.md — skipping that check."
+            )
+        elif tracked != current:
+            findings.append(
+                f"compatibility-matrix.md 'Version Tracking' section says "
+                f"current tracked version is `{tracked}` but .maf-version is "
+                f"`{current}`. Update the 'Current tracked version' line."
+            )
+
+    guide_file = GUIDES_DIR / f"maf-{current}-migration-guide.md"
+    if not guide_file.is_file():
+        findings.append(
+            f"missing migration guide: {guide_file.relative_to(ROOT)}"
+        )
+
+    if findings:
+        print("")
+        print("=" * 72)
+        print("CROSS-FILE CONSISTENCY ISSUES:")
+        print("=" * 72)
+        for f in findings:
+            print(f"  * {f}")
+        print("")
+        return 1
+
+    print("All cross-file consistency checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/maf-ai-fill-todos.yml
+++ b/.github/workflows/maf-ai-fill-todos.yml
@@ -38,11 +38,19 @@ on:
       target_version:
         description: 'MAF version to fill TODOs for (e.g. 1.4.0, 1.5.0)'
         required: true
+      bot:
+        description: 'Which Coding Agent to assign (claude|copilot|codex). Default: claude — empirically better at structured-instruction following and catching duplicates than Copilot for this task.'
+        required: false
+        default: 'claude'
   workflow_call:
     inputs:
       target_version:
         type: string
         required: true
+      bot:
+        type: string
+        required: false
+        default: 'claude'
 
 permissions:
   contents: read
@@ -80,8 +88,9 @@ jobs:
             --description "AI auto-fill of TODOs (Copilot Coding Agent)" \
             --force || true
 
-      - name: Open issue assigned to Copilot Coding Agent
+      - name: Open issue assigned to chosen Coding Agent
         env:
+          BOT_NAME: ${{ inputs.bot || 'claude' }}
           # COPILOT_ASSIGN_PAT is a fine-grained PAT owned by a Copilot-enabled
           # user. It's REQUIRED for auto-assigning the Coding Agent bot:
           # `addAssigneesToAssignable` categorically rejects GITHUB_TOKEN and
@@ -104,16 +113,16 @@ jobs:
           # substitutes {{TARGET}} / {{DIGITS}} with no shell parsing.
           ISSUE_BODY=$(python3 .github/scripts/build_ai_fill_issue_body.py)
 
-          # Two-step pattern: create the issue first, then assign Copilot via
-          # GraphQL. The standard `gh issue edit --add-assignee Copilot` fails
-          # because gh CLI looks up assignees via REST `/users/Copilot`, and
-          # the Copilot bot ISN'T returned by that endpoint (it's a Bot, not a
-          # User). The GraphQL mutation `addAssigneesToAssignable` accepts the
-          # bot's global node ID directly, which is what the GitHub UI uses
-          # under the hood when you click "Assignees → Copilot".
+          # Two-step pattern: create the issue first, then assign the chosen
+          # Coding Agent via GraphQL. The standard `gh issue edit
+          # --add-assignee` fails because gh CLI looks up assignees via REST
+          # `/users/<name>`, and these bots aren't returned by that endpoint
+          # (they're Bots, not Users). The GraphQL mutation
+          # `addAssigneesToAssignable` accepts global node IDs directly, which
+          # is what the GitHub UI uses under the hood.
 
           ISSUE_URL=$(gh issue create \
-            --title "Fill TODOs for MAF $TARGET" \
+            --title "Fill TODOs for MAF $TARGET (assigned to: $BOT_NAME)" \
             --body "$ISSUE_BODY" \
             --label "maf-release,ai-fill")
           echo "✅ Issue created: $ISSUE_URL"
@@ -132,11 +141,41 @@ jobs:
             -F num="$ISSUE_NUM" \
             --jq '.data.repository.issue.id')
 
-          # Copilot Coding Agent's global node ID. Stable across all repos —
-          # discovered empirically by inspecting a manually-assigned issue.
-          # If Copilot Coding Agent is ever rolled forward to a new bot
-          # account, this constant needs updating.
-          COPILOT_BOT_ID="BOT_kgDOC9w8XQ"
+          # Resolve the chosen bot's GraphQL node ID dynamically via
+          # suggestedActors. Avoids hardcoded constants that can rotate when
+          # GitHub re-provisions bot accounts. Bot login names are stable:
+          #   copilot -> copilot-swe-agent
+          #   claude  -> anthropic-code-agent
+          #   codex   -> openai-code-agent
+          case "$BOT_NAME" in
+            copilot) NEEDLE="copilot-swe-agent" ;;
+            claude)  NEEDLE="anthropic-code-agent" ;;
+            codex)   NEEDLE="openai-code-agent" ;;
+            *) echo "::error::Unknown bot '$BOT_NAME' — expected copilot|claude|codex"; exit 1 ;;
+          esac
+
+          BOT_ID=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!) {
+              repository(owner: $owner, name: $repo) {
+                suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 25) {
+                  nodes {
+                    ... on Bot { id login }
+                    ... on User { id login }
+                  }
+                }
+              }
+            }' \
+            -f owner="${GITHUB_REPOSITORY%%/*}" \
+            -f repo="${GITHUB_REPOSITORY##*/}" \
+            --jq ".data.repository.suggestedActors.nodes[] | select(.login==\"$NEEDLE\") | .id")
+          if [ -z "$BOT_ID" ] || [ "$BOT_ID" = "null" ]; then
+            echo "::error::Could not find $NEEDLE in suggestedActors. Enable the agent at"
+            echo "::error::https://github.com/${GITHUB_REPOSITORY}/settings/copilot"
+            exit 1
+          fi
+          echo "Resolved bot $BOT_NAME ($NEEDLE) -> $BOT_ID"
+          # Keep COPILOT_BOT_ID name for back-compat with downstream messages.
+          COPILOT_BOT_ID="$BOT_ID"
 
           # Best-effort: assign via the additive GraphQL mutation. Uses
           # `addAssigneesToAssignable` (not `replaceActorsForAssignable`) so

--- a/.github/workflows/maf-ai-fill-verify.yml
+++ b/.github/workflows/maf-ai-fill-verify.yml
@@ -22,9 +22,11 @@ name: MAF AI-Fill PR Verify
 
 on:
   pull_request:
-    types: [opened, synchronize, labeled]
-    paths:
-      - '.github/skills/maf-obsolete-api-registry/registry.yaml'
+    types: [opened, synchronize, labeled, ready_for_review, reopened]
+    # No `paths:` filter — branch protection requires this check to report
+    # a status on EVERY PR (otherwise PRs that don't touch registry.yaml
+    # get blocked by "missing required check"). The job filters internally:
+    # if registry.yaml isn't in the diff, it reports success trivially.
 
 permissions:
   contents: read
@@ -32,35 +34,69 @@ permissions:
 
 jobs:
   verify:
-    # Only fire on PRs that look like bot-generated ai-fill output: either
-    # the `ai-fill` label OR a head branch from one of the Coding Agent
-    # bots. Hand-written registry PRs from the maintainer skip this check.
-    # (Pattern matches maf-ai-semantic-review.yml — keeps both rung-1 and
-    # rung-2 checks consistent.)
-    if: >
-      contains(github.event.pull_request.labels.*.name, 'ai-fill') ||
-      startsWith(github.head_ref, 'claude/') ||
-      startsWith(github.head_ref, 'copilot/') ||
-      startsWith(github.head_ref, 'codex/')
+    # Always run (so branch protection's required-status-check sees a result
+    # on every PR). The first step decides whether to do real verification
+    # or report trivial success based on the actual diff.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Decide whether this PR is in scope
+        id: scope
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # In scope if: PR is labelled `ai-fill` OR head branch is a Coding
+          # Agent bot's, AND the PR diff touches registry.yaml OR the migration
+          # guide OR compatibility-matrix.md (any file the watcher touches).
+          git fetch origin "$BASE_REF":"refs/heads/$BASE_REF" --depth=50 || true
+          DIFF_FILES=$(git diff --name-only "origin/$BASE_REF" HEAD || true)
+          echo "Files changed in PR:"
+          echo "$DIFF_FILES" | sed 's/^/  /'
+
+          TOUCHES_WATCHER_FILES=false
+          if echo "$DIFF_FILES" | grep -qE '^(\.github/skills/maf-obsolete-api-registry/registry\.yaml|docs/compatibility-matrix\.md|guides/maf-.*-migration-guide\.md|\.maf-version)$'; then
+            TOUCHES_WATCHER_FILES=true
+          fi
+
+          LABEL_OR_BOT="${{
+            (contains(github.event.pull_request.labels.*.name, 'ai-fill') ||
+             startsWith(github.head_ref, 'claude/') ||
+             startsWith(github.head_ref, 'copilot/') ||
+             startsWith(github.head_ref, 'codex/')) && 'true' || 'false'
+          }}"
+
+          if [ "$TOUCHES_WATCHER_FILES" = "true" ] && [ "$LABEL_OR_BOT" = "true" ]; then
+            echo "in_scope=true" >> $GITHUB_OUTPUT
+            echo "::notice title=verify-registry in scope::Running full rung-1 verification."
+          else
+            echo "in_scope=false" >> $GITHUB_OUTPUT
+            echo "::notice title=verify-registry trivially passes::PR doesn't touch watcher-managed files OR isn't from a fill bot — reporting success."
+          fi
 
       - name: Setup .NET
+        if: steps.scope.outputs.in_scope == 'true'
         uses: actions/setup-dotnet@v4
         with:
-          # Net8 LTS — install-only; nupkg multi-targets so any flavor works.
           dotnet-version: '8.0.x'
 
       - name: Install maf-autopilot (prerelease)
+        if: steps.scope.outputs.in_scope == 'true'
         run: |
           dotnet tool install --global maf-autopilot --prerelease \
             || dotnet tool update --global maf-autopilot --prerelease
 
-      - name: Run verify-registry
+      - uses: actions/setup-python@v5
+        if: steps.scope.outputs.in_scope == 'true'
+        with:
+          python-version: '3.12'
+
+      - name: Run verify-registry (rung-1 mechanical)
         id: verify
+        if: steps.scope.outputs.in_scope == 'true'
         continue-on-error: true
         run: |
           set +e
@@ -75,42 +111,69 @@ jobs:
           } >> $GITHUB_OUTPUT
           exit $EXIT
 
-      - name: Comment on PR if verification failed
-        if: steps.verify.outputs.exit_code != '0'
+      - name: Run cross-file consistency check
+        id: crossfile
+        if: steps.scope.outputs.in_scope == 'true'
+        continue-on-error: true
+        run: |
+          set +e
+          OUTPUT=$(python3 .github/scripts/verify_crossfile_consistency.py 2>&1)
+          EXIT=$?
+          echo "$OUTPUT"
+          {
+            echo "output<<EOF"
+            echo "$OUTPUT"
+            echo "EOF"
+            echo "exit_code=$EXIT"
+          } >> $GITHUB_OUTPUT
+          exit $EXIT
+
+      - name: Comment on PR if any check failed
+        if: |
+          steps.scope.outputs.in_scope == 'true' &&
+          (steps.verify.outputs.exit_code != '0' ||
+           steps.crossfile.outputs.exit_code != '0')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERIFY_OUTPUT: ${{ steps.verify.outputs.output }}
+          CROSSFILE_OUTPUT: ${{ steps.crossfile.outputs.output }}
+          VERIFY_EXIT: ${{ steps.verify.outputs.exit_code }}
+          CROSSFILE_EXIT: ${{ steps.crossfile.outputs.exit_code }}
         run: |
-          BODY=$(cat <<EOF
-          ## ❌ AI-fill verification failed
+          {
+            echo "## ❌ AI-fill verification failed"
+            echo ""
+            if [ "$VERIFY_EXIT" != "0" ]; then
+              echo "### Registry entry checks (rung-1 mechanical)"
+              echo ""
+              echo '```'
+              echo "$VERIFY_OUTPUT"
+              echo '```'
+              echo ""
+            fi
+            if [ "$CROSSFILE_EXIT" != "0" ]; then
+              echo "### Cross-file consistency checks"
+              echo ""
+              echo '```'
+              echo "$CROSSFILE_OUTPUT"
+              echo '```'
+              echo ""
+            fi
+            echo "**Common fixes:**"
+            echo "- example_before == example_after -> these must differ."
+            echo "- fix_description too short -> write a real sentence, no TODO/TBD."
+            echo "- unbalanced braces -> bot truncated a code block."
+            echo "- guide_section placeholder -> use 'N/A' literal."
+            echo "- duplicate version row -> UPDATE the watcher placeholder, do NOT add a row."
+            echo "- Version Tracking section stale -> bump 'Current tracked version' to match .maf-version."
+          } > /tmp/comment.md
+          gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/comment.md
 
-          \`maf-autopilot verify-registry\` flagged issues in this PR's
-          \`registry.yaml\` changes. Detail below — fix locally and push:
-
-          \`\`\`
-          ${{ steps.verify.outputs.output }}
-          \`\`\`
-
-          **Common fixes:**
-          - "example_before == example_after" → these must differ; the
-            example shows a migration, not a noop.
-          - "fix_description is too short" → write a real sentence; the
-            verifier rejects ≤ 20-char descriptions and "TODO"/"TBD".
-          - "unbalanced braces" → Copilot probably truncated a code block.
-          - "guide_section is a placeholder" → use the literal string
-            \`N/A\` if there's no parallel guide section.
-
-          See \`.github/workflows/maf-ai-fill-todos.yml\` for the full
-          filling rubric. Re-run \`verify-registry\` locally after fixing:
-
-          \`\`\`bash
-          maf-autopilot verify-registry
-          \`\`\`
-          EOF
-          )
-          gh pr comment "${{ github.event.pull_request.number }}" --body "$BODY"
-
-      - name: Final status (re-fail if verify failed)
-        if: steps.verify.outputs.exit_code != '0'
+      - name: Final status (fail if any check failed)
+        if: |
+          steps.scope.outputs.in_scope == 'true' &&
+          (steps.verify.outputs.exit_code != '0' ||
+           steps.crossfile.outputs.exit_code != '0')
         run: |
-          echo "Registry verification failed — see PR comment for detail."
+          echo "Verification failed — see PR comment for detail."
           exit 1

--- a/.github/workflows/maf-ai-semantic-review.yml
+++ b/.github/workflows/maf-ai-semantic-review.yml
@@ -18,9 +18,12 @@ name: MAF AI Semantic Review
 
 on:
   pull_request:
+    # No `paths:` filter — empirically broken with ready_for_review events
+    # (state flips carry no commit deltas, so paths matching is unreliable
+    # and the trigger silently skips). Observed 2026-05-17 on PR #26.
+    # Instead, the build_prompt step emits skip=true if no entries actually
+    # changed, gating downstream AI inference + post-comment.
     types: [ready_for_review, reopened, synchronize]
-    paths:
-      - '.github/skills/maf-obsolete-api-registry/registry.yaml'
   workflow_dispatch:
     inputs:
       pr_number:

--- a/.github/workflows/maf-pr-audit.yml
+++ b/.github/workflows/maf-pr-audit.yml
@@ -22,16 +22,43 @@ jobs:
           # Need the base branch ref to compute the diff.
           fetch-depth: 0
 
+      - name: Decide whether to audit (skip if only samples/ changed)
+        id: scope
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          # samples/ intentionally contains buggy / out-of-date code:
+          # - samples/find-the-bug/* has an answer-key.md alongside
+          #   intentional anti-patterns (the tutorial IS the point).
+          # - samples/maf-1.2-sample/* is the analyzer's test corpus —
+          #   patterns valid in MAF 1.2 that later versions flag.
+          # Auditing them produces a noisy F grade that doesn't reflect
+          # the toolkit's code quality. Skip if EVERY changed code file
+          # is under samples/.
+          git fetch origin "$BASE_REF":"refs/heads/$BASE_REF" --depth=50 || true
+          CHANGED_CODE=$(git diff --name-only "origin/$BASE_REF" HEAD | grep -E '\.(cs|csproj)$' || true)
+          NON_SAMPLE=$(echo "$CHANGED_CODE" | grep -v '^samples/' || true)
+          echo "Changed .cs/.csproj files in PR:"
+          echo "$CHANGED_CODE" | sed 's/^/  /'
+          if [ -z "$NON_SAMPLE" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "::notice title=MAF audit skipped::Only samples/ files changed — they're intentionally buggy demo corpora, not real code to audit."
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Setup .NET
+        if: steps.scope.outputs.skip != 'true'
         uses: actions/setup-dotnet@v4
         with:
-          # Net8 LTS — install-only; nupkg multi-targets so any flavor works.
           dotnet-version: '8.0.x'
 
       - name: Install maf-autopilot (prerelease)
+        if: steps.scope.outputs.skip != 'true'
         run: dotnet tool install --global maf-autopilot --prerelease || dotnet tool update --global maf-autopilot --prerelease
 
       - name: Run MCP server and call MafAuditPullRequest
+        if: steps.scope.outputs.skip != 'true'
         id: audit
         env:
           BASE_REF: ${{ github.base_ref }}
@@ -65,6 +92,7 @@ jobs:
           cat pr-audit-full.md
 
       - name: Comment on PR
+        if: steps.scope.outputs.skip != 'true'
         # SHA-pinned per supply-chain hardening. Verify against tag with:
         #   gh api repos/marocchino/sticky-pull-request-comment/git/refs/tags/v2.9.2 --jq .object.sha
         # Update via Dependabot (.github/dependabot.yml).


### PR DESCRIPTION
## Summary

Six changes addressing gaps surfaced by PR #26's live-fire of the bot fill chain:

| # | File | Change |
|---|---|---|
| 1 | `ai_fill_issue_prompt.md.tpl` | Tell the fill bot to UPDATE the watcher's placeholder row in compat-matrix in-place (don't add a new row), update Version Tracking section, run final consistency grep. |
| 2 | **NEW** `verify_crossfile_consistency.py` | Cross-file consistency checks: duplicate version rows, top row matches `.maf-version`, Version Tracking line current, migration guide exists. |
| 3 | `maf-ai-fill-verify.yml` | Drop `paths` filter so this required check reports a status on EVERY PR (fixes branch-protection footgun). Job filters internally — out-of-scope PRs report success trivially. Runs both verify-registry AND new cross-file check. |
| 4 | `maf-ai-semantic-review.yml` | Drop `paths` filter — empirically broken with `ready_for_review` events (observed on PR #26). Supersedes PR #31. |
| 5 | `maf-ai-fill-todos.yml` | Switch default fill bot from Copilot to **Claude** (better at structured-instruction following + duplicate-catching). Resolve bot ID dynamically via `suggestedActors`. New `bot` workflow_dispatch input. |
| 6 | `maf-pr-audit.yml` | Skip MAF audit when only `samples/` files changed (those are intentionally buggy tutorial corpora, not real code). |

## Why each

**(1)** Copilot's own self-review on PR #26 caught two defects the rung-1/rung-2 checks missed: duplicate `**1.6.1**` rows in compat-matrix, and "Current tracked version: 1.3.0" still showing the old version. Both are now explicitly addressed in the prompt with grep-based self-checks.

**(2)** Adds a deterministic cross-file consistency layer alongside the per-entry mechanical check. Smoke-tested locally — already detects the 1.3.0 staleness on current main.

**(3)** The required `verify` check previously only fired on PRs that touched `registry.yaml`. Branch protection treats "no status reported" as blocking. Now it always reports — trivially success when not applicable.

**(4)** The `paths` filter doesn't see file deltas on `ready_for_review` (state flip, no commits). Rung-2 silently never triggered on PR #26's draft-to-ready flip. Confirmed by run history.

**(5)** Claude Coding Agent tends to follow explicit "DO NOT" constraints more rigorously than Copilot. Per user's request to force a more thorough model for the fill task.

**(6)** F-grade noise from auditing `samples/find-the-bug/` and `samples/maf-1.2-sample/` is misleading — those files are SUPPOSED to be flagged.

## Test plan

- [x] All four YAML files lint clean (`yaml.safe_load`).
- [x] `verify_crossfile_consistency.py` smoke-tested on main — flags Version Tracking staleness as expected.
- [x] This PR itself doesn't touch `registry.yaml`, so it exercises the new "verify reports trivial success on out-of-scope PRs" path.
- [ ] Real validation: next MAF release exercises the full chain (or manual dispatch).

## Follow-ups

- Close PR #31 (superseded by change #4).
- PR #26: choose to (a) ask Copilot to fix via comment, (b) close and re-fire fill with the improved prompt + Claude bot, or (c) merge as-is and clean up in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)