### PR TITLE
chore(brand): flip repo URLs to joslat/maf-doctor (post-rename)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ See [`AGENTS.md`](./AGENTS.md) for the full repo layout and location of every so
 - Versions for every NuGet are centrally pinned in `/Directory.Packages.props` — when adding a `<PackageReference>` to any csproj, do NOT include `Version=` inline; add a `<PackageVersion>` to `Directory.Packages.props` instead.
 
 ```bash
-git clone https://github.com/joslat/maf-autopilot
+git clone https://github.com/joslat/maf-doctor
 cd maf-autopilot
 dotnet restore maf-autopilot.sln
 dotnet build maf-autopilot.sln           # builds net8.0 + net9.0 + net10.0 + netstandard2.0 (analyzer)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@
 # Containerised distribution of the maf-autopilot MCP server.
 #
 # Usage:
-#   docker pull ghcr.io/joslat/maf-autopilot:latest
-#   docker run --rm -i ghcr.io/joslat/maf-autopilot
+#   docker pull ghcr.io/joslat/maf-doctor:latest
+#   docker run --rm -i ghcr.io/joslat/maf-doctor
 #
 # The container speaks MCP over stdio. Wire it up in your IDE's mcp.json with:
 #   {
@@ -12,7 +12,7 @@
 #       "maf-doctor": {
 #         "type": "stdio",
 #         "command": "docker",
-#         "args": ["run", "--rm", "-i", "ghcr.io/joslat/maf-autopilot:latest"]
+#         "args": ["run", "--rm", "-i", "ghcr.io/joslat/maf-doctor:latest"]
 #       }
 #     }
 #   }
@@ -69,9 +69,9 @@ WORKDIR /app
 COPY --from=build /app .
 
 # OCI labels — useful for `docker inspect` and registry browsing.
-LABEL org.opencontainers.image.title="maf-autopilot"
+LABEL org.opencontainers.image.title="maf-doctor"
 LABEL org.opencontainers.image.description="MCP server + Roslyn analyzers for Microsoft Agent Framework (MAF) — migration, audit, prompt-lint, cost auditor, scaffolder, simulator."
-LABEL org.opencontainers.image.source="https://github.com/joslat/maf-autopilot"
+LABEL org.opencontainers.image.source="https://github.com/joslat/maf-doctor"
 LABEL org.opencontainers.image.licenses="MIT"
 
 # Security: drop root. The MCP server speaks stdio only and writes nothing to the

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ VS Code picks up `.vscode/mcp.json` automatically and starts the MCP server. Cop
 If you'd rather not install the .NET SDK locally, pull the container instead:
 
 ```bash
-docker pull ghcr.io/joslat/maf-autopilot:latest
+docker pull ghcr.io/joslat/maf-doctor:latest
 ```
 
 Wire it into your IDE's `mcp.json`:
@@ -116,7 +116,7 @@ Wire it into your IDE's `mcp.json`:
     "maf-doctor": {
       "type": "stdio",
       "command": "docker",
-      "args": ["run", "--rm", "-i", "ghcr.io/joslat/maf-autopilot:latest"]
+      "args": ["run", "--rm", "-i", "ghcr.io/joslat/maf-doctor:latest"]
     }
   }
 }
@@ -130,7 +130,7 @@ Copy `.github/` from this repo into your .NET repository root. You get the agent
 
 ```powershell
 # In your MAF project root
-git clone https://github.com/joslat/maf-autopilot tmp-maf
+git clone https://github.com/joslat/maf-doctor tmp-maf
 Copy-Item tmp-maf/.github -Destination .github -Recurse
 Remove-Item tmp-maf -Recurse
 ```
@@ -204,7 +204,7 @@ maf-autopilot/
 │   ├── maf-autopilot.Analyzers/           # Roslyn analyzer package (MAF001/002/003 — separate NuGet)
 │   ├── maf-autopilot.Tests/               # 580 xUnit tests (× 3 TFMs = 1740 executions per run)
 │   └── maf-autopilot.Analyzers.Tests/     # 11 analyzer tests (× 3 TFMs = 33 executions)
-├── Dockerfile                             # multi-stage build → ghcr.io/joslat/maf-autopilot:latest
+├── Dockerfile                             # multi-stage build → ghcr.io/joslat/maf-doctor:latest
 ├── guides/
 │   ├── maf-current-migration-guide.md     # Cumulative — auto-generated, all versions concatenated (start here)
 │   ├── maf-1.3.0-migration-guide.md       # 21-section migration guide (hand-authored bootstrap)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -203,7 +203,7 @@ This pattern matches the sibling [`AgentEval`](https://github.com/joslat/AgentEv
 |---|---|---|---|
 | NuGet (server) | `maf-autopilot` .NET global tool | Developers installing via `dotnet tool install` | `nuget.org/packages/maf-autopilot` |
 | NuGet (analyzer) | `maf-autopilot.Analyzers` analyzer | Consumer .csproj `<PackageReference>` | `nuget.org/packages/maf-autopilot.Analyzers` |
-| Docker | Multi-arch image (amd64+arm64) | Developers without .NET SDK on host | `ghcr.io/joslat/maf-autopilot:<semver>` |
+| Docker | Multi-arch image (amd64+arm64) | Developers without .NET SDK on host | `ghcr.io/joslat/maf-doctor:<semver>` |
 | Skills-only | The `.github/` directory copied into a consumer repo | Users wanting agents+skills without the MCP server | `git clone` |
 
 ---

--- a/docs/maf-migration-toolkit-plan.md
+++ b/docs/maf-migration-toolkit-plan.md
@@ -208,7 +208,7 @@ Vision-completing work; ship as 1.1.0 / 1.2.0.
 
 | Order | Item | Note |
 |---|---|---|
-| D.1 | **#28** Docker distribution via GHCR | `docker pull ghcr.io/joslat/maf-autopilot:latest`. Multi-arch amd64+arm64; semver-keyed tags; stable-only `latest`. | ✅ DONE 2026-05-12 |
+| D.1 | **#28** Docker distribution via GHCR | `docker pull ghcr.io/joslat/maf-doctor:latest`. Multi-arch amd64+arm64; semver-keyed tags; stable-only `latest`. | ✅ DONE 2026-05-12 |
 | D.2 | **#32** Multi-version migration paths | `MafMigrationPath(currentVer, targetVer)` walks version-keyed guide metadata, returns ordered intermediate-step sections. Built on #20 metadata. | ✅ DONE 2026-05-12 |
 | D.3 | **#45** Merge `fan-out-validator` + `fan-in-static-analyzer` | Cosmetic — done as part of A.3 skill slimming (`fan-in-static-analyzer` is now a redirect stub). | ✅ DONE 2026-05-12 (via A.3) |
 | D.4 | GitHub App `@maf-bot` | PR comments scoped to changed lines; pairs with #52. Org-wide adoption vector. Not in current tracking table — file an issue. |
@@ -275,10 +275,10 @@ Vision-completing work; ship as 1.1.0 / 1.2.0.
 | 25 | NuGet publish (`dotnet tool install -g maf-autopilot`) | Publish to NuGet.org as a global tool. Enables `dotnet tool install -g maf-autopilot` | P1 | 🔄 IN PROGRESS | 60% | 50% | **Updated 2026-05-11.** 3 alphas live on nuget.org (`1.3.0-alpha-1/2/3`). Pipeline works (release.yml proven). Remaining: (a) plain `dotnet tool install --global maf-autopilot` fails because all versions are prereleases — needs `--prerelease` flag OR a stable cut; (b) csproj `<Version>` is `1.3.0-tool.1` — drifted from reality (release.yml overrides via workflow input); (c) no stable 1.3.0 yet. Track stable cut as separate row #50. |
 | 26 | `maf-autopilot` Sampling tools | Agentic tools using `server.SampleAsync()`: `maf_full_audit` (analyze→plan→generate→validate), `maf_migration_suggest` | P3 | ❌ NOT STARTED | 0% | 0% | Unlocked by SDK 1.2.0. Server calls host LLM (VS Code Copilot) with zero API keys. Multi-step reasoning chains entirely inside the MCP server. |
 | 27 | `maf-autopilot` full analysis tools | Remaining 6 tools: `maf_detect_cs0618`, `maf_api_diff`, `maf_fan_out_validate`, `maf_executor_pattern_check`, `maf_compatibility`, `maf_migration_path` | P3 | ❌ NOT STARTED | 0% | 0% | Higher-effort tools requiring dotnet build invocation, Roslyn analysis, dotnet-inspect subprocess. See Section 10 tool specs. |
-| 28 | Docker distribution via GHCR | `docker pull ghcr.io/joslat/maf-autopilot:latest` | P3 | ❌ NOT STARTED | 0% | 0% | Depends on #25. Dockerfile + GHCR push in workflow. |
+| 28 | Docker distribution via GHCR | `docker pull ghcr.io/joslat/maf-doctor:latest` | P3 | ❌ NOT STARTED | 0% | 0% | Depends on #25. Dockerfile + GHCR push in workflow. |
 | 29 | Roslyn analyzer companion | Flags void fan-out handlers + insecure credentials + sensitive-data logging at write-time in the IDE | P1 | ✅ DONE | 100% | 85% | **Done 2026-05-11 (magic-path sprint).** New `src/maf-autopilot.Analyzers/` project targeting `netstandard2.0` (Roslyn requirement). Three rules: `MAF001` fan-out handler must return `Task<T>`/`ValueTask<T>` (Error), `MAF002` avoid `DefaultAzureCredential` outside tests (Warning), `MAF003` `EnableSensitiveData = true` outside tests (Warning). Each shipped with help-link URIs to the SKILL.md files. Analyzer release tracking files in place. 11 tests using `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit`. Will pack as `maf-autopilot.Analyzers` NuGet — separate package from the global tool. |
 | 30 | `registry.yaml` auto-update in CI | Semantic step (Copilot Coding Agent or LLM API call) to auto-generate new registry entries from dotnet-inspect diff output — closes the last manual step in `maf-release-watcher.yml` | P2 | ❌ NOT STARTED | 0% | 0% | Pure scripts can't write meaningful YAML entries without semantic analysis. Target: hybrid Copilot Agent step in workflow (see Section 11). No external prerequisite — this is a CI-internal improvement to the release watcher itself. |
-| 31 | `maf_open_feedback_issue` Sampling tool | After migration, uses `server.SampleAsync()` to analyze the migration log, then opens a structured GitHub Issue on `joslat/maf-autopilot` with new CS0618 patterns and guide corrections | P2 | ❌ NOT STARTED | 0% | 0% | Closes the reflexive learning loop in MCP binary mode. Requires GitHub MCP access (already in VS Code Copilot via `mcp_github_*`). See Section 9.2. Prerequisite: #25 NuGet publish. |
+| 31 | `maf_open_feedback_issue` Sampling tool | After migration, uses `server.SampleAsync()` to analyze the migration log, then opens a structured GitHub Issue on `joslat/maf-doctor` with new CS0618 patterns and guide corrections | P2 | ❌ NOT STARTED | 0% | 0% | Closes the reflexive learning loop in MCP binary mode. Requires GitHub MCP access (already in VS Code Copilot via `mcp_github_*`). See Section 9.2. Prerequisite: #25 NuGet publish. |
 | 32 | Multi-version migration paths | Support 1.1.0 → 1.3.0 in one pass (not step-by-step through intermediate versions) | P3 | ❌ NOT STARTED | 0% | 0% | Depends on version-keyed guide sections (#20 ✅). Migration agent stacks multiple version paths by loading sections tagged for each intermediate version. |
 | 33 | **Bump `dotnet-inspect` 0.7.6 → 0.7.8 + fix attribution** | Pin update across 21 places. Author correction `filipw` → `richlander`. Rewrite "[Obsolete] caveat" paragraphs in README, `dotnet-inspect/SKILL.md`, `copilot-instructions.md`, `maf-constraints.instructions.md`, migration guide. | P1 | ✅ DONE | 100% | 85% | **Done 2026-05-11.** All 21 pinned references bumped. Attribution corrected. `cs0618-hunter` framing rewritten: dotnet-inspect@0.7.8 is the static / pre-build path; compiler stays authoritative for transitive / overload-resolution / project-local cases. Reviewed by Opus; minor housekeeping (cs0618 §"Why Not Use" + guide frontmatter) swept in follow-up commit. |
 | 34 | Fix README install command + csproj version drift | README + setup.md install snippets must use `--prerelease` (or be pinned to `--version 1.3.0-alpha-3`) until stable ships. `maf-autopilot.csproj:15` `<Version>` bumped to next prerelease so csproj stops lying. | P1 | ✅ DONE | 100% | 85% | **Done 2026-05-11.** README + setup.md install snippets show `--prerelease` and link nuget.org/packages/maf-autopilot. csproj `<Version>` bumped `1.3.0-tool.1` → `1.3.0-alpha-4`. Build clean. |
@@ -779,12 +779,12 @@ When `maf-autopilot` is deployed as an installed binary (the MCP-first model), t
 
 | Mode | Where learnings live | How they reach the central toolkit |
 |------|---------------------|------------------------------------|
-| File-copy mode (17 `.github/` files copied to target repo) | Updated in-place by retrospective skill directly | Manual PR from the updated local files to `joslat/maf-autopilot` |
+| File-copy mode (17 `.github/` files copied to target repo) | Updated in-place by retrospective skill directly | Manual PR from the updated local files to `joslat/maf-doctor` |
 | MCP binary mode (`dotnet tool install -g maf-autopilot`) | Cannot write embedded resources | **Via `maf_open_feedback_issue` Sampling tool** |
 
 **The `maf_open_feedback_issue` tool (tracking row #31):**
 
-After a migration completes, this MCP tool uses `server.SampleAsync()` to analyze the migration log (plan file, terminal history, or user-provided excerpt), then — if the user has [GitHub MCP](https://github.com/github/github-mcp-server) connected — opens a structured issue on `joslat/maf-autopilot`:
+After a migration completes, this MCP tool uses `server.SampleAsync()` to analyze the migration log (plan file, terminal history, or user-provided excerpt), then — if the user has [GitHub MCP](https://github.com/github/github-mcp-server) connected — opens a structured issue on `joslat/maf-doctor`:
 
 ```
 Title: [Retrospective] CS0618 pattern not in registry: WorkflowBuilder.SomeMember
@@ -1227,8 +1227,8 @@ dotnet tool install --global maf-autopilot
 ### Option 2: Docker / GitHub Container Registry
 
 ```bash
-docker pull ghcr.io/joslat/maf-autopilot:latest
-docker run -p 7891:7891 ghcr.io/joslat/maf-autopilot:latest
+docker pull ghcr.io/joslat/maf-doctor:latest
+docker run -p 7891:7891 ghcr.io/joslat/maf-doctor:latest
 ```
 
 **How to release:**
@@ -1371,7 +1371,7 @@ Ordered by value-to-effort ratio. See the **Implementation Tracking Table** at t
 
 - [ ] #26 Sampling tools — `maf_full_audit`, `maf_migration_suggest` using `server.SampleAsync()`
 - [ ] #27 Full analysis tools — `maf_detect_cs0618`, `maf_api_diff`, `maf_fan_out_validate`, `maf_compatibility`, `maf_migration_path`
-- [ ] #28 Docker distribution via GHCR — `ghcr.io/joslat/maf-autopilot:latest`
+- [ ] #28 Docker distribution via GHCR — `ghcr.io/joslat/maf-doctor:latest`
 - [ ] #29 Roslyn analyzer companion — flags void fan-out handlers at write-time in IDE
 - [ ] #32 Multi-version migration paths — 1.1.0 → 1.3.0 in one pass without step-by-step
 

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -119,7 +119,7 @@ The previous "(1) fix registry drift" item is **done** — landed in the same se
 
 1. **(50 min — must be human) Run the workshop end-to-end (T.3 → T.4 → T.5).** Follow [`samples/workshop.md`](../samples/workshop.md). This drives `@maf-auditor` → `@maf-migration` via Copilot Chat in VS Code Insiders — the agents themselves are a GitHub Copilot client feature, not something Claude Code can invoke. The migration log + final `MafDoctor` grade A/B IS the A.8 evidence to point at when announcing 1.0.
 
-2. **(10 min — human-driven publish) Cut stable `1.3.0` (T.7 → A.8 unblocked).** This is the **release cut**: `gh workflow run release.yml -f version=1.3.0` triggers the GitHub Actions release workflow which (a) runs `dotnet test` across all 3 TFMs, (b) `dotnet pack`s the multi-target nupkg + the analyzer nupkg, (c) pushes both to `nuget.org` with the `NUGET_API_KEY` secret, (d) builds + pushes the multi-arch Docker image to `ghcr.io/joslat/maf-autopilot:1.3.0`, (e) creates a tagged GitHub Release with auto-generated release notes. **"Announces" means: once `1.3.0` (without `-alpha-N`) is live on nuget.org, anyone running `dotnet tool install -g maf-autopilot` (no `--prerelease` flag needed) gets it.** That's the implicit announcement. An optional explicit announcement step would be a discussions post / blog / social — none required for the cut itself. This is a one-way publish to a public registry, so it stays human-driven.
+2. **(10 min — human-driven publish) Cut stable `1.3.0` (T.7 → A.8 unblocked).** This is the **release cut**: `gh workflow run release.yml -f version=1.3.0` triggers the GitHub Actions release workflow which (a) runs `dotnet test` across all 3 TFMs, (b) `dotnet pack`s the multi-target nupkg + the analyzer nupkg, (c) pushes both to `nuget.org` with the `NUGET_API_KEY` secret, (d) builds + pushes the multi-arch Docker image to `ghcr.io/joslat/maf-doctor:1.3.0`, (e) creates a tagged GitHub Release with auto-generated release notes. **"Announces" means: once `1.3.0` (without `-alpha-N`) is live on nuget.org, anyone running `dotnet tool install -g maf-autopilot` (no `--prerelease` flag needed) gets it.** That's the implicit announcement. An optional explicit announcement step would be a discussions post / blog / social — none required for the cut itself. This is a one-way publish to a public registry, so it stays human-driven.
 
 3. **(done by Claude Code, 2026-05-13)** Phase R Dependabot triage:
    - ✅ Closed #1, #2 (Docker .NET 10 forcers — Dockerfile stays net8 LTS)
@@ -1055,7 +1055,7 @@ rm -f  samples/maf-1.3-sample/docs/migration-plan.md
 2. `dotnet pack src/maf-autopilot/maf-autopilot.csproj` — produces a single multi-TFM nupkg.
 3. `dotnet pack src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj` — produces the analyzer nupkg.
 4. `dotnet nuget push *.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate`.
-5. Docker multi-arch image built + pushed to `ghcr.io/joslat/maf-autopilot:1.3.0` + `:latest`.
+5. Docker multi-arch image built + pushed to `ghcr.io/joslat/maf-doctor:1.3.0` + `:latest`.
 6. `softprops/action-gh-release` creates a tagged GitHub Release with auto-generated notes.
 
 **Why you (not Claude).** One-way publish to a public registry. Once `1.3.0` (no `-alpha-N`) is live, anyone running `dotnet tool install -g maf-autopilot` (no `--prerelease`) gets it. That's the implicit announcement.
@@ -1088,7 +1088,7 @@ gh run watch
 - [ ] **Package live on nuget.org:** https://www.nuget.org/packages/maf-autopilot/1.3.0 should resolve within ~5 minutes.
 - [ ] **Analyzer package live:** https://www.nuget.org/packages/maf-autopilot.Analyzers/1.3.0.
 - [ ] **GitHub Release page** has been created with auto-generated notes from `softprops/action-gh-release`.
-- [ ] **Docker image** pushed: `docker pull ghcr.io/joslat/maf-autopilot:1.3.0` succeeds.
+- [ ] **Docker image** pushed: `docker pull ghcr.io/joslat/maf-doctor:1.3.0` succeeds.
 - [ ] **A clean install works:** in a fresh shell, `dotnet tool install -g maf-autopilot` (NO `--prerelease`) gets you 1.3.0 stable.
 
 **Rollback (if the publish goes wrong).**
@@ -1217,7 +1217,7 @@ After push, refresh the README on GitHub. The two `<img>` blocks at the top shou
    ```
    https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2F<user>%2F<gist-id>%2Fraw%2Fmaf-autopilot-health.json
    ```
-5. Add `[![MAF Health](https://img.shields.io/endpoint?url=...)](https://github.com/joslat/maf-autopilot)` to your README.
+5. Add `[![MAF Health](https://img.shields.io/endpoint?url=...)](https://github.com/joslat/maf-doctor)` to your README.
 6. **Wire CI to refresh the gist** — add a step to `.github/workflows/maf-drift-detector.yml` (or release.yml) that updates the gist via `gh gist edit` after each release.
 
 ##### Alternative — Cloudflare Worker (~30 min, free tier, more flexible)
@@ -1290,7 +1290,7 @@ File the failure detail as a follow-up issue. Claude can fix the toolkit-side co
 
 ##### Suggested channels (any subset)
 
-- **GitHub Discussions** on `joslat/maf-autopilot` — long-form, evergreen, indexable.
+- **GitHub Discussions** on `joslat/maf-doctor` — long-form, evergreen, indexable.
 - **A Medium / dev.to blog post** — for narrative + screenshots of the casts (X.3 produces them).
 - **Twitter/X thread** — 5-tweet outline: install → audit → grade F → auto-fix → grade A. The cast GIFs from X.3 are tweet-shaped.
 - **LinkedIn post** — tag Microsoft Agent Framework team for visibility.

--- a/docs/self-update-remediation-plan.md
+++ b/docs/self-update-remediation-plan.md
@@ -1,6 +1,6 @@
 # MAF self-update remediation plan
 
-**Created:** 2026-06-14 · **Owner:** @joslat · **Status:** ✅ Code-complete — 30/33 done; the 3 open items (5.2 live dry-run, 5.3 re-trigger, 6.4 repo rename) are maintainer-only 🔒 post-merge steps.
+**Created:** 2026-06-14 · **Owner:** @joslat · **Status:** ✅ **COMPLETE — 33/33.** Merged to `main` (#66→#59); watcher live-validated (dry-run + real 1.6.1→1.10.0 update on main); drift detector live; repo renamed to `joslat/maf-doctor` + URLs flipped. Optional 6.5 (namespace) intentionally left as a future separate PR.
 **Scope:** Fix the two failing self-update workflows (MAF Release Watcher, MAF Drift Detector), harden the whole self-update engine and its AI-fill chain, validate the auto-update path end-to-end, and execute the brand-only rename to **MAF Doctor**.
 
 ## Why this exists (one-paragraph problem statement)
@@ -47,13 +47,13 @@ Both scheduled self-update workflows have failed on **every** scheduled run sinc
 | 4 · Chain bugs | 4.10 | pr-audit honest scoping | Scope doctor to changed files OR fix the comment | 100% | ☑ | done — honest comment + product `--exclude` |
 | 4 · Chain bugs | 4.11 | ai-fill template guide anchor | Parameterize/comment the hardcoded 1.3.0 anchor | 100% | ☑ | done — check #6 now unions all guides |
 | 5 · Validation | 5.1 | NuGet fixture smoke test | Unit-test version detection in ci-invariants | 100% | ☑ | done — pytest step runs .github/scripts/tests in CI |
-| 5 · Validation | 5.2 | analyze-and-update dry-run | Synthetic bump on throwaway branch, prove push chain | 50% | ☐ | code-ready — `push_target` input added; **live run 🔒 maintainer** |
-| 5 · Validation | 5.3 | Re-trigger + verify lifecycle | Manual run both; confirm green + issue open/close | 0% | ☐ | **🔒 post-merge** — runs the OLD main until this PR merges |
+| 5 · Validation | 5.2 | analyze-and-update dry-run | Synthetic bump on throwaway branch, prove push chain | 100% | ☑ | done — dispatched on a throwaway branch; full chain green; main untouched |
+| 5 · Validation | 5.3 | Re-trigger + verify lifecycle | Manual run both; confirm green + issue open/close | 100% | ☑ | done — both green on main; watcher did real 1.6.1→1.10.0; drift opened #69 |
 | 5 · Validation | 5.4 | Workflow-set parse audit | Lint all 10 workflows; confirm startup_failures clear | 100% | ☑ | done — all 10 parse; actionlint gate added (0.2) |
 | 6 · Rebrand | 6.1 | PR-A: brand + server id + URLs | Text-only rename to MAF Doctor / maf-doctor | 70% | ☑ | server id + snippets done; **URL/RepositoryUrl flip deferred to 6.4** (avoids 404 window) |
 | 6 · Rebrand | 6.2 | InitCommand server key | Write `maf-doctor` key, keep `command=maf-autopilot` | 100% | ☑ | done — legacy-key guard; 6 tests green |
 | 6 · Rebrand | 6.3 | CHANGELOG migration notes | GHCR image-path + mcp.json server-id change | 100% | ☑ | done — Unreleased entry + maintainer follow-ups |
-| 6 · Rebrand | 6.4 | Repo rename | `joslat/maf-autopilot` → `joslat/maf-doctor` | 0% | ☐ | **🔒 post-merge** — bundle the URL/SARIF/OCI/RepositoryUrl flip here |
+| 6 · Rebrand | 6.4 | Repo rename | `joslat/maf-autopilot` → `joslat/maf-doctor` | 100% | ☑ | done — repo renamed (old path redirects); URL/SARIF/OCI/RepositoryUrl flipped (`chore/rebrand-urls`) |
 | 6 · Rebrand | 6.5 | Namespace rename (opt) | `MafAutopilot`→`MafDoctor`, separate mechanical PR | 0% | ☐ | **deferred by design** — optional, separate PR, never bundled |
 | 7 · Docs/closeout | 7.1 | Fix is_major escalation docs | architecture.md flow + plan B.3 | 100% | ☑ | done — flow rewritten (direct-push + escalation); B.3 superseded-note |
 | 7 · Docs/closeout | 7.2 | README/CHANGELOG behavior updates | Document failure issues, drift target, watcher cadence | 100% | ☑ | done — README tree cadence + CHANGELOG + TROUBLESHOOTING |
@@ -488,11 +488,11 @@ Every code change ships on a branch behind PRs; revert the PR to roll back. The 
 - **7.2** README workflow-tree cadence corrected (watcher daily; drift Mon 11:00 product-scoped); CHANGELOG + TROUBLESHOOTING already cover failure issues / drift target / cadence.
 - **7.3 — final green board:** `dotnet test` net10.0 = **739 + 15 (analyzers) passed, 0 failed**; **50 Python helper tests** pass; `compileall` clean; ci-invariants job (4)+(5) clean; frozen identity literals verified intact (`PackageId`, `ToolCommandName`, `dotnet tool install … maf-autopilot`).
 
-### Remaining (maintainer-only 🔒, post-merge)
-1. **5.2** — privileged dry-run of `analyze-and-update` against a throwaway branch (use the new `push_target` + a synthetic `maf_version`).
-2. **5.3** — manually re-trigger both scheduled workflows on `main` after merge; confirm green + the drift-issue open/close lifecycle.
-3. **6.4** — rename the GitHub repo `joslat/maf-autopilot` → `joslat/maf-doctor`, then flip the remaining `joslat/maf-autopilot` URL / `RepositoryUrl` / SARIF / OCI-label references (bundle the URL sed here to avoid a 404 window). The GHCR image path follows automatically.
-- Optional: **6.5** namespace rename `MafAutopilot`→`MafDoctor` as a separate mechanical PR; enable native failed-workflow email (2.3).
+### Completed post-merge (was maintainer-only 🔒)
+1. ✅ **5.2** — dry-run of `analyze-and-update` dispatched from the branch with `push_target=dryrun/self-update-validate`. Detected 1.6.1→1.10.0 via the real NuGet path, ran a real diff (artifact `maf-diff-1.10.0`), and committed the full update (`.maf-version`, matrix, new guide, **425 lines of registry drafts**, cumulative guide) to the throwaway branch. `main` untouched. Branch + the dry-run fill-issue cleaned up.
+2. ✅ **5.3** — after merge to `main`, both scheduled workflows triggered live and went **green**. The watcher did the real **1.6.1 → 1.10.0** auto-commit to `main` (the repo was 4 versions behind because the watcher had been broken) and dispatched the fill flow (#70); the drift detector self-provisioned the labels and opened #69 (grade F — expected until a build with 3.1's `--exclude` is published to NuGet).
+3. ✅ **6.4** — repo renamed `joslat/maf-autopilot` → **`joslat/maf-doctor`** (old path 301-redirects). Flipped every `joslat/maf-autopilot` URL / `RepositoryUrl` / SARIF helpUri / OCI title to `joslat/maf-doctor` on `chore/rebrand-urls` (SARIF + analyzer tests still green); the GHCR image path follows automatically. The package id / CLI / dll / namespace stay `maf-autopilot` (frozen).
+- Still optional (intentionally a separate future PR): **6.5** namespace rename `MafAutopilot`→`MafDoctor`; and enabling the native failed-workflow email (2.3).
 
 ### 2026-06-14 — Final review pass (self-review of the PR diff)
 - Verified the watcher escalation gating is coherent: `Commit directly to main` (`if: is_major != 'true'`) → `Open issue for Copilot` (`if: committed == 'true'`) → `Escalate MAJOR` (`if: is_major == 'true'`). Minor/patch commits & dispatch; no-op skips dispatch; majors escalate and never push.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -117,7 +117,7 @@ maf-autopilot init
 cd C:\git\joslat\maf-autopilot
 
 # Create private repo on GitHub and push
-gh repo create joslat/maf-autopilot \
+gh repo create joslat/maf-doctor \
   --private \
   --description "AI-powered toolkit for Microsoft Agent Framework (MAF) migrations — agents, skills, MCP server, and self-updating guide" \
   --source . \
@@ -134,7 +134,7 @@ gh repo create joslat/maf-autopilot \
 6. Click **Create repository**
 7. In your local terminal:
    ```bash
-   git remote add origin https://github.com/joslat/maf-autopilot.git
+   git remote add origin https://github.com/joslat/maf-doctor.git
    git branch -M main
    git push -u origin main
    ```
@@ -156,11 +156,11 @@ To use the release watcher workflow and eventually publish the NuGet package, yo
 
 ### Option A — Use this repo directly
 
-If you are **joslat** (the repo owner): the repository is `github.com/joslat/maf-autopilot`. The workflow is already present. Skip to [adding secrets](#adding-github-secrets).
+If you are **joslat** (the repo owner): the repository is `github.com/joslat/maf-doctor`. The workflow is already present. Skip to [adding secrets](#adding-github-secrets).
 
 ### Option B — Fork for your own use
 
-1. Fork `joslat/maf-autopilot` on GitHub
+1. Fork `joslat/maf-doctor` on GitHub
 2. In your fork: **Settings → Actions → General → Allow all actions** (ensure Actions are enabled)
 3. Change the `.maf-version` file if you want to track a different baseline version
 

--- a/samples/workshop.md
+++ b/samples/workshop.md
@@ -68,7 +68,7 @@ maf-autopilot --version
 If you don't have a clone of this repo handy, also:
 
 ```bash
-git clone https://github.com/joslat/maf-autopilot
+git clone https://github.com/joslat/maf-doctor
 cd maf-autopilot
 ```
 
@@ -659,7 +659,7 @@ The first two are **automatable** (just run the `.tape` scripts). The last two a
 
 [7:00 — 7:30]  Close
   "maf-autopilot 1.3.0 on NuGet. Install with one command. Audits any
-   MAF codebase. github.com/joslat/maf-autopilot."
+   MAF codebase. github.com/joslat/maf-doctor."
 ```
 
 **Recording tips:**
@@ -682,7 +682,7 @@ The first two are **automatable** (just run the `.tape` scripts). The last two a
 | **Before state** | Slide 1: "maf-autopilot Workshop — From Zero to Migrated Codebase" + your name. |
 | **What to do** | Walk through Phase A → B → C → D → E in order. Stop after each Phase for Q&A (~2 min each). Total: ~40 min content + ~10 min Q&A. |
 | **What to say** | The "Talk-track" callout boxes throughout the workshop sections. They're written as one-liners you can read verbatim or paraphrase. |
-| **After state** | Final slide: "Try it: `dotnet tool install -g maf-autopilot`; github.com/joslat/maf-autopilot; questions?" |
+| **After state** | Final slide: "Try it: `dotnet tool install -g maf-autopilot`; github.com/joslat/maf-doctor; questions?" |
 | **Where it goes** | YouTube / conference recording platform. |
 
 **Tip:** if recording over 50 minutes, plan **deliberate dead air at chapter transitions** (between Phase A → B, B → C, etc.) so your editor can cut cleanly. ~3 seconds of silent screen between phases makes editing 10× easier.

--- a/src/maf-autopilot.Analyzers/DefaultAzureCredentialAnalyzer.cs
+++ b/src/maf-autopilot.Analyzers/DefaultAzureCredentialAnalyzer.cs
@@ -31,7 +31,7 @@ public sealed class DefaultAzureCredentialAnalyzer : DiagnosticAnalyzer
         // Anchor fragments are slugified by GitHub from the full heading text, which
         // is fragile across heading edits. Link at the document root and rely on
         // the rule ID being grep-able inside the page.
-        helpLinkUri: "https://github.com/joslat/maf-autopilot/blob/main/.github/skills/maf-anti-pattern-scanner/SKILL.md");
+        helpLinkUri: "https://github.com/joslat/maf-doctor/blob/main/.github/skills/maf-anti-pattern-scanner/SKILL.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);

--- a/src/maf-autopilot.Analyzers/FanOutHandlerAnalyzer.cs
+++ b/src/maf-autopilot.Analyzers/FanOutHandlerAnalyzer.cs
@@ -38,7 +38,7 @@ public sealed class FanOutHandlerAnalyzer : DiagnosticAnalyzer
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: Description,
-        helpLinkUri: "https://github.com/joslat/maf-autopilot/blob/main/.github/skills/maf-fan-out-validator/SKILL.md");
+        helpLinkUri: "https://github.com/joslat/maf-doctor/blob/main/.github/skills/maf-fan-out-validator/SKILL.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);

--- a/src/maf-autopilot.Analyzers/SensitiveDataAnalyzer.cs
+++ b/src/maf-autopilot.Analyzers/SensitiveDataAnalyzer.cs
@@ -27,7 +27,7 @@ public sealed class SensitiveDataAnalyzer : DiagnosticAnalyzer
         description: "Sensitive-data logging is intended for development diagnostics only. Production telemetry should default to redacted attributes.",
         // Anchor fragments are slugified by GitHub from the full heading text. Link
         // at the document root; the rule ID is grep-able inside the page.
-        helpLinkUri: "https://github.com/joslat/maf-autopilot/blob/main/.github/skills/maf-anti-pattern-scanner/SKILL.md");
+        helpLinkUri: "https://github.com/joslat/maf-doctor/blob/main/.github/skills/maf-anti-pattern-scanner/SKILL.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
         ImmutableArray.Create(Rule);

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -19,7 +19,7 @@
     <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) 1.3.0 — write-time enforcement of fan-out safety, secure credentials, and observability defaults. Pairs with the maf-autopilot MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/joslat/maf-autopilot</RepositoryUrl>
+    <RepositoryUrl>https://github.com/joslat/maf-doctor</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/maf-autopilot/Tools/SarifEmitter.cs
+++ b/src/maf-autopilot/Tools/SarifEmitter.cs
@@ -14,7 +14,7 @@ namespace MafAutopilot.Tools;
 internal static class SarifEmitter
 {
     public const string ToolName = "maf-autopilot";
-    public const string ToolUri = "https://github.com/joslat/maf-autopilot";
+    public const string ToolUri = "https://github.com/joslat/maf-doctor";
 
     /// <summary>
     /// Builds a SARIF document for a collection of normalised findings.

--- a/src/maf-autopilot/Tools/SarifExportTool.cs
+++ b/src/maf-autopilot/Tools/SarifExportTool.cs
@@ -61,7 +61,7 @@ internal static class SarifExportTool
 
     private static IEnumerable<SarifRule> BuildAntiPatternRuleCatalog()
     {
-        const string skillUri = "https://github.com/joslat/maf-autopilot/blob/main/.github/skills/maf-anti-pattern-scanner/SKILL.md";
+        const string skillUri = "https://github.com/joslat/maf-doctor/blob/main/.github/skills/maf-anti-pattern-scanner/SKILL.md";
         foreach (var rule in AntiPatternScannerTool.AllRules)
         {
             yield return new SarifRule(
@@ -80,6 +80,6 @@ internal static class SarifExportTool
             Name: "Fan-out handler must return Task<T> or ValueTask<T>",
             Severity: SarifSeverity.Error,
             FullDescription: "A [MessageHandler] method that returns void, Task, or ValueTask (non-generic) produces no downstream message and silently starves the fan-in barrier.",
-            HelpUri: "https://github.com/joslat/maf-autopilot/blob/main/.github/skills/maf-fan-out-validator/SKILL.md");
+            HelpUri: "https://github.com/joslat/maf-doctor/blob/main/.github/skills/maf-fan-out-validator/SKILL.md");
     }
 }

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -23,7 +23,7 @@
     <Description>MAF autopilot MCP server — Tools + Resources + Prompts + Sampling for MAF 1.3.0 migrations. Answers "is this API safe?", exposes migration guide as resources, and uses sampling for multi-step agentic analysis.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/joslat/maf-autopilot</RepositoryUrl>
+    <RepositoryUrl>https://github.com/joslat/maf-doctor</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 
     <!-- Ensure logs go to stderr so stdout stays clean for MCP protocol -->


### PR DESCRIPTION
Completes the rename: repo is now `joslat/maf-doctor` (old path 301-redirects). Flips all repo-URL references (docs/Dockerfile links, `RepositoryUrl`, SARIF helpUri/ToolUri, OCI title) to the new path. Frozen identity (PackageId / CLI / dll / namespace / `dotnet tool install maf-autopilot` / nuget.org/packages/maf-autopilot) untouched. SARIF + analyzer tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)