### PR TITLE
refactor(namespace): MafAutopilot -> MafDoctor (C# namespace only)

### DIFF
--- a/src/maf-autopilot.Analyzers.Tests/CredentialAndSensitiveDataTests.cs
+++ b/src/maf-autopilot.Analyzers.Tests/CredentialAndSensitiveDataTests.cs
@@ -1,16 +1,16 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using MafAutopilot.Analyzers;
+using MafDoctor.Analyzers;
 using Xunit;
 
-namespace MafAutopilot.Analyzers.Tests;
+namespace MafDoctor.Analyzers.Tests;
 
 using DacVerify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<
-    MafAutopilot.Analyzers.DefaultAzureCredentialAnalyzer,
+    MafDoctor.Analyzers.DefaultAzureCredentialAnalyzer,
     Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 using SdVerify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<
-    MafAutopilot.Analyzers.SensitiveDataAnalyzer,
+    MafDoctor.Analyzers.SensitiveDataAnalyzer,
     Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
 public class DefaultAzureCredentialAnalyzerTests

--- a/src/maf-autopilot.Analyzers.Tests/FanOutHandlerAnalyzerTests.cs
+++ b/src/maf-autopilot.Analyzers.Tests/FanOutHandlerAnalyzerTests.cs
@@ -1,13 +1,13 @@
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
-using MafAutopilot.Analyzers;
+using MafDoctor.Analyzers;
 using Xunit;
 
 using Verify = Microsoft.CodeAnalysis.CSharp.Testing.CSharpAnalyzerTest<
-    MafAutopilot.Analyzers.FanOutHandlerAnalyzer,
+    MafDoctor.Analyzers.FanOutHandlerAnalyzer,
     Microsoft.CodeAnalysis.Testing.DefaultVerifier>;
 
-namespace MafAutopilot.Analyzers.Tests;
+namespace MafDoctor.Analyzers.Tests;
 
 public class FanOutHandlerAnalyzerTests
 {

--- a/src/maf-autopilot.Analyzers.Tests/maf-autopilot.Analyzers.Tests.csproj
+++ b/src/maf-autopilot.Analyzers.Tests/maf-autopilot.Analyzers.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <RootNamespace>MafAutopilot.Analyzers.Tests</RootNamespace>
+    <RootNamespace>MafDoctor.Analyzers.Tests</RootNamespace>
     <!-- NU1701: Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit transitively
          pulls netstandard1.x packages. They work fine on net8/9/10 but emit warnings. -->
     <NoWarn>$(NoWarn);CA1707;NU1701</NoWarn>

--- a/src/maf-autopilot.Analyzers/DefaultAzureCredentialAnalyzer.cs
+++ b/src/maf-autopilot.Analyzers/DefaultAzureCredentialAnalyzer.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace MafAutopilot.Analyzers;
+namespace MafDoctor.Analyzers;
 
 /// <summary>
 /// MAF002 — DefaultAzureCredential in production.

--- a/src/maf-autopilot.Analyzers/FanOutHandlerAnalyzer.cs
+++ b/src/maf-autopilot.Analyzers/FanOutHandlerAnalyzer.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace MafAutopilot.Analyzers;
+namespace MafDoctor.Analyzers;
 
 /// <summary>
 /// MAF001 — fan-out handler must return Task&lt;T&gt; or ValueTask&lt;T&gt;.

--- a/src/maf-autopilot.Analyzers/SensitiveDataAnalyzer.cs
+++ b/src/maf-autopilot.Analyzers/SensitiveDataAnalyzer.cs
@@ -4,7 +4,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
-namespace MafAutopilot.Analyzers;
+namespace MafDoctor.Analyzers;
 
 /// <summary>
 /// MAF003 — EnableSensitiveData = true outside of test code.

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -9,7 +9,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
-    <RootNamespace>MafAutopilot.Analyzers</RootNamespace>
+    <RootNamespace>MafDoctor.Analyzers</RootNamespace>
     <AssemblyName>maf-autopilot.Analyzers</AssemblyName>
 
     <!-- NuGet packaging -->

--- a/src/maf-autopilot.Tests/AgentScaffolderTests.cs
+++ b/src/maf-autopilot.Tests/AgentScaffolderTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Scaffolding;
-using MafAutopilot.Tools;
+using MafDoctor.Scaffolding;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for the scaffolder + the critical dogfooding check: code we generate

--- a/src/maf-autopilot.Tests/AntiPatternScannerExecutorRuleTests.cs
+++ b/src/maf-autopilot.Tests/AntiPatternScannerExecutorRuleTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for the `MAF-AP-EXEC-001` anti-pattern rule — detects pre-1.3.0 executor

--- a/src/maf-autopilot.Tests/AntiPatternScannerToolTests.cs
+++ b/src/maf-autopilot.Tests/AntiPatternScannerToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for AntiPatternScannerTool. All tests use literal C# source strings

--- a/src/maf-autopilot.Tests/ApiSafetyToolTests.cs
+++ b/src/maf-autopilot.Tests/ApiSafetyToolTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Data;
-using MafAutopilot.Tools;
+using MafDoctor.Data;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// End-to-end tests for the ApiSafetyTool — invokes the tool the way the MCP host would.

--- a/src/maf-autopilot.Tests/AutoFixToolTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixToolTests.cs
@@ -1,10 +1,10 @@
 using System.Text.Json;
-using MafAutopilot.Tools;
-using MafAutopilot.Tools.Rewriters;
+using MafDoctor.Tools;
+using MafDoctor.Tools.Rewriters;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Phase W.6 — tests for <see cref="AutoFixTool"/> + each rewriter.

--- a/src/maf-autopilot.Tests/BadgeCommandTests.cs
+++ b/src/maf-autopilot.Tests/BadgeCommandTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Commands;
+using MafDoctor.Commands;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Phase W.13 — tests for <see cref="BadgeCommand"/>.

--- a/src/maf-autopilot.Tests/BeforeAfterToolTests.cs
+++ b/src/maf-autopilot.Tests/BeforeAfterToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Phase W.7 — tests for <see cref="BeforeAfterTool"/>.

--- a/src/maf-autopilot.Tests/BoundedInputTests.cs
+++ b/src/maf-autopilot.Tests/BoundedInputTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for <see cref="BoundedInput"/>. The cap table is the contract; the

--- a/src/maf-autopilot.Tests/CompatibilityToolTests.cs
+++ b/src/maf-autopilot.Tests/CompatibilityToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for the `MafCompatibility` MCP tool. Salvaged from the May-6 sketch

--- a/src/maf-autopilot.Tests/Cs0618HuntToolTests.cs
+++ b/src/maf-autopilot.Tests/Cs0618HuntToolTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Data;
-using MafAutopilot.Tools;
+using MafDoctor.Data;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for the pure parser core of Cs0618HuntTool. The shell-out to `dotnet build`

--- a/src/maf-autopilot.Tests/DiffPackageToolTests.cs
+++ b/src/maf-autopilot.Tests/DiffPackageToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for the pure parser of DiffPackageTool. The fixture string in
@@ -205,7 +205,7 @@ public class DiffPackageToolTests
     [Fact]
     public void Mcp_InvalidArguments_ReturnError()
     {
-        var tool = new DiffPackageTool(new MafAutopilot.Data.RegistryService());
+        var tool = new DiffPackageTool(new MafDoctor.Data.RegistryService());
 
         Assert.Contains("Error", tool.MafDiffPackage("", "1.0", "2.0"), StringComparison.OrdinalIgnoreCase);
         Assert.Contains("Error", tool.MafDiffPackage("Foo;rm", "1.0", "2.0"), StringComparison.OrdinalIgnoreCase);

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class DoctorToolTests
 {

--- a/src/maf-autopilot.Tests/DraftIssueToolTests.cs
+++ b/src/maf-autopilot.Tests/DraftIssueToolTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Data;
-using MafAutopilot.Tools;
+using MafDoctor.Data;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for the `MafDraftIssue` MCP tool. Focus areas:

--- a/src/maf-autopilot.Tests/EstimateCostToolTests.cs
+++ b/src/maf-autopilot.Tests/EstimateCostToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class EstimateCostToolTests
 {

--- a/src/maf-autopilot.Tests/ExplainToolTests.cs
+++ b/src/maf-autopilot.Tests/ExplainToolTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Data;
-using MafAutopilot.Tools;
+using MafDoctor.Data;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class ExplainToolTests
 {

--- a/src/maf-autopilot.Tests/FanOutValidatorToolTests.cs
+++ b/src/maf-autopilot.Tests/FanOutValidatorToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for FanOutValidatorTool — pure Roslyn syntax-tree walking.

--- a/src/maf-autopilot.Tests/FormatEntryTests.cs
+++ b/src/maf-autopilot.Tests/FormatEntryTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Pinpoint tests for <see cref="RegistryService.FormatEntry"/> — the markdown formatter

--- a/src/maf-autopilot.Tests/InitCommandTests.cs
+++ b/src/maf-autopilot.Tests/InitCommandTests.cs
@@ -1,8 +1,8 @@
 using System.Text.Json.Nodes;
-using MafAutopilot;
+using MafDoctor;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for `maf-autopilot init` — specifically the .vscode/mcp.json merge logic.
@@ -33,7 +33,7 @@ public sealed class InitCommandTests : IDisposable
     // -------------------------------------------------------------------------
 
     [Fact]
-    public async Task WriteMcpJsonAsync_NoExistingFile_CreatesWithMafAutopilotEntry()
+    public async Task WriteMcpJsonAsync_NoExistingFile_CreatesWithMafDoctorEntry()
     {
         await InitCommand.WriteMcpJsonAsync(_tempDir);
 

--- a/src/maf-autopilot.Tests/LlmFencingTests.cs
+++ b/src/maf-autopilot.Tests/LlmFencingTests.cs
@@ -1,8 +1,8 @@
 using System.Text;
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for <see cref="LlmFencing"/>. Parity tests for the Python sibling

--- a/src/maf-autopilot.Tests/MafPromptsTests.cs
+++ b/src/maf-autopilot.Tests/MafPromptsTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Prompts;
+using MafDoctor.Prompts;
 using ModelContextProtocol.Protocol;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for the MCP Prompts in <see cref="MafPrompts"/>. The focus is the

--- a/src/maf-autopilot.Tests/MafResourcesTests.cs
+++ b/src/maf-autopilot.Tests/MafResourcesTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Resources;
+using MafDoctor.Resources;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for MafResources — the read-only knowledge surface exposed at maf:// URIs.
@@ -116,7 +116,7 @@ public class MafResourcesTests
         // rule that AntiPatternScannerTool.AllRules actually ships. If a future rule
         // is added without updating the catalog, this fails.
         var body = MafResources.GetRules();
-        foreach (var rule in MafAutopilot.Tools.AntiPatternScannerTool.AllRules)
+        foreach (var rule in MafDoctor.Tools.AntiPatternScannerTool.AllRules)
             Assert.Contains(rule.Id, body, StringComparison.Ordinal);
     }
 

--- a/src/maf-autopilot.Tests/McpToolAnnotationTests.cs
+++ b/src/maf-autopilot.Tests/McpToolAnnotationTests.cs
@@ -1,9 +1,9 @@
 using System.Reflection;
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using ModelContextProtocol.Server;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Locks the <c>[McpServerTool]</c> annotation contract for tools whose hints

--- a/src/maf-autopilot.Tests/MigrationPathToolTests.cs
+++ b/src/maf-autopilot.Tests/MigrationPathToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class MigrationPathToolTests
 {

--- a/src/maf-autopilot.Tests/MigrationRiskScoreToolTests.cs
+++ b/src/maf-autopilot.Tests/MigrationRiskScoreToolTests.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Phase W.11 — tests for <see cref="MigrationRiskScoreTool"/>.

--- a/src/maf-autopilot.Tests/NewAgentToolMcpTests.cs
+++ b/src/maf-autopilot.Tests/NewAgentToolMcpTests.cs
@@ -1,12 +1,12 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Direct tests of the `[McpServerTool]`-decorated entry points on
 /// <see cref="NewAgentTool"/>. The pure-function core
-/// (<see cref="MafAutopilot.Scaffolding.AgentScaffolder"/>) has its own
+/// (<see cref="MafDoctor.Scaffolding.AgentScaffolder"/>) has its own
 /// dedicated test class; this file exercises the file-writing + namespace-detection
 /// + path-validation glue that's only reached through the MCP method.
 ///

--- a/src/maf-autopilot.Tests/PathGuardTests.cs
+++ b/src/maf-autopilot.Tests/PathGuardTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class PathGuardTests
 {

--- a/src/maf-autopilot.Tests/PreUpgradeDryRunToolTests.cs
+++ b/src/maf-autopilot.Tests/PreUpgradeDryRunToolTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Data;
-using MafAutopilot.Tools;
+using MafDoctor.Data;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class PreUpgradeDryRunToolTests
 {

--- a/src/maf-autopilot.Tests/PromptLintToolTests.cs
+++ b/src/maf-autopilot.Tests/PromptLintToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class PromptLintToolTests
 {

--- a/src/maf-autopilot.Tests/PullRequestAuditToolTests.cs
+++ b/src/maf-autopilot.Tests/PullRequestAuditToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class PullRequestAuditToolTests
 {

--- a/src/maf-autopilot.Tests/RegistryExtractCommandTests.cs
+++ b/src/maf-autopilot.Tests/RegistryExtractCommandTests.cs
@@ -1,11 +1,11 @@
-using MafAutopilot;
-using MafAutopilot.Data;
-using MafAutopilot.Tools;
+using MafDoctor;
+using MafDoctor.Data;
+using MafDoctor.Tools;
 using Xunit;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class RegistryExtractCommandTests
 {

--- a/src/maf-autopilot.Tests/RegistryLookupToolTests.cs
+++ b/src/maf-autopilot.Tests/RegistryLookupToolTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Data;
-using MafAutopilot.Tools;
+using MafDoctor.Data;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 public class RegistryLookupToolTests
 {

--- a/src/maf-autopilot.Tests/RegistryServiceTests.cs
+++ b/src/maf-autopilot.Tests/RegistryServiceTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for RegistryService — the single most regression-prone surface in the server.

--- a/src/maf-autopilot.Tests/RegressionPlanToolTests.cs
+++ b/src/maf-autopilot.Tests/RegressionPlanToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Phase W.12 — tests for <see cref="RegressionPlanTool"/>.

--- a/src/maf-autopilot.Tests/RewriterIdempotenceTests.cs
+++ b/src/maf-autopilot.Tests/RewriterIdempotenceTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Tools.Rewriters;
+using MafDoctor.Tools.Rewriters;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Idempotence property tests for every <c>IRuleRewriter</c>: applying a

--- a/src/maf-autopilot.Tests/SampleRegressionTests.cs
+++ b/src/maf-autopilot.Tests/SampleRegressionTests.cs
@@ -1,8 +1,8 @@
 using System.Text.RegularExpressions;
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Phase W.9 — sample-level regression test. Iterates every <c>samples/*-sample/</c>

--- a/src/maf-autopilot.Tests/SarifEmitterTests.cs
+++ b/src/maf-autopilot.Tests/SarifEmitterTests.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// SarifEmitter and SarifExportTool are internal — exercised via InternalsVisibleTo.

--- a/src/maf-autopilot.Tests/ScaffolderCompileValidationTests.cs
+++ b/src/maf-autopilot.Tests/ScaffolderCompileValidationTests.cs
@@ -1,10 +1,10 @@
-using MafAutopilot.Scaffolding;
-using MafAutopilot.Tools;
+using MafDoctor.Scaffolding;
+using MafDoctor.Tools;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Compile-validation tests for the scaffolder (Phase F.4 — Tests reviewer's

--- a/src/maf-autopilot.Tests/ScaffolderSecurityTests.cs
+++ b/src/maf-autopilot.Tests/ScaffolderSecurityTests.cs
@@ -1,12 +1,12 @@
 using System.Diagnostics;
-using MafAutopilot.Data;
-using MafAutopilot.Scaffolding;
-using MafAutopilot.Tools;
+using MafDoctor.Data;
+using MafDoctor.Scaffolding;
+using MafDoctor.Tools;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Security regression tests for Phase N — one test (group) per finding from the

--- a/src/maf-autopilot.Tests/SimulateWorkflowToolTests.cs
+++ b/src/maf-autopilot.Tests/SimulateWorkflowToolTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for the workflow topology analyzer. All tests use literal source strings —

--- a/src/maf-autopilot.Tests/TourToolTests.cs
+++ b/src/maf-autopilot.Tests/TourToolTests.cs
@@ -1,9 +1,9 @@
 using System.Reflection;
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using ModelContextProtocol.Server;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for the `MafTour` discovery tool. The catalogue is hand-curated;

--- a/src/maf-autopilot.Tests/ValidateOverridePathTests.cs
+++ b/src/maf-autopilot.Tests/ValidateOverridePathTests.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// Tests for <see cref="RegistryService.ValidateOverridePath"/> — the

--- a/src/maf-autopilot.Tests/VerifyRegistryCommandTests.cs
+++ b/src/maf-autopilot.Tests/VerifyRegistryCommandTests.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Commands;
-using MafAutopilot.Data;
+using MafDoctor.Commands;
+using MafDoctor.Data;
 using Xunit;
 
-namespace MafAutopilot.Tests;
+namespace MafDoctor.Tests;
 
 /// <summary>
 /// #5 polish — tests for <see cref="VerifyRegistryCommand"/>.

--- a/src/maf-autopilot.Tests/maf-autopilot.Tests.csproj
+++ b/src/maf-autopilot.Tests/maf-autopilot.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <RootNamespace>MafAutopilot.Tests</RootNamespace>
+    <RootNamespace>MafDoctor.Tests</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/maf-autopilot/Commands/BadgeCommand.cs
+++ b/src/maf-autopilot/Commands/BadgeCommand.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 
-namespace MafAutopilot.Commands;
+namespace MafDoctor.Commands;
 
 /// <summary>
 /// Phase W.13 — `maf-autopilot badge &lt;repoPath&gt;` subcommand.

--- a/src/maf-autopilot/Commands/VerifyRegistryCommand.cs
+++ b/src/maf-autopilot/Commands/VerifyRegistryCommand.cs
@@ -1,7 +1,7 @@
 using System.Text.RegularExpressions;
-using MafAutopilot.Data;
+using MafDoctor.Data;
 
-namespace MafAutopilot.Commands;
+namespace MafDoctor.Commands;
 
 /// <summary>
 /// CLI: <c>maf-autopilot verify-registry</c>.

--- a/src/maf-autopilot/Data/RegistryModels.cs
+++ b/src/maf-autopilot/Data/RegistryModels.cs
@@ -1,7 +1,7 @@
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 
-namespace MafAutopilot.Data;
+namespace MafDoctor.Data;
 
 /// <summary>
 /// Root of the MAF obsolete-API registry YAML document.

--- a/src/maf-autopilot/Data/RegistryService.cs
+++ b/src/maf-autopilot/Data/RegistryService.cs
@@ -1,7 +1,7 @@
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace MafAutopilot.Data;
+namespace MafDoctor.Data;
 
 /// <summary>
 /// Loads and queries the MAF obsolete-API registry.

--- a/src/maf-autopilot/InitCommand.cs
+++ b/src/maf-autopilot/InitCommand.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
-namespace MafAutopilot;
+namespace MafDoctor;
 
 /// <summary>
 /// CLI init subcommand: `maf-autopilot init [--with-cursor]`

--- a/src/maf-autopilot/NewCommand.cs
+++ b/src/maf-autopilot/NewCommand.cs
@@ -1,7 +1,7 @@
-using MafAutopilot.Scaffolding;
-using MafAutopilot.Tools;
+using MafDoctor.Scaffolding;
+using MafDoctor.Tools;
 
-namespace MafAutopilot;
+namespace MafDoctor;
 
 /// <summary>
 /// CLI subcommand: <c>maf-autopilot new agent &lt;Name&gt;</c> or <c>new executor &lt;Name&gt;</c>.

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -1,6 +1,6 @@
-using MafAutopilot;
-using MafAutopilot.Data;
-using MafAutopilot.Tools;
+using MafDoctor;
+using MafDoctor.Data;
+using MafDoctor.Tools;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -38,7 +38,7 @@ if (args.Length >= 1 && args[0] == "doctor")
         if (path is null && !args[i].StartsWith("--", StringComparison.Ordinal)) path = args[i];
     }
     path ??= Directory.GetCurrentDirectory();
-    var report = new MafAutopilot.Tools.DoctorTool().Run(path, "markdown", excludes);
+    var report = new MafDoctor.Tools.DoctorTool().Run(path, "markdown", excludes);
     Console.WriteLine(report);
     Environment.Exit(0);
     return;
@@ -49,7 +49,7 @@ if (args.Length >= 1 && args[0] == "badge")
     // host the JSON output (X.4) and reference it from shields.io URLs like
     // https://img.shields.io/endpoint?url=<your-hosted-json>.
     var path = args.Length >= 2 ? args[1] : Directory.GetCurrentDirectory();
-    var badge = MafAutopilot.Commands.BadgeCommand.Build(path);
+    var badge = MafDoctor.Commands.BadgeCommand.Build(path);
     Console.WriteLine(badge);
     Environment.Exit(0);
     return;
@@ -62,7 +62,7 @@ if (args.Length >= 1 && args[0] == "autofix-all")
     var positional = args.Skip(1).Where(a => !a.StartsWith("--")).ToList();
     var path = positional.Count > 0 ? positional[0] : Directory.GetCurrentDirectory();
     var dryRun = args.Contains("--dry-run");
-    var report = new MafAutopilot.Tools.AutoFixTool().MafAutoFixAll(path, dryRun: dryRun);
+    var report = new MafDoctor.Tools.AutoFixTool().MafAutoFixAll(path, dryRun: dryRun);
     Console.WriteLine(report);
     Environment.Exit(0);
     return;
@@ -72,7 +72,7 @@ if (args.Length >= 1 && args[0] == "verify-registry")
     // #5 polish (2026-05-13) — verification gate for the AI-fill flow. The
     // PR-triggered workflow maf-ai-fill-verify.yml runs this command against
     // the AI-filled registry.yaml. Exit code 1 blocks the PR's auto-merge.
-    var exitCode = MafAutopilot.Commands.VerifyRegistryCommand.Run();
+    var exitCode = MafDoctor.Commands.VerifyRegistryCommand.Run();
     Environment.Exit(exitCode);
     return;
 }

--- a/src/maf-autopilot/Prompts/MafPrompts.cs
+++ b/src/maf-autopilot/Prompts/MafPrompts.cs
@@ -5,9 +5,9 @@ using System.Text;
 // Cross-layer dep `Prompts → Tools` is intentional: LlmFencing and
 // BoundedInput are primitives (data-fencing + length-cap helpers), not
 // feature modules. See CONTRIBUTING.md "Helper composition — decision tree".
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 
-namespace MafAutopilot.Prompts;
+namespace MafDoctor.Prompts;
 
 /// <summary>
 /// MCP Prompts — pre-built starting prompts for common MAF migration workflows.

--- a/src/maf-autopilot/RegistryExtractCommand.cs
+++ b/src/maf-autopilot/RegistryExtractCommand.cs
@@ -1,11 +1,11 @@
 using System.Text;
 using System.Text.RegularExpressions;
-using MafAutopilot.Data;
-using MafAutopilot.Tools;
+using MafDoctor.Data;
+using MafDoctor.Tools;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 
-namespace MafAutopilot;
+namespace MafDoctor;
 
 /// <summary>
 /// CLI subcommand: <c>maf-autopilot registry-extract &lt;packageId&gt; &lt;oldVer&gt; &lt;newVer&gt;</c>.

--- a/src/maf-autopilot/Resources/MafResources.cs
+++ b/src/maf-autopilot/Resources/MafResources.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel;
 using System.Reflection;
 using System.Text;
-using MafAutopilot.Tools;
+using MafDoctor.Tools;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Resources;
+namespace MafDoctor.Resources;
 
 /// <summary>
 /// MCP Resources — expose all MAF knowledge files at stable maf:// URIs.

--- a/src/maf-autopilot/Scaffolding/AgentScaffolder.cs
+++ b/src/maf-autopilot/Scaffolding/AgentScaffolder.cs
@@ -2,7 +2,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis.CSharp;
 
-namespace MafAutopilot.Scaffolding;
+namespace MafDoctor.Scaffolding;
 
 /// <summary>
 /// Generates clean MAF 1.3.0 agent code that passes the anti-pattern scanner

--- a/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
+++ b/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafScanAntiPatterns

--- a/src/maf-autopilot/Tools/ApiSafetyTool.cs
+++ b/src/maf-autopilot/Tools/ApiSafetyTool.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafApiSafety

--- a/src/maf-autopilot/Tools/AutoFixTool.cs
+++ b/src/maf-autopilot/Tools/AutoFixTool.cs
@@ -1,11 +1,11 @@
 using System.ComponentModel;
 using System.Text.Json;
-using MafAutopilot.Tools.Rewriters;
+using MafDoctor.Tools.Rewriters;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: <c>MafAutoFix</c>.

--- a/src/maf-autopilot/Tools/BeforeAfterTool.cs
+++ b/src/maf-autopilot/Tools/BeforeAfterTool.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel;
 using System.Text;
-using MafAutopilot.Tools.Rewriters;
+using MafDoctor.Tools.Rewriters;
 using Microsoft.CodeAnalysis.CSharp;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: <c>MafBeforeAfter</c>.

--- a/src/maf-autopilot/Tools/BoundedInput.cs
+++ b/src/maf-autopilot/Tools/BoundedInput.cs
@@ -1,6 +1,6 @@
 using System.Text;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// Length-cap guard for user-controlled string inputs entering an MCP tool.

--- a/src/maf-autopilot/Tools/CompatibilityTool.cs
+++ b/src/maf-autopilot/Tools/CompatibilityTool.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafCompatibility

--- a/src/maf-autopilot/Tools/Cs0618HuntTool.cs
+++ b/src/maf-autopilot/Tools/Cs0618HuntTool.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafRunCs0618Hunt

--- a/src/maf-autopilot/Tools/DiffPackageTool.cs
+++ b/src/maf-autopilot/Tools/DiffPackageTool.cs
@@ -2,10 +2,10 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Text;
 using System.Text.RegularExpressions;
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafDiffPackage

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafDoctor

--- a/src/maf-autopilot/Tools/DraftIssueTool.cs
+++ b/src/maf-autopilot/Tools/DraftIssueTool.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafDraftIssue

--- a/src/maf-autopilot/Tools/EstimateCostTool.cs
+++ b/src/maf-autopilot/Tools/EstimateCostTool.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafEstimateCost

--- a/src/maf-autopilot/Tools/ExplainTool.cs
+++ b/src/maf-autopilot/Tools/ExplainTool.cs
@@ -2,10 +2,10 @@ using System.ComponentModel;
 using System.Text;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafExplain

--- a/src/maf-autopilot/Tools/FanOutValidatorTool.cs
+++ b/src/maf-autopilot/Tools/FanOutValidatorTool.cs
@@ -5,7 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafValidateFanOut

--- a/src/maf-autopilot/Tools/LlmFencing.cs
+++ b/src/maf-autopilot/Tools/LlmFencing.cs
@@ -1,7 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// Wraps user-controlled content destined for an LLM (a calling agent's context,

--- a/src/maf-autopilot/Tools/MigrationPathTool.cs
+++ b/src/maf-autopilot/Tools/MigrationPathTool.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
-using MafAutopilot.Resources;
+using MafDoctor.Resources;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafMigrationPath

--- a/src/maf-autopilot/Tools/MigrationRiskScoreTool.cs
+++ b/src/maf-autopilot/Tools/MigrationRiskScoreTool.cs
@@ -2,7 +2,7 @@ using System.ComponentModel;
 using System.Text.Json;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: <c>MafScoreMigrationRisk</c>.

--- a/src/maf-autopilot/Tools/NewAgentTool.cs
+++ b/src/maf-autopilot/Tools/NewAgentTool.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
-using MafAutopilot.Scaffolding;
+using MafDoctor.Scaffolding;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tools: MafNewAgent and MafNewExecutor

--- a/src/maf-autopilot/Tools/PathGuard.cs
+++ b/src/maf-autopilot/Tools/PathGuard.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// Shared input-validation for path parameters that come from the LLM.

--- a/src/maf-autopilot/Tools/PreUpgradeDryRunTool.cs
+++ b/src/maf-autopilot/Tools/PreUpgradeDryRunTool.cs
@@ -1,10 +1,10 @@
 using System.ComponentModel;
 using System.Text;
 using System.Text.RegularExpressions;
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafPreUpgradeDryRun

--- a/src/maf-autopilot/Tools/ProcessRunner.cs
+++ b/src/maf-autopilot/Tools/ProcessRunner.cs
@@ -1,6 +1,6 @@
 using System.Diagnostics;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// Shared, hardened external-process invocation for tools that shell out to

--- a/src/maf-autopilot/Tools/PromptLintTool.cs
+++ b/src/maf-autopilot/Tools/PromptLintTool.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafLintAgentPrompt

--- a/src/maf-autopilot/Tools/PullRequestAuditTool.cs
+++ b/src/maf-autopilot/Tools/PullRequestAuditTool.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.Text;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafAuditPullRequest

--- a/src/maf-autopilot/Tools/RegistryLookupTool.cs
+++ b/src/maf-autopilot/Tools/RegistryLookupTool.cs
@@ -1,8 +1,8 @@
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using ModelContextProtocol.Server;
 using System.ComponentModel;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafRegistryLookup

--- a/src/maf-autopilot/Tools/RegressionPlanTool.cs
+++ b/src/maf-autopilot/Tools/RegressionPlanTool.cs
@@ -1,9 +1,9 @@
 using System.ComponentModel;
 using System.Text;
-using MafAutopilot.Data;
+using MafDoctor.Data;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: <c>MafGenerateRegressionPlan</c>.

--- a/src/maf-autopilot/Tools/Rewriters/DefaultAzureCredentialRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/DefaultAzureCredentialRewriter.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace MafAutopilot.Tools.Rewriters;
+namespace MafDoctor.Tools.Rewriters;
 
 /// <summary>
 /// Rule: <c>MAF-AP-SEC-001</c> / <c>MAF002</c>.

--- a/src/maf-autopilot/Tools/Rewriters/EnableSensitiveDataRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/EnableSensitiveDataRewriter.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace MafAutopilot.Tools.Rewriters;
+namespace MafDoctor.Tools.Rewriters;
 
 /// <summary>
 /// Rule: <c>MAF-AP-SEC-003</c> / <c>MAF003</c>.

--- a/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace MafAutopilot.Tools.Rewriters;
+namespace MafDoctor.Tools.Rewriters;
 
 /// <summary>
 /// Rule: <c>MAF-AP-WF-001</c>.

--- a/src/maf-autopilot/Tools/Rewriters/FanInArgOrderRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/FanInArgOrderRewriter.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace MafAutopilot.Tools.Rewriters;
+namespace MafDoctor.Tools.Rewriters;
 
 /// <summary>
 /// Rule: <c>MAF130-FAN-IN-001</c>.

--- a/src/maf-autopilot/Tools/Rewriters/IRuleRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/IRuleRewriter.cs
@@ -1,6 +1,6 @@
 using Microsoft.CodeAnalysis;
 
-namespace MafAutopilot.Tools.Rewriters;
+namespace MafDoctor.Tools.Rewriters;
 
 /// <summary>
 /// Contract for a deterministic per-rule auto-fixer. Implementations are

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -2,7 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace MafAutopilot.Tools.Rewriters;
+namespace MafDoctor.Tools.Rewriters;
 
 /// <summary>
 /// Rule: <c>MAF-AP-CONC-002</c>.

--- a/src/maf-autopilot/Tools/SarifEmitter.cs
+++ b/src/maf-autopilot/Tools/SarifEmitter.cs
@@ -2,7 +2,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// Emits SARIF v2.1.0 documents for the maf-autopilot scanners. SARIF is the

--- a/src/maf-autopilot/Tools/SarifExportTool.cs
+++ b/src/maf-autopilot/Tools/SarifExportTool.cs
@@ -1,4 +1,4 @@
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// SARIF v2.1.0 emitter wrappers around the existing finding lists.

--- a/src/maf-autopilot/Tools/SimulateWorkflowTool.cs
+++ b/src/maf-autopilot/Tools/SimulateWorkflowTool.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafSimulateWorkflow

--- a/src/maf-autopilot/Tools/SourceFileWalker.cs
+++ b/src/maf-autopilot/Tools/SourceFileWalker.cs
@@ -1,6 +1,6 @@
 using System.Runtime.InteropServices;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// Shared file-enumeration + relative-path helpers used by every scanner that

--- a/src/maf-autopilot/Tools/TourTool.cs
+++ b/src/maf-autopilot/Tools/TourTool.cs
@@ -2,7 +2,7 @@ using System.ComponentModel;
 using System.Text;
 using ModelContextProtocol.Server;
 
-namespace MafAutopilot.Tools;
+namespace MafDoctor.Tools;
 
 /// <summary>
 /// MCP tool: MafTour

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -5,7 +5,7 @@
     <!-- Multi-target: NuGet picks the best TFM at install time. Matches the
          AgentEval house style (see docs/architecture.md → "Multi-targeting"). -->
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <RootNamespace>MafAutopilot</RootNamespace>
+    <RootNamespace>MafDoctor</RootNamespace>
     <AssemblyName>maf-autopilot</AssemblyName>
 
     <!-- .NET Global Tool packaging -->


### PR DESCRIPTION
Optional task 6.5 — mechanical rename of the C# root namespace `MafAutopilot` -> `MafDoctor` across 97 .cs/.csproj files. **Identity frozen:** AssemblyName/PackageId/ToolCommandName/dll/dirs/InternalsVisibleTo stay `maf-autopilot`, so installs + Docker ENTRYPOINT are unchanged. Build clean; 737 main + 15 analyzer tests pass under the new namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)