### PR TITLE
release: v1.2.2 — fix published package metadata + drop README naming note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.2] - 2026-06-14
+
+### Fixed (NuGet package metadata)
+
+- **Corrected the published package descriptions.** Both `maf-doctor` and `maf-doctor.Analyzers` still carried the pre-rename blurb on nuget.org ("MAF autopilot MCP server … MAF 1.3.0 migrations" / "Pairs with the maf-autopilot MCP server"). They now describe MAF Doctor accurately and version-agnostically.
+- **Removed the README "Naming" note.** It explained the rename/deprecation of a package that was never publicly announced — pointless noise for a new reader. The intro now states plainly that `maf-doctor` is a **.NET global tool installed from NuGet** (`dotnet tool install -g maf-doctor`), with `maf-doctor.Analyzers` as a separate analyzer package.
+
 ## [1.2.1] - 2026-06-14
 
 **First release published under the `maf-doctor` package id** (and `maf-doctor.Analyzers`) — this is the version where the rename below actually reaches NuGet.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 > Diagnose, explain, prescribe, verify — for MAF agents and workflows.
 
-> **Naming:** the brand is **MAF Doctor**; the NuGet package + CLI are **`maf-doctor`**. (Pre-rename this shipped as `maf-autopilot` ≤ 1.2.0 — that package is deprecated in favor of `maf-doctor`. The internal `src/maf-autopilot/` project folder keeps its name; it's invisible to users.)
-
-**MAF Doctor** is a .NET global tool that does three things in one install:
+**MAF Doctor** is a **.NET global tool** — installed from NuGet with `dotnet tool install -g maf-doctor` — that does three things in one install:
 
 1. **An MCP server** — exposes 25 executable tools, 6 resources, and 7 prompts to GitHub Copilot / Claude Code / Cursor via `.vscode/mcp.json`.
 2. **A CLI** — `maf-doctor doctor` (A–F health letter), `maf-doctor autofix-all` (deterministic rewriters), `maf-doctor new agent <Name>`, `maf-doctor init` (drops MCP config + steering snippets into your repo), and more.

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -14,9 +14,9 @@
 
     <!-- NuGet packaging -->
     <PackageId>maf-doctor.Analyzers</PackageId>
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <Authors>joslat</Authors>
-    <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) 1.3.0 — write-time enforcement of fan-out safety, secure credentials, and observability defaults. Pairs with the maf-autopilot MCP server.</Description>
+    <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) — write-time enforcement of fan-out safety, secure credentials, and observability defaults (MAF001-MAF003). Companion to the maf-doctor .NET global tool / MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/joslat/maf-doctor</RepositoryUrl>

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -17,9 +17,9 @@
          release.yml overrides this from the pushed tag and keeps the analyzer
          package in lockstep, so the canonical version is the git tag (`vX.Y.Z`).
          This value is the local/dev default. -->
-    <Version>1.2.1</Version>
+    <Version>1.2.2</Version>
     <Authors>joslat</Authors>
-    <Description>MAF autopilot MCP server — Tools + Resources + Prompts + Sampling for MAF 1.3.0 migrations. Answers "is this API safe?", exposes migration guide as resources, and uses sampling for multi-step agentic analysis.</Description>
+    <Description>MAF Doctor — a .NET global tool and MCP server for Microsoft Agent Framework (MAF). Diagnoses, explains, and auto-fixes MAF agents and workflows: A-F health grades, deterministic Roslyn rewriters, anti-pattern and fan-out scanning, and a self-updating obsolete-API registry. Use it from Copilot / Claude / Cursor via MCP, or standalone as a CLI.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/joslat/maf-doctor</RepositoryUrl>


### PR DESCRIPTION
Follow-up to v1.2.1 — fixes what shows on the **nuget.org package page** (baked from package metadata, so it needs a republish).

## Fixed
- **Package descriptions** — both `maf-doctor` and `maf-doctor.Analyzers` still carried the pre-rename, version-pinned blurb ("MAF autopilot MCP server … MAF 1.3.0 migrations" / "Pairs with the maf-autopilot MCP server"). Rewritten to describe MAF Doctor accurately and without a hardcoded MAF version.
- **README "Naming" note removed** — it explained the rename + deprecation of a package that was never publicly announced; pure noise for a new reader. The intro now states plainly: `maf-doctor` is a **.NET global tool installed from NuGet** (`dotnet tool install -g maf-doctor`); `maf-doctor.Analyzers` is a separate analyzer package.

Both packages → **1.2.2**. The release.yml analyzer-glob fix from #84 is already on `main`, so the tag publish should go clean first try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)