### PR TITLE
fix(verify): install pyyaml — cross-file check broke without it

### DIFF
--- a/.github/workflows/maf-ai-fill-verify.yml
+++ b/.github/workflows/maf-ai-fill-verify.yml
@@ -94,6 +94,10 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install Python deps for cross-file check
+        if: steps.scope.outputs.in_scope == 'true'
+        run: pip install pyyaml
+
       - name: Run verify-registry (rung-1 mechanical)
         id: verify
         if: steps.scope.outputs.in_scope == 'true'


### PR DESCRIPTION
Trivial dep fix. PR #37 added 'import yaml' to verify_crossfile_consistency.py but I forgot the matching 'pip install pyyaml' in the verify workflow. PR #40 caught it.