### PR TITLE
fix(release): analyzer nupkg verification used pre-rename package id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release maf-autopilot
+name: Release maf-doctor
 
 on:
   workflow_dispatch:
@@ -132,8 +132,8 @@ jobs:
             --no-restore \
             --output src/dist/
           PACK_EXIT=$?
-          if ls src/dist/maf-autopilot.Analyzers*.nupkg >/dev/null 2>&1; then
-            echo "Packed: $(ls src/dist/maf-autopilot.Analyzers*.nupkg)"
+          if ls src/dist/maf-doctor.Analyzers*.nupkg >/dev/null 2>&1; then
+            echo "Packed: $(ls src/dist/maf-doctor.Analyzers*.nupkg)"
             exit 0
           fi
           echo "::error::Analyzer nupkg was not produced (pack exit code was $PACK_EXIT)"


### PR DESCRIPTION
The `v1.2.1` release run failed at **Pack analyzer package** — but the package packed fine (`maf-doctor.Analyzers.1.2.1.nupkg`). The NU5017-workaround verification still globbed for the **old** id:

```bash
if ls src/dist/maf-autopilot.Analyzers*.nupkg ...   # ← never matches post-rename
```

The output nupkg name follows `<PackageId>` (now `maf-doctor.Analyzers`), not the csproj filename. The glob matched nothing → returned the NU5017 exit code → job halted **before** `Publish to NuGet`. So `v1.2.1` packed but never published (no partial release — confirmed no NuGet push, no GH release).

Fix: glob `maf-doctor.Analyzers*.nupkg` in both the guard and the echo. The `src/maf-autopilot/...` csproj/sln **paths** stay (deliberately-kept internal names). Cosmetic: workflow `name:` → `Release maf-doctor`.

After merge, the `v1.2.1` tag is re-pointed to the fixed commit to re-run the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)