### PR TITLE
chore(watcher): run Thursday 06:00 UTC (MAF .NET ship day)

### DIFF
--- a/.github/workflows/maf-release-watcher.yml
+++ b/.github/workflows/maf-release-watcher.yml
@@ -2,7 +2,7 @@ name: MAF Release Watcher
 
 on:
   schedule:
-    - cron: '0 9 * * *'   # Daily 09:00 UTC (task 3.6 — cuts detection latency 7d→1d; no-op path is cheap)
+    - cron: '0 6 * * 4'   # Thursday 06:00 UTC (~08:00 Europe/Zurich) — aligned with MAF's .NET Thursday-morning ship cadence. Manual workflow_dispatch covers off-cadence releases.
   workflow_dispatch:        # Manual trigger anytime
     inputs:
       maf_version:

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ maf-autopilot/
 │   └── workflows/                         # 7 GitHub Actions
 │       ├── release.yml                    # NuGet publish (test → pack → push) on v* tag
 │       ├── docker-publish.yml             # multi-arch GHCR image on tag push
-│       ├── maf-release-watcher.yml        # daily (09:00 UTC) MAF version check; minors auto-commit, majors escalate
+│       ├── maf-release-watcher.yml        # Thu 06:00 UTC MAF version check (MAF .NET ship day); minors auto-commit, majors escalate
 │       ├── maf-ai-fill-todos.yml          # dispatches GitHub issue for Copilot Coding Agent to fill registry TODOs
 │       ├── maf-ai-fill-verify.yml         # PR-gate: runs verify-registry on AI-filled output before merge
 │       ├── maf-pr-audit.yml               # PR-scoped scan, posts a sticky comment


### PR DESCRIPTION
Per maintainer — MAF for .NET typically ships Thursday early morning, so align the watcher poll to it. Was daily `0 9 * * *`; now `0 6 * * 4` (Thu 06:00 UTC ≈ 08:00 Europe/Zurich). Manual dispatch still covers off-cadence releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)