### PR TITLE
release: v1.2.1 — first maf-doctor publish + README lean-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-06-14
+
+**First release published under the `maf-doctor` package id** (and `maf-doctor.Analyzers`) — this is the version where the rename below actually reaches NuGet.
+
 ### Changed (BREAKING — full rename to `maf-doctor`)
 
 - **The NuGet package + CLI are renamed `maf-autopilot` → `maf-doctor`** (and `maf-autopilot.Analyzers` → `maf-doctor.Analyzers`). The brand, repo, MCP server id, and C# namespace were already MAF Doctor; this completes the rename so the package/command match. Done pre-public-announcement, so the break is acceptable.
   - **For users:** `dotnet tool uninstall -g maf-autopilot && dotnet tool install -g maf-doctor`; the command is now `maf-doctor …`. Re-run `maf-doctor init` (it recognizes a legacy `maf-autopilot` mcp.json server entry and won't duplicate). The Docker image runs `maf-doctor.dll`.
   - The old `maf-autopilot` package (≤ 1.2.0) will be **deprecated on nuget.org** with a pointer to `maf-doctor`.
   - The internal `src/maf-autopilot/` project folder + `.csproj`/`.sln` filenames are unchanged (invisible to users; avoids high-churn path rewrites).
-  - _Note: publishing `maf-doctor` to NuGet requires the maintainer's NuGet API key on the new package id; until then, the install-based scheduled workflows (drift / pr-audit / verify) will fail at the install step — by design._
+
+### Docs
+
+- **README leaned to the essentials** — removed the Project Structure tree, the Skill Orchestration catalog, and the dated distribution block; deduplicated the `dotnet-inspect` notes; trimmed the companion-MCP recommendation to **Microsoft Learn MCP** (we don't wire Context7/DeepWiki/Serena); added an **"It updates itself"** section explaining how and when the self-update watcher runs (Thursday 06:00 UTC; minors auto-commit, majors escalate); and dropped hardcoded version pins so the docs stop going stale as MAF ships.
+- Fixed stale tool/resource/prompt counts and the `maf-autopilot.Analyzers` id in `docs/architecture.md`, and a stale "current release `1.3.0-alpha-5`" claim in `docs/setup.md`. The unrendered demo-cast `<img>` tags were removed (the `.tape` sources + `scripts/make-cast` remain — re-add once rendered).
 
 ## [1.2.0] - 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -2,70 +2,58 @@
 
 > Diagnose, explain, prescribe, verify — for MAF agents and workflows.
 
-> **Naming:** the brand is **MAF Doctor**; the NuGet package + CLI are **`maf-doctor`**. (Pre-1.3 this shipped as `maf-autopilot` ≤ 1.2.0 — that package is deprecated in favor of `maf-doctor`. The internal `src/maf-autopilot/` project folder keeps its name; it's invisible to users.)
-
-<!--
-  Two animated casts (each ~30 s). Rendered from docs/assets/*.tape via vhs.
-  Re-render after editing the .tape files: bash scripts/make-cast.sh (or .ps1).
-
-  If a GIF appears broken/missing, the renderer hasn't run yet —
-  see scripts/make-cast.sh for the install + render instructions.
--->
-<p align="center">
-  <img src="docs/assets/install-cast.gif"
-       alt="MAF Doctor — install + audit any MAF codebase in 30 seconds"
-       width="900" />
-  <br/>
-  <em>Install + audit a real MAF codebase. Doctor returns grade F + the top fixes.</em>
-</p>
-
-<p align="center">
-  <img src="docs/assets/migration-cast.gif"
-       alt="MAF Doctor — auto-fix the broken codebase to grade A in ~30 seconds"
-       width="900" />
-  <br/>
-  <em>One <code>autofix-all</code> command. Every mechanical rule. Grade F → A, deterministic.</em>
-</p>
+> **Naming:** the brand is **MAF Doctor**; the NuGet package + CLI are **`maf-doctor`**. (Pre-rename this shipped as `maf-autopilot` ≤ 1.2.0 — that package is deprecated in favor of `maf-doctor`. The internal `src/maf-autopilot/` project folder keeps its name; it's invisible to users.)
 
 **MAF Doctor** is a .NET global tool that does three things in one install:
 
-1. **An MCP server** — exposes **25 executable tools**, 6 resources, and 7 prompts to GitHub Copilot / Claude Code / Cursor via `.vscode/mcp.json`.
-2. **A CLI** — `maf-doctor doctor` (A-F health letter), `maf-doctor autofix-all` (deterministic rewriters), `maf-doctor new agent <Name>`, `maf-doctor new executor <Name>`, `maf-doctor init` (drops MCP config + steering snippets into your repo), `maf-doctor verify-registry`, `maf-doctor badge`, `maf-doctor registry-extract`.
-3. **A plugin** — `init` also drops 12 specialised skills, 7 specialist agents, and steering snippets for GitHub Copilot Coding Agent so Copilot's agentic loops gain MAF-specific knowledge.
+1. **An MCP server** — exposes 25 executable tools, 6 resources, and 7 prompts to GitHub Copilot / Claude Code / Cursor via `.vscode/mcp.json`.
+2. **A CLI** — `maf-doctor doctor` (A–F health letter), `maf-doctor autofix-all` (deterministic rewriters), `maf-doctor new agent <Name>`, `maf-doctor init` (drops MCP config + steering snippets into your repo), and more.
+3. **A plugin** — `init` also drops 12 specialised skills, 7 specialist agents, and steering snippets so GitHub Copilot's agentic loops gain MAF-specific knowledge.
 
-Plus a **separate `maf-doctor.Analyzers` NuGet** with 3 Roslyn analyzers (`MAF001`/`MAF002`/`MAF003`) for IDE write-time enforcement, and a curated **19-entry obsolete-API registry** keyed by MAF version (`applies_to_codebases` markers). Copilot invokes the tools automatically while auditing, migrating, reviewing, and maintaining your agents and workflows.
+Plus a separate **`maf-doctor.Analyzers`** NuGet with 3 Roslyn analyzers (`MAF001`/`MAF002`/`MAF003`) for IDE write-time enforcement, and a curated, version-keyed **obsolete-API registry** that maps every known `CS0618` to its exact replacement.
+
+> 📦 **[Latest release on NuGet →](https://www.nuget.org/packages/maf-doctor)** — and the toolkit keeps its own MAF knowledge current automatically. See [**It updates itself**](#it-updates-itself).
 
 ### What makes it worth trying
 
 - 🔍 **Catches the bugs that compile clean** — detects fan-out/fan-in silent failures where a workflow exits successfully but produces no output. Runtime-only, zero build signal, invisible without this tool.
-- 🩺 **Compiler ground-truth for CS0618** — `dotnet-inspect` v0.7.8 surfaces `[Obsolete]` statically (pre-build), but only the compiler catches transitive obsoletions, overload-resolution surprises, and project-local `[Obsolete]` attributes. `maf-doctor` pairs both.
-- ✅ **Best-practice auditing, not just migration** — reviews your MAF agents and workflows against current patterns after migration too. Catches drift, anti-patterns, and deprecated usage before they become production bugs.
+- 🩺 **Compiler ground-truth for CS0618** — surfaces obsolete-API usage the build would hit, including transitive obsoletions and overload-resolution surprises, and maps each to its canonical fix.
+- ✅ **Best-practice auditing, not just migration** — reviews your agents and workflows against current MAF patterns, catching drift and anti-patterns before they become production bugs.
 - 🤖 **Fully agentic loop** — Copilot audits your codebase, generates a tracked migration plan, executes it task-by-task with `dotnet build` verification after every step, and updates the plan as it goes.
-- 📖 **Self-updating knowledge** — a GitHub Actions workflow watches NuGet weekly, diffs the MAF API surface, and opens a PR updating the migration guide and compatibility matrix automatically when a new version ships.
-- 🧰 **Deterministic fixes, not guesses** — a machine-readable Obsolete API Registry maps every known CS0618 warning to its exact replacement pattern. No hallucinated fix patterns.
-- 🔄 **Keeps your code current** — as MAF evolves, re-run the auditor on your codebase. It cross-references the latest guide, flags anything that's now obsolete or has a better pattern, and tells you exactly what to change.
-- 🔐 **Hardened against the named MCP attack lattice** — v1.1 ships a comprehensive security pass: 5 critical-tier closures (path-escape, MCP annotation drift, scaffold-namespace code injection, supply-chain prompt injection via release notes, `workflow_dispatch` input injection), 11+ high-tier closures, defense-in-depth helpers (`LlmFencing`, `BoundedInput`, `PathGuard.ValidateContainment`), and `.github/workflows/ci-invariants.yml` enforcing 5 invariants in CI. Cisco mcp-scanner v4.6.0: 25/25 SAFE, 0 findings. See [`SECURITY.md`](SECURITY.md) for the vulnerability-disclosure policy + [`docs/security.md`](docs/security.md) for user-facing attack-class coverage.
+- 🧰 **Deterministic fixes, not guesses** — the obsolete-API registry maps every known `CS0618` to its exact replacement pattern. No hallucinated fixes.
+- 📖 **It updates itself** — as new MAF versions ship, the toolkit refreshes its own migration knowledge automatically. [How →](#it-updates-itself)
+- 🔐 **Hardened against the named MCP attack lattice** — a comprehensive security pass closes the critical- and high-tier MCP attack classes (path-escape, annotation drift, scaffold code-injection, prompt-injection via release notes, `workflow_dispatch` input injection), with defense-in-depth helpers and CI-enforced invariants. Cisco mcp-scanner: 25/25 tools SAFE, 0 findings. See [`SECURITY.md`](SECURITY.md) + [`docs/security.md`](docs/security.md).
+
+## It updates itself
+
+Migration tooling is only useful if it knows about the MAF version you're on. MAF Doctor keeps its own knowledge base current instead of asking you to wait for a maintainer release:
+
+**How** — a GitHub Actions watcher checks NuGet for a new `Microsoft.Agents.AI` release, diffs the API surface against the last known version, and updates the per-version migration guide, the compatibility matrix, and the obsolete-API registry:
+
+- **Minor / patch bumps** are committed straight to `main` — the guide, matrix, and `.maf-version` move forward on their own.
+- **Major bumps** don't auto-merge; they open a human-gated issue so a breaking release gets eyes before anything lands.
+- New registry entries are drafted by an AI-fill loop and **PR-verified** — `verify-registry` runs on the fill PR (and can gate the merge when required-status-checks is enabled), so the deterministic fix data stays trustworthy.
+
+**When** — every **Thursday 06:00 UTC** (~08:00 Europe/Zurich), aligned with MAF's .NET Thursday-morning ship cadence. Off-cadence releases are covered by a manual `workflow_dispatch` trigger.
+
+The practical upshot: you don't pin to a MAF version in these docs, and you don't wait on us. Re-run `maf-doctor doctor` after any MAF bump and it cross-references the freshest guide automatically.
 
 ## How It Works
 
-`maf-doctor` is a **[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server** packaged as a .NET global tool. When running in MCP mode (default — no subcommand), it exposes:
+`maf-doctor` is a **[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server** packaged as a .NET global tool. With no subcommand it runs in MCP mode and exposes:
 
-- **25 executable tools**, each annotated with MCP behavior hints (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`) so well-behaved clients can auto-classify them. Tools include: registry lookup (`MafApiSafety`, `MafRegistryLookup`, `MafListRegistry`), code scanning (`MafScanAntiPatterns`, `MafValidateFanOut`, `MafLintAgentPrompt`, `MafEstimateCost`), build-verified hunts (`MafRunCs0618Hunt`), NuGet diffing (`MafDiffPackage`, `MafPreUpgradeDryRun`), workflow simulation (`MafSimulateWorkflow`), explanations (`MafExplain`), scaffolders (`MafNewAgent`, `MafNewExecutor`), PR-scoped audits (`MafAuditPullRequest`), version planning (`MafMigrationPath`, `MafGenerateRegressionPlan`, `MafScoreMigrationRisk`), upstream-issue drafter (`MafDraftIssue`), capability tour (`MafTour`), `MafBeforeAfter`, `MafCompatibility`, and the single-command health letter `MafDoctor` (markdown + JSON output for CI integration). Anti-pattern + fan-out scanners both support `format: "sarif"` for GitHub Advanced Security integration. The 2 destructive tools (`MafAutoFix`, `MafAutoFixAll`) support `dryRun`.
-- **6 resources** — `maf://guide`, `maf://constraints`, `maf://registry`, `maf://rules`, `maf://help`, `maf://skills?name=...` — the full migration knowledge base, readable on demand.
-- **7 prompts** — `maf-audit`, `maf-migrate`, `maf-cs0618-hunt`, `maf-review`, `maf-debug`, `maf-scaffold`, `maf-help` — structured conversation starters.
+- **25 executable tools**, each annotated with MCP behavior hints (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`) so clients can auto-classify them — registry lookup, code scanning, build-verified CS0618 hunts, NuGet diffing, workflow simulation, scaffolding, PR-scoped audits, version planning, and the single-command health letter `MafDoctor`. Anti-pattern + fan-out scanners support `format: "sarif"` for GitHub Advanced Security; the 2 destructive tools (`MafAutoFix`, `MafAutoFixAll`) support `dryRun`.
+- **6 resources** — `maf://guide`, `maf://constraints`, `maf://registry`, `maf://rules`, `maf://help`, `maf://skills?name=...` — the full knowledge base, readable on demand.
+- **7 prompts** — `maf-audit`, `maf-migrate`, `maf-cs0618-hunt`, `maf-review`, `maf-debug`, `maf-scaffold`, `maf-help`.
 - **3 Roslyn analyzers** (separate `maf-doctor.Analyzers` NuGet) — `MAF001` fan-out, `MAF002` `DefaultAzureCredential`, `MAF003` `EnableSensitiveData`. Write-time enforcement.
 
-When invoked with a subcommand instead, the same binary runs as a CLI tool. See "Quick Start" below for the most useful subcommands (`init`, `doctor`, `new agent`, `autofix-all`).
+With a subcommand, the same binary runs as a CLI tool — see Quick Start below.
 
-GitHub Copilot Chat connects to the MCP server and gains agentic access to all of this during migration work.
-
-## Quick Start — Two Integration Modes
+## Quick Start
 
 > 🎬 **New here?** The [**3-minute quickstart**](docs/quickstart.md) walks install → init → analyze → auto-fix → upgrade-to-latest-MAF end-to-end (the demo-video script).
 
 ### ⭐ Mode 1: MCP Server (recommended — full agentic power)
-
-Install the NuGet global tool, then run `init` in your target project:
 
 ```powershell
 # 1. Install the MCP server as a .NET global tool
@@ -76,41 +64,28 @@ cd your-maf-project
 maf-doctor init
 ```
 
-> 📦 Current release: [`1.0.0`](https://www.nuget.org/packages/maf-doctor). Supports MAF 1.0 / 1.2 / 1.3 simultaneously.
+VS Code picks up `.vscode/mcp.json` automatically and starts the MCP server; Copilot Chat gains live tool calls, resource reads, and structured prompts.
 
-### ⚡ First 5 minutes — try these three commands
+**First three commands to try:**
 
 ```powershell
-# 1. Instant health check on any MAF project (A/B/C/F grade + top 3 fixes)
-maf-doctor doctor .
-
-# 2. Scaffold a brand-new MAF 1.3.0 agent + smoke test (10 seconds, anti-pattern-clean)
-maf-doctor new agent ChatBot
-
-# 3. Open VS Code; in Copilot Chat:
-@maf-auditor                           # full pre-migration audit + plan
-@maf-best-practice-reviewer            # steady-state best-practice review
+maf-doctor doctor .            # instant A/B/C/F health grade + top fixes
+maf-doctor autofix-all .       # apply every deterministic Roslyn rewriter
+maf-doctor new agent ChatBot   # scaffold an anti-pattern-clean MAF agent + smoke test
 ```
 
-For deeper queries, ask Copilot:
+Then, in Copilot Chat:
 
-> "Use `MafPreUpgradeDryRun` to tell me which files would break if I upgraded `Microsoft.Agents.AI` from 1.2.0 to 1.3.0."
-
-> "Run `MafSimulateWorkflow` against this repo and embed the Mermaid topology in my PR description."
-
-> "Use `MafLintAgentPrompt` to audit every agent's `Instructions` string for prompt-injection risk."
-
-VS Code picks up `.vscode/mcp.json` automatically and starts the MCP server. Copilot Chat gains live tool calls, resource reads, and structured prompts.
+```
+@maf-auditor                   # full pre-migration audit + plan
+@maf-best-practice-reviewer    # steady-state best-practice review
+```
 
 ### ⭐ Mode 1b: Docker container (no .NET SDK on the host)
-
-If you'd rather not install the .NET SDK locally, pull the container instead:
 
 ```bash
 docker pull ghcr.io/joslat/maf-doctor:latest
 ```
-
-Wire it into your IDE's `mcp.json`:
 
 ```json
 {
@@ -124,33 +99,23 @@ Wire it into your IDE's `mcp.json`:
 }
 ```
 
-Same tools, same skills, same resources — just isolated inside a container. Multi-arch (`amd64` + `arm64`).
+Same tools, skills, and resources — isolated in a container. Multi-arch (`amd64` + `arm64`).
 
-### Mode 2: Skills + Agents only (no MCP server required)
+### Mode 2: Skills + Agents only (no MCP server)
 
-Copy `.github/` from this repo into your .NET repository root. You get the agents and skills via VS Code's instruction/agent system — no MCP server needed, but no live tool calls either.
+Copy `.github/` from this repo into your .NET repository root for the agents and skills via VS Code's instruction/agent system — no live tool calls, but no install either.
 
 ```powershell
-# In your MAF project root
 git clone https://github.com/joslat/maf-doctor tmp-maf
 Copy-Item tmp-maf/.github -Destination .github -Recurse
 Remove-Item tmp-maf -Recurse
 ```
 
-Then open Copilot Chat and use `@maf-migration` or `@maf-auditor`.
+Then use `@maf-migration` or `@maf-auditor` in Copilot Chat.
 
-## Recommended companion MCPs
+## Recommended companion MCP
 
-MAF Doctor is laser-focused on **diagnose + fix** for Microsoft Agent Framework. For best results, pair us with these companion MCPs in your `.vscode/mcp.json` or Claude Code config:
-
-| MCP | What it gives you | Endpoint | Auth |
-|---|---|---|---|
-| **[Microsoft Learn MCP](https://learn.microsoft.com/api/mcp)** | Live MAF documentation, code samples, version-aware. 3 tools. | `https://learn.microsoft.com/api/mcp` | None |
-| **[Context7](https://github.com/upstash/context7)** | 9000+ library docs, version-specific NuGet docs | `https://mcp.context7.com/mcp` | API key |
-| **[DeepWiki](https://mcp.deepwiki.com/mcp)** | Query `microsoft/agent-framework` source repo wiki directly | `https://mcp.deepwiki.com/mcp` | None |
-| **[Serena](https://github.com/oraios/serena)** | Semantic IDE-shape navigation across 40+ languages | local install | None |
-
-This stack gives an AI client: docs lookup (Learn / Context7 / DeepWiki), codebase navigation (Serena), and MAF-specific audit + fix + migration (MAF Doctor). Each MCP stays in its lane.
+MAF Doctor is laser-focused on **diagnose + fix** for Microsoft Agent Framework. For documentation lookup, pair it with the **[Microsoft Learn MCP](https://learn.microsoft.com/api/mcp)** — live, version-aware MAF docs and code samples (`https://learn.microsoft.com/api/mcp`, no auth). Docs lookup stays in Learn's lane; audit + fix + migration stays in ours.
 
 ## Why This Exists
 
@@ -159,132 +124,37 @@ This stack gives an AI client: docs lookup (Learn / Context7 / DeepWiki), codeba
 - MAF-specific executor pattern migration (`ReflectingExecutor` → `partial class : Executor` + `[MessageHandler]`)
 - Session API changes (`AgentThread` → `AgentSession`)
 - Fan-out/fan-in silent failure detection — a class of bug that builds green but runs wrong
-- Compiler ground-truth CS0618 detection (transitive obsoletions, overload-resolution surprises, project-local `[Obsolete]`) that pairs with `dotnet-inspect@0.7.8`'s new static surfacing
+- Compiler ground-truth CS0618 detection (transitive obsoletions, overload-resolution surprises, project-local `[Obsolete]`)
 - Build-verified, task-by-task execution with a full tracking table
-- A machine-readable Obsolete API Registry so fixes are deterministic, not guessed
-
----
-
-## Project Structure
-
-```
-maf-autopilot/
-├── .github/
-│   ├── agents/                            # 7 GitHub Copilot Coding Agent specialists
-│   │   ├── maf.agent.md                          # Root triage agent — routes you to the right specialist
-│   │   ├── maf-auditor.agent.md                  # Pre-migration scan → generates migration-plan.md
-│   │   ├── maf-best-practice-reviewer.agent.md   # Steady-state audit (post-migration) → audit-report.md
-│   │   ├── maf-migration.agent.md                # Build-verified task-by-task migration orchestrator
-│   │   ├── maf-incident-responder.agent.md       # Production failure triage → root-cause + fix
-│   │   ├── maf-onboarding.agent.md               # "New to this MAF repo" guided tour
-│   │   └── maf-rollback.agent.md                 # 1.3 → 1.2 surgical rollback (build-verified per task)
-│   ├── instructions/
-│   │   └── maf-constraints.instructions.md       # Always-loaded: breaking changes, constraints
-│   ├── skills/                            # 12 specialised skills (loaded by agents on demand)
-│   │   ├── cs0618-hunter/                 # compiler-ground-truth path (paired with MafRunCs0618Hunt)
-│   │   ├── dotnet-inspect/                # pinned to v0.7.8 (surfaces [Obsolete])
-│   │   ├── maf-anti-pattern-scanner/      # canonical anti-pattern rule list (paired with MafScanAntiPatterns)
-│   │   ├── maf-fan-out-validator/         # silent fan-in starvation rules
-│   │   ├── maf-issue-reporter/            # upstream-issue filing procedure (paired with MafDraftIssue)
-│   │   ├── maf-migration-guide/           # multi-section guide navigator (version-keyed)
-│   │   ├── maf-migration-plan-creator/    # template + ID conventions for tracking tables
-│   │   ├── maf-migration-retrospective/   # post-migration learning loop
-│   │   ├── maf-obsolete-api-registry/     # 19-entry CS0618 fix registry (the YAML source)
-│   │   ├── maf-release-watcher/           # weekly NuGet check + AI-fill loop documentation
-│   │   ├── maf-workflow-smoke-tester/     # smoke test templates
-│   │   └── nuget-diff-analyzer/           # generic NuGet diff procedure (subsumed by MafDiffPackage tool)
-│   └── workflows/                         # 7 GitHub Actions
-│       ├── release.yml                    # NuGet publish (test → pack → push) on v* tag
-│       ├── docker-publish.yml             # multi-arch GHCR image on tag push
-│       ├── maf-release-watcher.yml        # Thu 06:00 UTC MAF version check (MAF .NET ship day); minors auto-commit, majors escalate
-│       ├── maf-ai-fill-todos.yml          # dispatches GitHub issue for Copilot Coding Agent to fill registry TODOs
-│       ├── maf-ai-fill-verify.yml         # PR-gate: runs verify-registry on AI-filled output before merge
-│       ├── maf-pr-audit.yml               # PR-scoped scan, posts a sticky comment
-│       └── maf-drift-detector.yml         # weekly (Mon 11:00 UTC) MafDoctor on product code; opens issue if grade < A
-├── src/
-│   ├── maf-autopilot/                     # MCP server — 25 tools, 6 resources, 7 prompts; CLI binary
-│   ├── maf-autopilot.Analyzers/           # Roslyn analyzer package (MAF001/002/003 — separate NuGet)
-│   ├── maf-autopilot.Tests/               # 580 xUnit tests (× 3 TFMs = 1740 executions per run)
-│   └── maf-autopilot.Analyzers.Tests/     # 11 analyzer tests (× 3 TFMs = 33 executions)
-├── Dockerfile                             # multi-stage build → ghcr.io/joslat/maf-doctor:latest
-├── guides/
-│   ├── maf-current-migration-guide.md     # Cumulative — auto-generated, all versions concatenated (start here)
-│   ├── maf-1.3.0-migration-guide.md       # 21-section migration guide (hand-authored bootstrap)
-│   ├── maf-1.4.0-migration-guide.md       # 1.3 → 1.4 delta (auto-generated by release-watcher)
-│   └── maf-1.5.0-migration-guide.md       # 1.4 → 1.5 delta (auto-generated by release-watcher)
-├── docs/
-│   ├── maf-migration-toolkit-plan.md      # 🗺️ phased roadmap + full 68-row tracking table
-│   ├── project-status-and-vision.md       # stage assessment + completeness audit
-│   ├── compatibility-matrix.md            # MAF version ↔ dependency versions
-│   └── setup.md                           # detailed install + configure
-├── CONTRIBUTING.md                        # 4 contribution shapes + PR conventions
-├── TROUBLESHOOTING.md                     # install / init / MCP / dotnet-inspect / CI failure modes
-└── .maf-version                           # tracked version (for release watcher)
-```
-
----
-
-## Skill Orchestration — When to Call What
-
-| You need to…                                      | Use skill                      |
-|---------------------------------------------------|--------------------------------|
-| Look up MAF API signatures or patterns            | `maf-migration-guide`          |
-| Check if a NuGet type/member exists               | `dotnet-inspect`               |
-| Detect and fix CS0618 obsolete warnings           | `cs0618-hunter`                |
-| Look up the fix pattern for a specific CS0618     | `maf-obsolete-api-registry`    |
-| Review 1.3.0 code for known anti-patterns         | `maf-anti-pattern-scanner`     |
-| Generate a migration plan for a new codebase      | `maf-migration-plan-creator`   |
-| Validate fan-out/fan-in workflow structure        | `maf-fan-out-validator`        |
-| Post-process NuGet diff into actionable report    | `nuget-diff-analyzer`          |
-| File an upstream MAF bug                          | `maf-issue-reporter`           |
-| Check for / respond to new MAF versions           | `maf-release-watcher`          |
-| Generate smoke tests for migrated workflows       | `maf-workflow-smoke-tester`    |
-| Learn from migration surprises, improve toolkit   | `maf-migration-retrospective`  |
-
-> **Pin to `dotnet-inspect@0.7.8` or later.** v0.7.8 (2026-05-04) [closes the `[Obsolete]`-overload gap](https://github.com/richlander/dotnet-inspect/releases/tag/v0.7.8). For ground-truth on what your project actually triggers (transitive obsoletions, overload resolution, project-local `[Obsolete]`), `cs0618-hunter` (compiler-based) is still the canonical path.
-
----
+- A machine-readable obsolete-API registry so fixes are deterministic, not guessed
 
 ## Typical Migration Workflow
 
-1. **Audit** — open Copilot Chat → use the `maf-audit` prompt (or `@maf-auditor` agent) to scan your codebase and generate `src/docs/migration-plan.md`
-2. **Migrate** — use the `maf-migrate` prompt (or `@maf-migration` agent) to execute the plan task-by-task with `dotnet build` verification after each step
-3. **Hunt stragglers** — use the `maf-cs0618-hunt` prompt to catch any remaining CS0618 obsolete API warnings the build surfaces
+1. **Audit** — open Copilot Chat → use the `maf-audit` prompt (or `@maf-auditor` agent) to scan your codebase and generate a tracked `migration-plan.md`.
+2. **Migrate** — use the `maf-migrate` prompt (or `@maf-migration` agent) to execute the plan task-by-task with `dotnet build` verification after each step.
+3. **Hunt stragglers** — use the `maf-cs0618-hunt` prompt to catch any remaining CS0618 warnings the build surfaces.
 
-The MCP server tools are called automatically by Copilot during steps 1–3 — you don't invoke them directly.
-
----
+The MCP tools are called automatically by Copilot during these steps — you don't invoke them directly.
 
 ## Roadmap & Status
 
-For an up-to-date, evidence-anchored view of what is done, what is in progress, and what is pending, see:
+For an evidence-anchored view of what's done, in progress, and pending:
 
 - **[`docs/maf-migration-toolkit-plan.md`](docs/maf-migration-toolkit-plan.md)** — phased roadmap + the tracking table (single source of truth)
-- **[`docs/project-status-and-vision.md`](docs/project-status-and-vision.md)** — stage assessment, the broader vision beyond migration, completeness audit
+- **[`docs/project-status-and-vision.md`](docs/project-status-and-vision.md)** — stage assessment + the broader vision
 
-> The README used to carry its own tick-list of features. It drifted from the plan twice in two months. The plan tracking table is now authoritative; the README sticks to "what this is" and "how to use it."
-
-### Distribution status (2026-05-17)
-
-- ✅ **NuGet** — [`1.0.0`](https://www.nuget.org/packages/maf-doctor) on nuget.org. Supports MAF 1.0 / 1.2 / 1.3.
-- ✅ **Docker GHCR** — multi-arch (amd64+arm64) container, semver tags (built by `docker-publish.yml` on tag push)
-- ✅ **Roslyn analyzers** — `maf-doctor.Analyzers` package ships 3 write-time rules
-- ✅ **Multi-version migration paths** — `MafMigrationPath(currentVer, targetVer)` walks version-keyed guide metadata
-- ✅ **Security model documented** — see [`docs/security.md`](docs/security.md). Cisco mcp-scanner v4.6.0 (2026-05-17): **25/25 tools SAFE, 0 findings**.
-
----
+Distribution: **NuGet** (`maf-doctor` + `maf-doctor.Analyzers`), **Docker GHCR** (multi-arch `amd64`+`arm64`, semver tags), and the self-updating knowledge base described above. Security model: [`docs/security.md`](docs/security.md).
 
 ## Acknowledgements
 
-This toolkit relies heavily on **[dotnet-inspect](https://github.com/richlander/dotnet-inspect)** by [Rich Lander](https://github.com/richlander) — a powerful CLI for querying .NET API surfaces across NuGet packages, platform libraries, and local assemblies. The `nuget-diff-analyzer` skill and the `maf-release-watcher` workflow both use `dotnet-inspect` (via [dnx](https://github.com/filipw/dnx)) to diff MAF package versions and surface breaking API changes.
-
-> ℹ️ As of `dotnet-inspect` **v0.7.8** (2026-05-04), `[Obsolete]` members are surfaced in listings ([PR #318](https://github.com/richlander/dotnet-inspect/pull/318) closes [issue #316](https://github.com/richlander/dotnet-inspect/issues/316)). Versions ≤ v0.7.7 missed `[Obsolete]` at the overload level — historic motivation for `cs0618-hunter` as a workaround. **Pin to v0.7.8 or later.** `cs0618-hunter` remains valuable as the compiler ground-truth path (catches transitive obsoletions, overload-resolution surprises, project-local `[Obsolete]`); `dotnet-inspect` is the static / pre-build path. They are complementary.
-
----
+This toolkit relies on **[dotnet-inspect](https://github.com/richlander/dotnet-inspect)** by [Rich Lander](https://github.com/richlander) — a CLI for querying .NET API surfaces across NuGet packages and assemblies. The release watcher uses it (via [dnx](https://github.com/filipw/dnx)) to diff MAF package versions and surface breaking API changes. **Pin to v0.7.8 or later** — it surfaces `[Obsolete]` members at the overload level ([PR #318](https://github.com/richlander/dotnet-inspect/pull/318)); the compiler-based `cs0618-hunter` path stays complementary for transitive/project-local obsoletions.
 
 ## Contributing
 
-Whenever a migration surfaces a new surprise (unexpected breaking change, silent runtime failure, wrong pattern in the official docs), update:
-1. `guides/maf-1.3.0-migration-guide.md` — add to "Known Misalignments" or create a new section. (For deltas between versions, edit the matching per-version file; the cumulative `maf-current-migration-guide.md` auto-regenerates from those.)
-2. `.github/skills/maf-obsolete-api-registry/registry.yaml` — add the CS0618 entry
-3. `.github/instructions/maf-constraints.instructions.md` — update the breaking changes table if needed
+When a migration surfaces a new surprise (unexpected breaking change, silent runtime failure, wrong pattern in the docs), update:
+
+1. The matching per-version guide in `guides/` (the cumulative `maf-current-migration-guide.md` auto-regenerates from those).
+2. `.github/skills/maf-obsolete-api-registry/registry.yaml` — add the `CS0618` entry.
+3. `.github/instructions/maf-constraints.instructions.md` — update the breaking-changes table if needed.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution shapes + PR conventions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,9 +14,9 @@ A toolkit that turns **GitHub Copilot Chat into a Microsoft Agent Framework (MAF
 
 It ships through **four channels**:
 
-1. **MCP server (NuGet tool)** — the main product. 17 [Model Context Protocol](https://modelcontextprotocol.io/) tools that Copilot can invoke during chats: anti-pattern scanner, fan-out validator, workflow simulator, scaffolders, PR auditor, etc.
+1. **MCP server (NuGet tool)** — the main product. 25 [Model Context Protocol](https://modelcontextprotocol.io/) tools that Copilot can invoke during chats: anti-pattern scanner, fan-out validator, workflow simulator, scaffolders, PR auditor, etc.
 2. **MCP server (Docker)** — same product, containerised on GHCR (multi-arch amd64+arm64), for users without a .NET SDK on the host.
-3. **Roslyn analyzer (separate NuGet)** — `maf-autopilot.Analyzers`. Ships 3 write-time rules (MAF001–003) into any consumer project's compiler. Independent of the MCP server.
+3. **Roslyn analyzer (separate NuGet)** — `maf-doctor.Analyzers`. Ships 3 write-time rules (MAF001–003) into any consumer project's compiler. Independent of the MCP server.
 4. **Skills + agents (GitHub-native)** — 12 SKILL.md files + 6 agent personas + 3 always-loaded instruction files. Loaded by GitHub Copilot Chat directly from `.github/`.
 
 The MCP server, the analyzer NuGet, and the skill bundle are independently shippable. A user can adopt any one, two, or all three.
@@ -87,9 +87,9 @@ The MCP server, the analyzer NuGet, and the skill bundle are independently shipp
 
 **What it does:**
 - Speaks MCP over stdio (when run as a tool) or stdio-in-container (when run via Docker).
-- Exposes **17 tools** (`[McpServerTool]`-decorated methods under `Tools/*.cs`).
-- Exposes **4 resources** (`maf://constraints`, `maf://guide`, `maf://registry`, `maf://rules`, `maf://skills?name=...`).
-- Exposes **3 prompts** (`maf-audit`, `maf-migrate`, `maf-cs0618-hunt`).
+- Exposes **25 tools** (`[McpServerTool]`-decorated methods under `Tools/*.cs`) — see the README for the live catalogue.
+- Exposes **6 resources** (`maf://guide`, `maf://constraints`, `maf://registry`, `maf://rules`, `maf://help`, `maf://skills?name=...`).
+- Exposes **7 prompts** (`maf-audit`, `maf-migrate`, `maf-cs0618-hunt`, `maf-review`, `maf-debug`, `maf-scaffold`, `maf-help`).
 - Provides **CLI subcommands**: `init` (wires `.vscode/mcp.json`), `doctor` (health grade), `new agent` / `new executor` (scaffolders), `registry-extract` (CI helper).
 
 **Embeds at build time** (via `<EmbeddedResource>`): the 12 SKILL.md files, the 3 instruction files, the obsolete-API registry YAML, the migration guide. This is why the runtime container only needs a single .dll — everything ships inline.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -79,12 +79,12 @@ Run the MCP server locally to expose `maf://` resources and `/maf-*` prompts in 
 
 Install `maf-doctor` as a global .NET tool so any project can run `maf-doctor init` and use the MCP server without cloning this repo.
 
-**Prerequisites:** any of .NET 8 / .NET 9 / .NET 10 SDK. `maf-doctor` is published to NuGet as prereleases ([`1.3.0-alpha-5`](https://www.nuget.org/packages/maf-doctor) latest at time of writing). Stable 1.3.0 is gated on the Phase T MAF 1.3 sample dogfood (see [next-steps.md](./next-steps.md)).
+**Prerequisites:** any of .NET 8 / .NET 9 / .NET 10 SDK. Install the [latest published release](https://www.nuget.org/packages/maf-doctor) from NuGet — the toolkit keeps its own MAF knowledge current (see the README's "It updates itself").
 
 **Steps:**
 ```bash
 # Install once, globally
-dotnet tool install -g maf-doctor --prerelease
+dotnet tool install -g maf-doctor
 
 # In any MAF project folder:
 maf-doctor init

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -14,7 +14,7 @@
 
     <!-- NuGet packaging -->
     <PackageId>maf-doctor.Analyzers</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Authors>joslat</Authors>
     <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) 1.3.0 — write-time enforcement of fan-out safety, secure credentials, and observability defaults. Pairs with the maf-autopilot MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -12,13 +12,12 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>maf-doctor</ToolCommandName>
     <PackageId>maf-doctor</PackageId>
-    <!-- Version policy: decoupled from MAF's version progression.
-         1.0.0 = first stable release; supports MAF 1.0 / 1.2 / 1.3 simultaneously.
-         When cutting a new release, bump this AND push the workflow_dispatch
-         on `release.yml`. Don't bump locally without pushing — the README
-         documents the NuGet version, so any drift confuses users.
-         (See CHANGELOG.md — "Versioning note for alpha users".) -->
-    <Version>1.2.0</Version>
+    <!-- Version policy: decoupled from MAF's version progression — the toolkit
+         self-updates its MAF knowledge (see README → "It updates itself").
+         release.yml overrides this from the pushed tag and keeps the analyzer
+         package in lockstep, so the canonical version is the git tag (`vX.Y.Z`).
+         This value is the local/dev default. -->
+    <Version>1.2.1</Version>
     <Authors>joslat</Authors>
     <Description>MAF autopilot MCP server — Tools + Resources + Prompts + Sampling for MAF 1.3.0 migrations. Answers "is this API safe?", exposes migration guide as resources, and uses sampling for multi-step agentic analysis.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>


### PR DESCRIPTION
Cuts **v1.2.1**, the first release published under the **`maf-doctor`** package id (server + `maf-doctor.Analyzers` in lockstep), and leans the README to essentials.

## Release
- Both csprojs → `1.2.1`. Tagging `v1.2.1` after merge triggers `release.yml` → packs + pushes **both** packages to NuGet (`maf-doctor*` key covers both) + GH release.
- `v1.2.0` was already taken by the old `maf-autopilot` release, hence `1.2.1`.

## README — leaned out (≈290 → ≈190 lines)
- **New "It updates itself" section** — explains *how* (watcher diffs NuGet, updates guide + compatibility matrix + obsolete-API registry; minors auto-commit to `main`, majors escalate to a human-gated issue, AI-fill is PR-verified) and *when* (Thursday 06:00 UTC — MAF's .NET ship morning; manual dispatch for off-cadence).
- **Dropped hardcoded version pins** — no more "Current release 1.0.0 / supports MAF 1.0/1.2/1.3"; the toolkit self-updates, so the docs don't go stale.
- **Companion MCPs → Microsoft Learn only** (we don't wire Context7/DeepWiki/Serena anywhere — verified across the repo).
- **Cut bloat**: Project Structure tree, Skill Orchestration catalog, dated distribution block, triplicated `dotnet-inspect` notes.
- Removed the two unrendered demo-cast `<img>` tags (they'd render broken on GitHub + the NuGet page; `.tape` sources + `scripts/make-cast` remain — re-add once rendered).

## Secondary docs
- `docs/architecture.md`: stale 17/4/3 tool counts → 25/6/7; `maf-autopilot.Analyzers` → `maf-doctor.Analyzers`.
- `docs/setup.md`: stale "current release `1.3.0-alpha-5` / gated on Phase T" → version-agnostic install.

## Verification
The leaned README was adversarially verified (4-agent workflow): self-update claims confirmed against `maf-release-watcher.yml`, links/anchors resolve, no dangling MCP refs, no essential info lost. Must-fix (broken GIFs) + should-fixes applied.

> The `audit` check will still be red until `maf-doctor` is live on NuGet — which this release fixes once the tag publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)