### PR TITLE
fix(release): analyzer version lockstep with server tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,13 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
+          # Keep BOTH packages in version lockstep (the server tool + the analyzer).
+          # Previously only the server csproj was overridden, so the analyzer
+          # shipped at its stale csproj <Version> and `--skip-duplicate` silently
+          # skipped re-publishing it. Override both from the tag/input.
           sed -i "s|<Version>.*</Version>|<Version>${VERSION}</Version>|" src/maf-autopilot/maf-autopilot.csproj
-          echo "Set csproj <Version> to $VERSION"
+          sed -i "s|<Version>.*</Version>|<Version>${VERSION}</Version>|" src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+          echo "Set <Version> to $VERSION on both the server tool and the analyzer."
 
       - name: Restore
         run: dotnet restore maf-autopilot.sln

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -14,7 +14,7 @@
 
     <!-- NuGet packaging -->
     <PackageId>maf-autopilot.Analyzers</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>joslat</Authors>
     <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) 1.3.0 — write-time enforcement of fan-out safety, secure credentials, and observability defaults. Pairs with the maf-autopilot MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>


### PR DESCRIPTION
v1.2.0 shipped the analyzer as 1.1.0 (release.yml only overrode the server csproj; `--skip-duplicate` skipped re-publish). Bumps the analyzer csproj to 1.2.0 and makes release.yml override **both** csproj versions from the tag, so future releases publish them matched. Cosmetic for v1.2.0 (analyzer rules unchanged); prevents the drift next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)