### PR TITLE
release: v1.2.3 — tone down README inline-code (red-on-pink on NuGet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3] - 2026-06-14
+
+### Changed (docs)
+
+- **Toned down inline-code density in the README.** NuGet.org styles inline `code` spans as red-on-pink, so the previous README (~50 inline-code spans) rendered as a wall of red on the package page (it looks fine on GitHub). Rewrote prose to use plain/bold text, keeping backticks only where monospace genuinely helps — the literal API transformations in "Why This Exists" and the one registry path a contributor edits (6 spans total). Fenced command blocks are unchanged.
+
 ## [1.2.2] - 2026-06-14
 
 ### Fixed (NuGet package metadata)

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 > Diagnose, explain, prescribe, verify — for MAF agents and workflows.
 
-**MAF Doctor** is a **.NET global tool** — installed from NuGet with `dotnet tool install -g maf-doctor` — that does three things in one install:
+**MAF Doctor** is a **.NET global tool** (installed from NuGet) that does three things in one install:
 
-1. **An MCP server** — exposes 25 executable tools, 6 resources, and 7 prompts to GitHub Copilot / Claude Code / Cursor via `.vscode/mcp.json`.
-2. **A CLI** — `maf-doctor doctor` (A–F health letter), `maf-doctor autofix-all` (deterministic rewriters), `maf-doctor new agent <Name>`, `maf-doctor init` (drops MCP config + steering snippets into your repo), and more.
-3. **A plugin** — `init` also drops 12 specialised skills, 7 specialist agents, and steering snippets so GitHub Copilot's agentic loops gain MAF-specific knowledge.
+1. **An MCP server** — exposes 25 executable tools, 6 resources, and 7 prompts to GitHub Copilot / Claude Code / Cursor.
+2. **A CLI** — **doctor** for an A–F health letter, **autofix-all** for deterministic rewriters, **new agent** to scaffold, **init** to wire up your repo, and more.
+3. **A plugin** — init also drops 12 specialised skills, 7 specialist agents, and steering snippets so GitHub Copilot's agentic loops gain MAF-specific knowledge.
 
-Plus a separate **`maf-doctor.Analyzers`** NuGet with 3 Roslyn analyzers (`MAF001`/`MAF002`/`MAF003`) for IDE write-time enforcement, and a curated, version-keyed **obsolete-API registry** that maps every known `CS0618` to its exact replacement.
+Plus a separate **maf-doctor.Analyzers** NuGet package with 3 Roslyn analyzers (MAF001 / MAF002 / MAF003) for IDE write-time enforcement, and a curated, version-keyed **obsolete-API registry** that maps every known CS0618 warning to its exact replacement.
 
 > 📦 **[Latest release on NuGet →](https://www.nuget.org/packages/maf-doctor)** — and the toolkit keeps its own MAF knowledge current automatically. See [**It updates itself**](#it-updates-itself).
 
@@ -17,33 +17,33 @@ Plus a separate **`maf-doctor.Analyzers`** NuGet with 3 Roslyn analyzers (`MAF00
 - 🔍 **Catches the bugs that compile clean** — detects fan-out/fan-in silent failures where a workflow exits successfully but produces no output. Runtime-only, zero build signal, invisible without this tool.
 - 🩺 **Compiler ground-truth for CS0618** — surfaces obsolete-API usage the build would hit, including transitive obsoletions and overload-resolution surprises, and maps each to its canonical fix.
 - ✅ **Best-practice auditing, not just migration** — reviews your agents and workflows against current MAF patterns, catching drift and anti-patterns before they become production bugs.
-- 🤖 **Fully agentic loop** — Copilot audits your codebase, generates a tracked migration plan, executes it task-by-task with `dotnet build` verification after every step, and updates the plan as it goes.
-- 🧰 **Deterministic fixes, not guesses** — the obsolete-API registry maps every known `CS0618` to its exact replacement pattern. No hallucinated fixes.
+- 🤖 **Fully agentic loop** — Copilot audits your codebase, generates a tracked migration plan, and executes it task-by-task, building after every step.
+- 🧰 **Deterministic fixes, not guesses** — the obsolete-API registry maps every known CS0618 warning to its exact replacement pattern. No hallucinated fixes.
 - 📖 **It updates itself** — as new MAF versions ship, the toolkit refreshes its own migration knowledge automatically. [How →](#it-updates-itself)
-- 🔐 **Hardened against the named MCP attack lattice** — a comprehensive security pass closes the critical- and high-tier MCP attack classes (path-escape, annotation drift, scaffold code-injection, prompt-injection via release notes, `workflow_dispatch` input injection), with defense-in-depth helpers and CI-enforced invariants. Cisco mcp-scanner: 25/25 tools SAFE, 0 findings. See [`SECURITY.md`](SECURITY.md) + [`docs/security.md`](docs/security.md).
+- 🔐 **Hardened against the named MCP attack lattice** — a comprehensive security pass closes the critical- and high-tier MCP attack classes (path-escape, annotation drift, scaffold code-injection, prompt-injection via release notes, workflow-dispatch input injection), with defense-in-depth helpers and CI-enforced invariants. Cisco mcp-scanner: 25/25 tools SAFE, 0 findings. See [SECURITY.md](SECURITY.md) and [docs/security.md](docs/security.md).
 
 ## It updates itself
 
 Migration tooling is only useful if it knows about the MAF version you're on. MAF Doctor keeps its own knowledge base current instead of asking you to wait for a maintainer release:
 
-**How** — a GitHub Actions watcher checks NuGet for a new `Microsoft.Agents.AI` release, diffs the API surface against the last known version, and updates the per-version migration guide, the compatibility matrix, and the obsolete-API registry:
+**How** — a GitHub Actions watcher checks NuGet for a new Microsoft.Agents.AI release, diffs the API surface against the last known version, and updates the per-version migration guide, the compatibility matrix, and the obsolete-API registry:
 
-- **Minor / patch bumps** are committed straight to `main` — the guide, matrix, and `.maf-version` move forward on their own.
+- **Minor / patch bumps** are committed straight to the main branch — the guide, matrix, and tracked version move forward on their own.
 - **Major bumps** don't auto-merge; they open a human-gated issue so a breaking release gets eyes before anything lands.
-- New registry entries are drafted by an AI-fill loop and **PR-verified** — `verify-registry` runs on the fill PR (and can gate the merge when required-status-checks is enabled), so the deterministic fix data stays trustworthy.
+- New registry entries are drafted by an AI-fill loop and **PR-verified** — a registry-verification check runs on the fill PR (and can gate the merge when required-status-checks is enabled), so the deterministic fix data stays trustworthy.
 
-**When** — every **Thursday 06:00 UTC** (~08:00 Europe/Zurich), aligned with MAF's .NET Thursday-morning ship cadence. Off-cadence releases are covered by a manual `workflow_dispatch` trigger.
+**When** — every **Thursday 06:00 UTC** (~08:00 Europe/Zurich), aligned with MAF's .NET Thursday-morning ship cadence. Off-cadence releases are covered by a manual dispatch trigger.
 
-The practical upshot: you don't pin to a MAF version in these docs, and you don't wait on us. Re-run `maf-doctor doctor` after any MAF bump and it cross-references the freshest guide automatically.
+The practical upshot: you don't pin to a MAF version in these docs, and you don't wait on us. Re-run the doctor after any MAF bump and it cross-references the freshest guide automatically.
 
 ## How It Works
 
-`maf-doctor` is a **[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server** packaged as a .NET global tool. With no subcommand it runs in MCP mode and exposes:
+MAF Doctor is a **[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server** packaged as a .NET global tool. With no subcommand it runs in MCP mode and exposes:
 
-- **25 executable tools**, each annotated with MCP behavior hints (`readOnlyHint` / `destructiveHint` / `idempotentHint` / `openWorldHint`) so clients can auto-classify them — registry lookup, code scanning, build-verified CS0618 hunts, NuGet diffing, workflow simulation, scaffolding, PR-scoped audits, version planning, and the single-command health letter `MafDoctor`. Anti-pattern + fan-out scanners support `format: "sarif"` for GitHub Advanced Security; the 2 destructive tools (`MafAutoFix`, `MafAutoFixAll`) support `dryRun`.
-- **6 resources** — `maf://guide`, `maf://constraints`, `maf://registry`, `maf://rules`, `maf://help`, `maf://skills?name=...` — the full knowledge base, readable on demand.
-- **7 prompts** — `maf-audit`, `maf-migrate`, `maf-cs0618-hunt`, `maf-review`, `maf-debug`, `maf-scaffold`, `maf-help`.
-- **3 Roslyn analyzers** (separate `maf-doctor.Analyzers` NuGet) — `MAF001` fan-out, `MAF002` `DefaultAzureCredential`, `MAF003` `EnableSensitiveData`. Write-time enforcement.
+- **25 executable tools**, each annotated with MCP behavior hints (read-only / destructive / idempotent / open-world) so clients can auto-classify them — registry lookup, code scanning, build-verified CS0618 hunts, NuGet diffing, workflow simulation, scaffolding, PR-scoped audits, version planning, and a single-command health letter. The anti-pattern and fan-out scanners emit SARIF for GitHub Advanced Security; the two destructive tools (auto-fix and auto-fix-all) support a dry-run.
+- **6 resources** — the migration guide, constraints, registry, rules, help, and per-name skills — readable on demand.
+- **7 prompts** — audit, migrate, cs0618-hunt, review, debug, scaffold, and help.
+- **3 Roslyn analyzers** (in the separate maf-doctor.Analyzers package) — MAF001 (fan-out), MAF002 (DefaultAzureCredential), MAF003 (EnableSensitiveData). Write-time enforcement.
 
 With a subcommand, the same binary runs as a CLI tool — see Quick Start below.
 
@@ -62,7 +62,7 @@ cd your-maf-project
 maf-doctor init
 ```
 
-VS Code picks up `.vscode/mcp.json` automatically and starts the MCP server; Copilot Chat gains live tool calls, resource reads, and structured prompts.
+VS Code picks up the MCP config automatically and starts the server; Copilot Chat gains live tool calls, resource reads, and structured prompts.
 
 **First three commands to try:**
 
@@ -97,11 +97,11 @@ docker pull ghcr.io/joslat/maf-doctor:latest
 }
 ```
 
-Same tools, skills, and resources — isolated in a container. Multi-arch (`amd64` + `arm64`).
+Same tools, skills, and resources — isolated in a container. Multi-arch (amd64 + arm64).
 
 ### Mode 2: Skills + Agents only (no MCP server)
 
-Copy `.github/` from this repo into your .NET repository root for the agents and skills via VS Code's instruction/agent system — no live tool calls, but no install either.
+Copy this repo's .github folder into your .NET repository root for the agents and skills via VS Code's instruction/agent system — no live tool calls, but no install either.
 
 ```powershell
 git clone https://github.com/joslat/maf-doctor tmp-maf
@@ -109,28 +109,28 @@ Copy-Item tmp-maf/.github -Destination .github -Recurse
 Remove-Item tmp-maf -Recurse
 ```
 
-Then use `@maf-migration` or `@maf-auditor` in Copilot Chat.
+Then use the @maf-migration or @maf-auditor agents in Copilot Chat.
 
 ## Recommended companion MCP
 
-MAF Doctor is laser-focused on **diagnose + fix** for Microsoft Agent Framework. For documentation lookup, pair it with the **[Microsoft Learn MCP](https://learn.microsoft.com/api/mcp)** — live, version-aware MAF docs and code samples (`https://learn.microsoft.com/api/mcp`, no auth). Docs lookup stays in Learn's lane; audit + fix + migration stays in ours.
+MAF Doctor is laser-focused on **diagnose + fix** for Microsoft Agent Framework. For documentation lookup, pair it with the **[Microsoft Learn MCP](https://learn.microsoft.com/api/mcp)** — live, version-aware MAF docs and code samples, no auth required. Docs lookup stays in Learn's lane; audit + fix + migration stays in ours.
 
 ## Why This Exists
 
-`dotnet upgrade-assistant` handles package version bumps. MAF Doctor handles everything else:
+The .NET upgrade-assistant handles package version bumps. MAF Doctor handles everything else:
 
 - MAF-specific executor pattern migration (`ReflectingExecutor` → `partial class : Executor` + `[MessageHandler]`)
 - Session API changes (`AgentThread` → `AgentSession`)
 - Fan-out/fan-in silent failure detection — a class of bug that builds green but runs wrong
-- Compiler ground-truth CS0618 detection (transitive obsoletions, overload-resolution surprises, project-local `[Obsolete]`)
+- Compiler ground-truth CS0618 detection (transitive obsoletions, overload-resolution surprises, project-local Obsolete attributes)
 - Build-verified, task-by-task execution with a full tracking table
 - A machine-readable obsolete-API registry so fixes are deterministic, not guessed
 
 ## Typical Migration Workflow
 
-1. **Audit** — open Copilot Chat → use the `maf-audit` prompt (or `@maf-auditor` agent) to scan your codebase and generate a tracked `migration-plan.md`.
-2. **Migrate** — use the `maf-migrate` prompt (or `@maf-migration` agent) to execute the plan task-by-task with `dotnet build` verification after each step.
-3. **Hunt stragglers** — use the `maf-cs0618-hunt` prompt to catch any remaining CS0618 warnings the build surfaces.
+1. **Audit** — open Copilot Chat → use the audit prompt (or the @maf-auditor agent) to scan your codebase and generate a tracked migration plan.
+2. **Migrate** — use the migrate prompt (or the @maf-migration agent) to execute the plan task-by-task, building after each step.
+3. **Hunt stragglers** — use the cs0618-hunt prompt to catch any remaining CS0618 warnings the build surfaces.
 
 The MCP tools are called automatically by Copilot during these steps — you don't invoke them directly.
 
@@ -138,21 +138,21 @@ The MCP tools are called automatically by Copilot during these steps — you don
 
 For an evidence-anchored view of what's done, in progress, and pending:
 
-- **[`docs/maf-migration-toolkit-plan.md`](docs/maf-migration-toolkit-plan.md)** — phased roadmap + the tracking table (single source of truth)
-- **[`docs/project-status-and-vision.md`](docs/project-status-and-vision.md)** — stage assessment + the broader vision
+- **[docs/maf-migration-toolkit-plan.md](docs/maf-migration-toolkit-plan.md)** — phased roadmap + the tracking table (single source of truth)
+- **[docs/project-status-and-vision.md](docs/project-status-and-vision.md)** — stage assessment + the broader vision
 
-Distribution: **NuGet** (`maf-doctor` + `maf-doctor.Analyzers`), **Docker GHCR** (multi-arch `amd64`+`arm64`, semver tags), and the self-updating knowledge base described above. Security model: [`docs/security.md`](docs/security.md).
+Distribution: **NuGet** (maf-doctor + maf-doctor.Analyzers), **Docker GHCR** (multi-arch amd64 + arm64, semver tags), and the self-updating knowledge base described above. Security model: [docs/security.md](docs/security.md).
 
 ## Acknowledgements
 
-This toolkit relies on **[dotnet-inspect](https://github.com/richlander/dotnet-inspect)** by [Rich Lander](https://github.com/richlander) — a CLI for querying .NET API surfaces across NuGet packages and assemblies. The release watcher uses it (via [dnx](https://github.com/filipw/dnx)) to diff MAF package versions and surface breaking API changes. **Pin to v0.7.8 or later** — it surfaces `[Obsolete]` members at the overload level ([PR #318](https://github.com/richlander/dotnet-inspect/pull/318)); the compiler-based `cs0618-hunter` path stays complementary for transitive/project-local obsoletions.
+This toolkit relies on **[dotnet-inspect](https://github.com/richlander/dotnet-inspect)** by [Rich Lander](https://github.com/richlander) — a CLI for querying .NET API surfaces across NuGet packages and assemblies. The release watcher uses it (via [dnx](https://github.com/filipw/dnx)) to diff MAF package versions and surface breaking API changes. **Pin to v0.7.8 or later** — it surfaces Obsolete members at the overload level ([PR #318](https://github.com/richlander/dotnet-inspect/pull/318)); the compiler-based cs0618-hunter path stays complementary for transitive and project-local obsoletions.
 
 ## Contributing
 
 When a migration surfaces a new surprise (unexpected breaking change, silent runtime failure, wrong pattern in the docs), update:
 
-1. The matching per-version guide in `guides/` (the cumulative `maf-current-migration-guide.md` auto-regenerates from those).
-2. `.github/skills/maf-obsolete-api-registry/registry.yaml` — add the `CS0618` entry.
-3. `.github/instructions/maf-constraints.instructions.md` — update the breaking-changes table if needed.
+1. The matching per-version guide in the guides folder (the cumulative guide auto-regenerates from those).
+2. The obsolete-API registry at `.github/skills/maf-obsolete-api-registry/registry.yaml` — add the CS0618 entry.
+3. The MAF constraints instructions — update the breaking-changes table if needed.
 
-See [`CONTRIBUTING.md`](CONTRIBUTING.md) for contribution shapes + PR conventions.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution shapes + PR conventions.

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -14,7 +14,7 @@
 
     <!-- NuGet packaging -->
     <PackageId>maf-doctor.Analyzers</PackageId>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <Authors>joslat</Authors>
     <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) — write-time enforcement of fan-out safety, secure credentials, and observability defaults (MAF001-MAF003). Companion to the maf-doctor .NET global tool / MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -17,7 +17,7 @@
          release.yml overrides this from the pushed tag and keeps the analyzer
          package in lockstep, so the canonical version is the git tag (`vX.Y.Z`).
          This value is the local/dev default. -->
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <Authors>joslat</Authors>
     <Description>MAF Doctor — a .NET global tool and MCP server for Microsoft Agent Framework (MAF). Diagnoses, explains, and auto-fixes MAF agents and workflows: A-F health grades, deterministic Roslyn rewriters, anti-pattern and fan-out scanning, and a self-updating obsolete-API registry. Use it from Copilot / Claude / Cursor via MCP, or standalone as a CLI.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>


### PR DESCRIPTION
The README renders fine on GitHub (gray inline code), but on **nuget.org** inline `code` spans are styled red-on-pink — and the README had ~50 of them, so the package page was a wall of red.

## Change
Rewrote README prose to plain/bold text, keeping backticks **only** where monospace genuinely helps:
- the literal API transformations in "Why This Exists" (`ReflectingExecutor` → `partial class : Executor`, `AgentThread` → `AgentSession`, …)
- the one registry path a contributor edits

**6 inline-code spans total, down from ~50.** Fenced command blocks (which render gray on NuGet) are untouched, so the install/usage snippets are unchanged.

Both packages → **1.2.3**; tagging `v1.2.3` republishes so the cleaner README reaches the NuGet page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)