### PR TITLE
release: v1.2.0 (CHANGELOG + version bump)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed (self-update reliability — branch `fix/self-update`)
+## [1.2.0] - 2026-06-14
+
+### Added
+
+- **MAF 1.10.0 support** — 22 registry entries (obsolete/changed APIs), the compatibility-matrix row (`Microsoft.Extensions.AI >= 10.6.0`), and the `1.6.1 → 1.10.0` migration guide. Auto-detected by the now-fixed release watcher; migration content authored by the Copilot coding agent and verified by the registry gates. _(AI-authored migration guidance — review against the upstream `microsoft/agent-framework` changelog when convenient.)_
+
+### Fixed (self-update reliability)
 
 The scheduled **MAF Release Watcher** and **MAF Drift Detector** had failed on
 **every** scheduled run since creation, for two unrelated reasons (full report +

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -18,7 +18,7 @@
          on `release.yml`. Don't bump locally without pushing — the README
          documents the NuGet version, so any drift confuses users.
          (See CHANGELOG.md — "Versioning note for alpha users".) -->
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>joslat</Authors>
     <Description>MAF autopilot MCP server — Tools + Resources + Prompts + Sampling for MAF 1.3.0 migrations. Answers "is this API safe?", exposes migration guide as resources, and uses sampling for multi-step agentic analysis.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>


### PR DESCRIPTION
Finalizes the CHANGELOG to **[1.2.0]** and bumps csproj 1.1.0 → 1.2.0. Merge **after #77** (the 1.10.0 fill), then tag `v1.2.0` to trigger the NuGet + GitHub release. Pairs with #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)