### PR TITLE
docs: usage + init-reference + cast README; finish maf-doctor product-name sweep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to maf-autopilot (MAF Doctor)
+# Contributing to maf-doctor (MAF Doctor)
 
 Thanks for considering a contribution. This guide covers the four most common contribution shapes — a registry entry, a skill, an agent change, and an MCP server tool — plus the project-wide conventions that keep them coherent.
 
@@ -17,7 +17,7 @@ See [`AGENTS.md`](./AGENTS.md) for the full repo layout and location of every so
 
 ```bash
 git clone https://github.com/joslat/maf-doctor
-cd maf-autopilot
+cd maf-doctor
 dotnet restore maf-autopilot.sln
 dotnet build maf-autopilot.sln           # builds net8.0 + net9.0 + net10.0 + netstandard2.0 (analyzer)
 dotnet test maf-autopilot.sln            # 474 tests × 3 TFMs = 1422 test executions

--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ With a subcommand, the same binary runs as a CLI tool — see Quick Start below.
 # 1. Install the MCP server as a .NET global tool
 dotnet tool install --global maf-doctor
 
-# 2. In your MAF project — writes .vscode/mcp.json + .github/copilot-instructions.md
+# 2. In your MAF project — wires MCP + steering for VS Code, Copilot & Claude Code
 cd your-maf-project
 maf-doctor init
 ```
 
 init wires the MCP server into both **VS Code** (.vscode/mcp.json) and **Claude Code** (.mcp.json), and drops auto-loaded steering in each tool's convention dir — .github/instructions/ for Copilot, .claude/ plus a one-line CLAUDE.md import for Claude Code, and an AGENTS.md managed block. These are refreshed on every re-run and never merged into your own files. Your assistant picks the server up automatically and gains live tool calls, resource reads, and structured prompts.
+
+> 📖 **Going deeper:** [what `init` installs (and why)](docs/init-reference.md) · [using MAF Doctor — prompts, tools, agents & natural-language steering](docs/usage.md) · [hands-on workshop](samples/workshop.md).
 
 **First three commands to try:**
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,11 +2,11 @@
 
 > **Last updated:** 2026-05-13 — Phase S landed: multi-target nupkg + central package management.
 
-This document explains what each piece of `maf-autopilot` is, how the pieces fit together, and where the structural choices were deliberate (vs. accidental).
+This document explains what each piece of `maf-doctor` is, how the pieces fit together, and where the structural choices were deliberate (vs. accidental).
 
 ---
 
-## What is `maf-autopilot`?
+## What is `maf-doctor`?
 
 A toolkit that turns **GitHub Copilot Chat into a Microsoft Agent Framework (MAF) expert** for the lifetime of a .NET project.
 
@@ -25,7 +25,7 @@ The MCP server, the analyzer NuGet, and the skill bundle are independently shipp
 
 ```
 ┌──────────────────────────────────────────────────────────────────────────┐
-│                          maf-autopilot repo                              │
+│                          maf-doctor repo                                 │
 │                                                                          │
 │  /Directory.Packages.props  ← central package mgmt (CPM)                │
 │  /Directory.Build.props     ← shared compiler settings                  │
@@ -35,7 +35,7 @@ The MCP server, the analyzer NuGet, and the skill bundle are independently shipp
 │  │  /src/maf-autopilot/    │   │  /src/maf-autopilot.Analyzers/    │   │
 │  │  ── MCP server          │   │  ── Roslyn analyzers              │   │
 │  │  ── net8.0;net9.0;net10.0   │   │  ── netstandard2.0 (compiler host)│
-│  │  ── NuGet: maf-autopilot│   │  ── NuGet: maf-autopilot.Analyzers│   │
+│  │  ── NuGet: maf-doctor   │   │  ── NuGet: maf-doctor.Analyzers   │   │
 │  │  ── Docker: GHCR (net8) │   │  ── 3 rules (MAF001/002/003)      │   │
 │  └────────┬────────────────┘   └────────┬──────────────────────────┘   │
 │           │ ProjectReference (none)     │ ProjectReference (none)        │
@@ -76,7 +76,7 @@ The MCP server, the analyzer NuGet, and the skill bundle are independently shipp
 
 ## What each .NET project IS
 
-### `maf-autopilot` (the MCP server)
+### `maf-doctor` (the MCP server)
 
 **Path:** `/src/maf-autopilot/`
 **Target frameworks:** `net8.0;net9.0;net10.0` (multi-target — NuGet picks the best TFM at install time)
@@ -92,7 +92,7 @@ The MCP server, the analyzer NuGet, and the skill bundle are independently shipp
 
 **Embeds at build time** (via `<EmbeddedResource>`): the 12 SKILL.md files, the 3 instruction files, the obsolete-API registry YAML, the migration guide. This is why the runtime container only needs a single .dll — everything ships inline.
 
-### `maf-autopilot.Analyzers` (the Roslyn analyzer NuGet)
+### `maf-doctor.Analyzers` (the Roslyn analyzer NuGet)
 
 **Path:** `/src/maf-autopilot.Analyzers/`
 **Target framework:** **netstandard2.0** (mandatory — Roslyn analyzers load into the compiler host, which targets netstandard2.0).
@@ -104,7 +104,7 @@ The MCP server, the analyzer NuGet, and the skill bundle are independently shipp
 - `MAF002` — avoid `DefaultAzureCredential` in production code.
 - `MAF003` — avoid `EnableSensitiveData = true` outside test code.
 
-**Critically: it has ZERO dependencies on the MCP server.** A consumer can install just the analyzers without ever touching `maf-autopilot` the tool.
+**Critically: it has ZERO dependencies on the MCP server.** A consumer can install just the analyzers without ever touching `maf-doctor` the tool.
 
 ### `maf-autopilot.Tests`
 
@@ -171,7 +171,7 @@ maf-autopilot.sln
 
 ## Multi-targeting
 
-The MCP server NuGet `maf-autopilot` ships TFM assemblies for **net8.0 + net9.0 + net10.0** inside a single `nupkg`. NuGet's TFM resolution selects the best match at consumer install time:
+The MCP server NuGet `maf-doctor` ships TFM assemblies for **net8.0 + net9.0 + net10.0** inside a single `nupkg`. NuGet's TFM resolution selects the best match at consumer install time:
 
 - A user on the .NET 8 LTS runtime installs the `net8.0` binary.
 - A user on the .NET 9 STS runtime installs the `net9.0` binary.
@@ -187,7 +187,7 @@ This pattern matches the sibling [`AgentEval`](https://github.com/joslat/AgentEv
 | `Directory.Build.props` | Shared compiler settings (`LangVersion`, `ImplicitUsings`, `Nullable`). Per-project csprojs may override (the analyzer uses its own `LangVersion=latest` + locked `netstandard2.0`). |
 | `global.json` | Pins `sdk.version=8.0.100` with `rollForward: latestMajor` + `allowPrerelease: true`. Any installed SDK ≥ 8.x can build the solution. |
 
-**The Roslyn analyzer (`maf-autopilot.Analyzers`) is excluded from multi-targeting.** It MUST stay on `netstandard2.0` — analyzers load into the compiler host (csc.exe / VS / OmniSharp), which itself runs on the netstandard2.0 surface. Multi-targeting an analyzer would not change consumer reach (consumer csproj loads the netstandard2.0 DLL regardless of consumer TFM) and would break compatibility with older compiler hosts.
+**The Roslyn analyzer (`maf-doctor.Analyzers`) is excluded from multi-targeting.** It MUST stay on `netstandard2.0` — analyzers load into the compiler host (csc.exe / VS / OmniSharp), which itself runs on the netstandard2.0 surface. Multi-targeting an analyzer would not change consumer reach (consumer csproj loads the netstandard2.0 DLL regardless of consumer TFM) and would break compatibility with older compiler hosts.
 
 **The Dockerfile is excluded.** Only the multi-target NuGet ships all 3 TFMs; the container can only choose one runtime. Net8 LTS is the smallest, longest-supported runtime image — picked for the smallest container footprint.
 
@@ -199,8 +199,8 @@ This pattern matches the sibling [`AgentEval`](https://github.com/joslat/AgentEv
 
 | Channel | What ships | Who consumes | Where |
 |---|---|---|---|
-| NuGet (server) | `maf-autopilot` .NET global tool | Developers installing via `dotnet tool install` | `nuget.org/packages/maf-doctor` |
-| NuGet (analyzer) | `maf-autopilot.Analyzers` analyzer | Consumer .csproj `<PackageReference>` | `nuget.org/packages/maf-doctor.Analyzers` |
+| NuGet (server) | `maf-doctor` .NET global tool | Developers installing via `dotnet tool install` | `nuget.org/packages/maf-doctor` |
+| NuGet (analyzer) | `maf-doctor.Analyzers` analyzer | Consumer .csproj `<PackageReference>` | `nuget.org/packages/maf-doctor.Analyzers` |
 | Docker | Multi-arch image (amd64+arm64) | Developers without .NET SDK on host | `ghcr.io/joslat/maf-doctor:<semver>` |
 | Skills-only | The `.github/` directory copied into a consumer repo | Users wanting agents+skills without the MCP server | `git clone` |
 

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,58 @@
+# `docs/assets/` — the README demo casts
+
+This folder holds the two animated terminal demos shown in the top-level `README.md`:
+
+| Source (`.tape`) | Renders to | Shows |
+|---|---|---|
+| `install-cast.tape` | `install-cast.gif` | Install the tool + `maf-doctor doctor .` → grade **F** + top fixes |
+| `migration-cast.tape` | `migration-cast.gif` | `maf-doctor autofix-all .` → grade **F → A**, deterministic |
+
+## What the `.tape` files are
+
+They're **[VHS](https://github.com/charmbracelet/vhs)** scripts (by Charm). VHS reads a `.tape` file — a list of `Type`, `Enter`, `Sleep`, `Set` directives — drives a **headless terminal**, runs the commands for real, and records the session to a `.gif`. So the casts aren't hand-made screen recordings: they're reproducible scripts you re-run whenever the CLI output changes.
+
+The `.gif` outputs are **not committed** — they're build artifacts you render on demand (which is why the README's `<img>` tags were removed until someone renders + commits them).
+
+## How to render them ("auto-run")
+
+**Prerequisites:** `vhs` (which pulls in `ttyd` + `ffmpeg`).
+
+```bash
+# macOS
+brew install vhs ffmpeg ttyd
+# Windows
+winget install charmbracelet.vhs
+# Linux → https://github.com/charmbracelet/vhs#installation
+```
+
+**Render** (the scripts resolve the repo root, so run from anywhere):
+
+```bash
+bash scripts/make-cast.sh             # render BOTH casts (default)
+bash scripts/make-cast.sh install     # only install-cast.gif
+bash scripts/make-cast.sh migration   # only migration-cast.gif
+```
+
+```powershell
+pwsh scripts/make-cast.ps1            # PowerShell equivalent
+```
+
+Or invoke VHS directly on one tape:
+
+```bash
+vhs docs/assets/install-cast.tape     # → docs/assets/install-cast.gif
+```
+
+The script aborts with install hints if `vhs` isn't on `PATH`.
+
+## After rendering
+
+The GIFs land in `docs/assets/`. To show them in the README, commit them and add the `<img>` tags back:
+
+```bash
+git add docs/assets/*.gif && git commit -m "docs: render README casts"
+```
+
+## Editing a cast
+
+Edit the `.tape` (typed commands, timings, theme via `Set …`) and re-render. The tapes run **real commands** against the bundled `samples/maf-1.3-sample/`, so after a recording reset the sample with `git restore samples/maf-1.3-sample/`. Keep the demo honest — if the CLI output changes, re-render rather than editing the GIF.

--- a/docs/assets/install-cast.tape
+++ b/docs/assets/install-cast.tape
@@ -1,4 +1,4 @@
-# vhs script for the maf-autopilot install + audit demo.
+# vhs script for the maf-doctor install + audit demo.
 #
 # Render locally:
 #   bash scripts/make-cast.sh           # produces docs/assets/install-cast.gif
@@ -21,7 +21,7 @@ Set TypingSpeed 50ms
 Set Shell "bash"
 
 # ───────── beat 1: install ─────────
-Type "# Install maf-autopilot as a global .NET tool"
+Type "# Install maf-doctor as a global .NET tool"
 Enter
 Sleep 800ms
 

--- a/docs/assets/migration-cast.tape
+++ b/docs/assets/migration-cast.tape
@@ -1,4 +1,4 @@
-# vhs script for the maf-autopilot migration demo.
+# vhs script for the maf-doctor migration demo.
 #
 # Companion to install-cast.tape. While that cast shows install + audit,
 # THIS cast shows the auto-fix loop: a broken codebase migrates to

--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -13,7 +13,7 @@
 -->
 
 > This file is the single source of truth for MAF version ↔ dependency version compatibility.
-> It is referenced by `maf-autopilot` MCP server tools (`maf_compatibility`) and auto-updated by the `maf-release-watcher` skill and GitHub Actions workflow.
+> It is referenced by `maf-doctor` MCP server tools (`maf_compatibility`) and auto-updated by the `maf-release-watcher` skill and GitHub Actions workflow.
 
 ---
 
@@ -82,4 +82,4 @@ When a new MAF version ships:
 
 ---
 
-*Maintained by maf-autopilot | See `.github/skills/maf-release-watcher/SKILL.md` for update process*
+*Maintained by maf-doctor | See `.github/skills/maf-release-watcher/SKILL.md` for update process*

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ Every document below is canonical for one slice of the project. **One concept, o
 
 | If you want to… | Read |
 |---|---|
-| Understand what `maf-autopilot` *is* and how the .NET projects fit together | [`architecture.md`](./architecture.md) |
+| Understand what `maf-doctor` *is* and how the .NET projects fit together | [`architecture.md`](./architecture.md) |
 | Look up MAF version ↔ dependency versions | [`compatibility-matrix.md`](./compatibility-matrix.md) |
 | Install + configure the toolkit | [`setup.md`](./setup.md) |
 | Install / run troubleshooting | [`/TROUBLESHOOTING.md`](../TROUBLESHOOTING.md) (repo root) |
@@ -25,7 +25,7 @@ Every document below is canonical for one slice of the project. **One concept, o
 
 ### 🏛️ [`architecture.md`](./architecture.md)
 
-**Purpose.** Component map. What is `maf-autopilot` vs `maf-autopilot.Analyzers` vs the two test projects? How do they relate? What does each one ship? Plus the multi-targeting strategy (`net8.0;net9.0;net10.0` nupkg + `Directory.Packages.props` CPM), and the rationale for the `/src/` layout and `.github/scripts/` placement (under "Structural decisions — closed").
+**Purpose.** Component map. What is `maf-doctor` vs `maf-doctor.Analyzers` vs the two test projects? How do they relate? What does each one ship? Plus the multi-targeting strategy (`net8.0;net9.0;net10.0` nupkg + `Directory.Packages.props` CPM), and the rationale for the `/src/` layout and `.github/scripts/` placement (under "Structural decisions — closed").
 
 **Status.** Current as of 2026-05-13 (Phase S landed).
 

--- a/docs/init-reference.md
+++ b/docs/init-reference.md
@@ -1,0 +1,43 @@
+# What `maf-doctor init` installs (and why)
+
+`maf-doctor init`, run from a repo root, makes that repo **MAF-aware** for whichever AI coding tool you use. It does two kinds of thing:
+
+1. **Wires the MCP server** into each tool's config, so the tool can call MAF Doctor's live tools/resources/prompts.
+2. **Drops steering** (instruction snippets) so the assistant *defers to those tools* for MAF work instead of its training data.
+
+It never touches your own hand-authored instruction files, and re-running it is safe — steering is **overwritten/refreshed**, MCP config is **merged**.
+
+```bash
+cd your-maf-project
+maf-doctor init                 # everything below
+maf-doctor init --with-cursor   # also the Cursor rule
+```
+
+## Files it writes
+
+| File | Ecosystem | Key / shape | On re-`init` | What it does |
+|---|---|---|---|---|
+| `.vscode/mcp.json` | **VS Code / Copilot** | `servers` → `{ "type": "stdio", "command": "maf-doctor" }` | **merged** (your other servers preserved) | Registers the MCP server so Copilot Chat gets live tool calls. |
+| `.mcp.json` | **Claude Code** | `mcpServers` → `{ "command": "maf-doctor" }` (no `type`) | **merged** | Same server, Claude Code's project-config format. |
+| `.github/instructions/maf-doctor.instructions.md` | **Copilot** | front-matter `applyTo: '**'` | **overwritten** | Auto-loaded steering: "for MAF code, call `MafDoctor` first, use the registry before fixing CS0618, prefer `MafAutoFixAll --dry-run`…". |
+| `.claude/maf-doctor.md` + one `@import` line in `CLAUDE.md` | **Claude Code** | sidecar file + import | sidecar **overwritten**; import added **once** | Same steering; Claude Code auto-loads `CLAUDE.md`, which pulls in the sidecar. Your own `CLAUDE.md` body is never edited. |
+| `AGENTS.md` | **agentskills.io tools** | `<!-- BEGIN maf-doctor -->…<!-- END maf-doctor -->` managed block | block **replaced in place** | Steering for tools that read `AGENTS.md`. Content outside the block is left alone. |
+| `.cursor/rules/maf-doctor.mdc` *(only with `--with-cursor`)* | **Cursor** | `.mdc` front-matter (`alwaysApply: true`) | **overwritten** | Cursor rules-dir steering. |
+
+**Why sidecars (not appends):** each tool auto-loads a *specific* file/dir. By owning a dedicated file in that location and overwriting it on every `init`, the guidance **refreshes** with the installed `maf-doctor` version, can never stack duplicates, and never collides with instructions you wrote yourself.
+
+## What it does **not** install
+
+- **The 12 skills** — they're embedded in the `maf-doctor` binary and served live at `maf://skills?name=<name>`; nothing is written to your repo (so they update when you `dotnet tool update`).
+- **The 7 specialist agents** (`@maf-auditor`, …) — these are GitHub-Copilot/Coding-Agent definitions that live in *this* toolkit's `.github/agents/`. `init` doesn't copy them; if you want the `@`-mention personas as files, use **Mode 2** (copy this repo's `.github/`). For most work you don't need them — the same workflows are exposed as MCP **prompts** (see [usage.md](./usage.md)).
+- **No edits to your own `copilot-instructions.md` / `CLAUDE.md` body.**
+
+## Safety / idempotency
+
+- **MCP config is merge-not-overwrite:** init parses your existing `mcp.json` / `.mcp.json` (JSONC-tolerant — `//` comments + trailing commas allowed), adds only the `maf-doctor` entry, and preserves every other server and top-level key. It also recognizes a legacy `maf-autopilot` server key so a repo configured by a pre-rename build isn't double-entered.
+- **Corruption-safe:** if an existing config can't be parsed, init backs it up to `*.bak.<timestamp>` before writing (and caps the read at 1 MB so a malformed file can't OOM the host).
+- **Re-runnable:** run `init` again any time to refresh the steering to the installed version — sidecars are rewritten, the `CLAUDE.md` import and `AGENTS.md` block are upserted, never duplicated.
+
+## After `init`
+
+Restart / reload your editor so it picks up the new MCP config, then drive MAF Doctor with the prompts, tools, and agents — see **[usage.md](./usage.md)**.

--- a/docs/mcp-security-hardening-best-practices.md
+++ b/docs/mcp-security-hardening-best-practices.md
@@ -2,7 +2,7 @@
 
 > **Audience:** authors and maintainers of Model Context Protocol (MCP) servers.
 >
-> **Source material:** distilled from the maf-autopilot v1.1 security hardening release (5 critical-tier + 11 high-tier closures + defense-in-depth + CI invariants — see [`CHANGELOG.md`](../CHANGELOG.md) for the closure list and [`docs/security/threat-model.md`](security/threat-model.md) for the threat surface map).
+> **Source material:** distilled from the maf-doctor v1.1 security hardening release (5 critical-tier + 11 high-tier closures + defense-in-depth + CI invariants — see [`CHANGELOG.md`](../CHANGELOG.md) for the closure list and [`docs/security/threat-model.md`](security/threat-model.md) for the threat surface map).
 >
 > **Last updated:** 2026-05-21. Anchored to the canonical sources in §10 — if any link rots, file an issue or open a PR.
 
@@ -606,7 +606,7 @@ jobs:
 
 ### 4.2 CI invariants — lock the code-side hardening in five jobs
 
-Beyond the external scanner, every code-side invariant from §2 should be enforced by a CI grep-guard. The maf-autopilot pattern is one workflow with five jobs:
+Beyond the external scanner, every code-side invariant from §2 should be enforced by a CI grep-guard. The maf-doctor pattern is one workflow with five jobs:
 
 | Job | What it locks |
 |---|---|
@@ -830,8 +830,8 @@ The complete source list, with one-line descriptions of what each names:
 
 ## See also
 
-- [`docs/security.md`](security.md) — the maf-autopilot user-facing security commitment (this playbook's reference implementation).
-- [`docs/security/threat-model.md`](security/threat-model.md) — the deeper technical record for maf-autopilot's specific threat surface.
+- [`docs/security.md`](security.md) — the maf-doctor user-facing security commitment (this playbook's reference implementation).
+- [`docs/security/threat-model.md`](security/threat-model.md) — the deeper technical record for maf-doctor's specific threat surface.
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — the contributor-facing security rubric + helper composition decision tree.
 - [`CHANGELOG.md`](../CHANGELOG.md) — the per-release closure list.
 - [`.github/workflows/ci-invariants.yml`](../.github/workflows/ci-invariants.yml) — the five-job CI invariant pattern in production.

--- a/docs/output-schemas.md
+++ b/docs/output-schemas.md
@@ -1,4 +1,4 @@
-# maf-autopilot output schemas
+# maf-doctor output schemas
 
 Tools that emit structured output document their schemas here. JSON outputs are stable within a major version (`schema_version` field tracks evolution).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -27,7 +27,7 @@ cd samples/maf-1.3-sample      # or: cd your-own-maf-project
 maf-doctor init
 ```
 
-`init` writes `.vscode/mcp.json` (wires the MCP server for your IDE) and `.github/copilot-instructions.md` (MAF hard-constraint rules), and drops the skills/agents bundle. Idempotent — safe to re-run.
+`init` wires the MCP server for VS Code (`.vscode/mcp.json`) and Claude Code (`.mcp.json`), and drops auto-loaded steering sidecars (Copilot / Claude / Cursor / AGENTS.md) — refreshed on re-run, never merged into your own files. The 12 skills are served by the MCP server, not written as files. Idempotent — safe to re-run. (details: [init-reference.md](./init-reference.md)).
 
 > 🎙️ *"`init` makes any repo MAF-aware: MCP config for the IDE, plus steering rules and 12 skills for Copilot's agent loop."*
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,4 +1,4 @@
-# Security — how MAF Doctor (`maf-autopilot`) is hardened
+# Security — how MAF Doctor (`maf-doctor`) is hardened
 
 > **Audience:** end users evaluating whether MAF Doctor is safe to install in their environment, and maintainers verifying mitigations stay in place.
 >
@@ -25,7 +25,7 @@
 
 | Mechanism | What it does | Where to verify |
 |---|---|---|
-| **Roslyn analyzer NuGet** | Ships as `maf-autopilot.Analyzers` (separate NuGet). 3 rules (`MAF001`, `MAF002`, `MAF003`) fire at write-time in the IDE — `MAF002` blocks `DefaultAzureCredential` in production code; `MAF003` blocks `EnableSensitiveData = true` outside tests | `src/maf-autopilot.Analyzers/*.cs` |
+| **Roslyn analyzer NuGet** | Ships as `maf-doctor.Analyzers` (separate NuGet). 3 rules (`MAF001`, `MAF002`, `MAF003`) fire at write-time in the IDE — `MAF002` blocks `DefaultAzureCredential` in production code; `MAF003` blocks `EnableSensitiveData = true` outside tests | `src/maf-autopilot.Analyzers/*.cs` |
 | **Multi-version regression CI** | Roslyn rewriters are run on pinned MAF 1.0 / 1.2 / 1.3 sample projects on every push — rewriter bugs that corrupt user code get caught before merge | `.github/workflows/*.yml` + `samples/maf-1.x-sample/` |
 | **`verify-registry` PR gate** | The AI-fill maintenance loop (release-watcher → Copilot Coding Agent → PR) is gated by a structural verifier — placeholders, broken examples, missing fields are caught before the PR can merge | `.github/workflows/maf-ai-fill-verify.yml` + `src/maf-autopilot/Commands/VerifyRegistryCommand.cs` |
 | **MIT-licensed, source-available** | All 25 tools, the analyzer, the rewriters, the registry — readable in the repo. No closed-source binaries shipped in the nupkg | `LICENSE` |

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,8 +1,8 @@
-# maf-autopilot threat model (v1.0.0)
+# maf-doctor threat model (v1.0.0)
 
-> **Audience:** users deciding whether to install maf-autopilot in a security-sensitive context. Maintainers verifying mitigations are in place.
+> **Audience:** users deciding whether to install maf-doctor in a security-sensitive context. Maintainers verifying mitigations are in place.
 >
-> **Scope:** what maf-autopilot reads, what it writes, what attack surfaces exist, what we mitigate, what we don't.
+> **Scope:** what maf-doctor reads, what it writes, what attack surfaces exist, what we mitigate, what we don't.
 
 ## 1. Data read
 
@@ -22,7 +22,7 @@
 | `.cs` files in user repo (rewriters) | `--dry-run` default opt-in; explicit `dryRun: false` to write |
 | Generated scaffolds (`Agents/*.cs`, `Workflows/*Executor.cs`) | Idempotent — skips existing files; logs `already exists` |
 | `.vscode/mcp.json` (via `init`) | User invokes `init` deliberately |
-| `.github/copilot-instructions.md`, `CLAUDE.md`, `AGENTS.md` (via `init`) | Merge-not-overwrite; existing files appended only if maf-autopilot section is absent |
+| Steering sidecars (via `init`): `.github/instructions/maf-doctor.instructions.md`, `.claude/maf-doctor.md` + a one-line `CLAUDE.md` import, `AGENTS.md` managed block | Overwrite-on-reinit sidecars only; init never merges into the user's own instruction files |
 | Embedded registry path | Not writable from MCP tools — registry maintenance is via `registry-extract` + AI-fill PR-flow |
 
 ## 3. Attack surfaces
@@ -63,7 +63,7 @@ A Roslyn rewriter bug could corrupt user `.cs` files. **Mitigations** (strengthe
 
 ### 3.5 `dotnet build` shell-out
 
-`MafRunCs0618Hunt` shells `dotnet build`, which executes the user's project file. If the project has malicious MSBuild targets, those run. **Acceptable, but explicitly annotated** (v1.1) — `[McpServerTool(ReadOnly = false, OpenWorld = true)]` so MCP-spec-compliant clients prompt the user for consent before invoking. The tool description warns about untrusted repos. Users running maf-autopilot on untrusted projects should sandbox the process.
+`MafRunCs0618Hunt` shells `dotnet build`, which executes the user's project file. If the project has malicious MSBuild targets, those run. **Acceptable, but explicitly annotated** (v1.1) — `[McpServerTool(ReadOnly = false, OpenWorld = true)]` so MCP-spec-compliant clients prompt the user for consent before invoking. The tool description warns about untrusted repos. Users running maf-doctor on untrusted projects should sandbox the process.
 
 ### 3.6 Type-expression input in `MafNewExecutor`
 
@@ -130,7 +130,7 @@ All third-party GitHub Actions are SHA-pinned (9 distinct actions × 23 call sit
 
 ## 5. Acknowledged residual gaps after 1.1
 
-- ❌ **No sandbox around `dotnet build`** — `MafRunCs0618Hunt` now correctly annotated `ReadOnly=false, OpenWorld=true` so MCP-spec-compliant clients prompt before invoking. True OS sandboxing remains out of scope for an OSS .NET CLI. Users running maf-autopilot on untrusted repos should sandbox externally (devcontainer, AppArmor, etc.).
+- ❌ **No sandbox around `dotnet build`** — `MafRunCs0618Hunt` now correctly annotated `ReadOnly=false, OpenWorld=true` so MCP-spec-compliant clients prompt before invoking. True OS sandboxing remains out of scope for an OSS .NET CLI. Users running maf-doctor on untrusted repos should sandbox externally (devcontainer, AppArmor, etc.).
 - ❌ **Direct-to-main commits by `maf-release-watcher.yml`** — intentional design tradeoff documented at watcher line 249 (dated 2026-05-12). Acceptable for solo-maintainer state; revisit if external maintainers join.
 - ❌ **Rewriter pure-syntax matching** — `DefaultAzureCredentialRewriter`/`FanInArgOrderRewriter` semantic-model upgrade deferred to v1.2.x (significant refactor; bounded by `--dry-run` default + idempotence tests).
 - ❌ **`ProcessRunner` env scrubbing + streaming output cap** — deferred to v1.2.x. 5 MB post-allocation cap remains.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -91,8 +91,11 @@ maf-doctor init
 ```
 
 `maf-doctor init` will:
-- Add the MCP server entry to `.vscode/mcp.json` (idempotent — safe to re-run)
-- Write `.github/copilot-instructions.md` with the MAF hard constraint rules (skips if already exists)
+- Wire the MCP server for **VS Code** (`.vscode/mcp.json`) and **Claude Code** (`.mcp.json`) — idempotent, safe to re-run
+- Write overwrite-on-reinit steering **sidecars** (never merged into your own instruction files): `.github/instructions/maf-doctor.instructions.md` (Copilot), `.claude/maf-doctor.md` + a one-line `@import` in `CLAUDE.md` and an `AGENTS.md` managed block (Claude Code / AGENTS-aware tools)
+- With `--with-cursor`: also write `.cursor/rules/maf-doctor.mdc`
+
+See [init-reference.md](./init-reference.md) for exactly what's written and why.
 
 **Then open VS Code** — the MCP server starts automatically.
 

--- a/docs/steering/README.md
+++ b/docs/steering/README.md
@@ -6,15 +6,16 @@ different convention:
 
 | File | Paste into | Auto-loaded by |
 |---|---|---|
-| `copilot-instructions.md` | `.github/copilot-instructions.md` | GitHub Copilot (VS Code / Web / CLI) |
+| `copilot-instructions.md` | `.github/instructions/maf-doctor.instructions.md` | GitHub Copilot (VS Code / Web / CLI) |
 | `claude-instructions.md` | `./CLAUDE.md` (or `.claude/instructions.md`) | Claude Code |
 | `agents.md` | `./AGENTS.md` | Cursor + any agentskills.io-respecting tool |
 | `cursor-rules.md` | `./.cursorrules` | Cursor (alternative format) |
 
 `maf-doctor init` drops these into your repo automatically (and wires the MCP
 server into both `.vscode/mcp.json` for VS Code/Copilot and `.mcp.json` for
-Claude Code). If you already have these files, init *merges* — it appends the
-MAF Doctor steering section rather than overwriting.
+Claude Code). These are managed **sidecars**: init *overwrites* them on every
+re-run (and upserts the one-line `CLAUDE.md` import + `AGENTS.md` managed block)
+rather than merging into — or ever editing — your own instruction files.
 
 If you use multiple AI assistants, keep all three files — they don't
 collide.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,86 @@
+# Using MAF Doctor — prompts, tools, agents, and natural language
+
+After `maf-doctor init` (see [init-reference.md](./init-reference.md)) and an editor restart, there are three ways to drive the toolkit. Pick whichever fits the moment — they all hit the same engine.
+
+| Way | Looks like | When |
+|---|---|---|
+| **Just ask** (natural language) | "Is `AgentThread` still safe? If not, fix it." | Default — the steering makes your assistant call the right tools for you. |
+| **Slash-prompts** (MCP prompts) | `/maf-audit`, `/maf-migrate` | Kick off a structured workflow with one command. |
+| **CLI** | `maf-doctor doctor .` | Scripts, CI, or when you're not in a chat. |
+
+## 1. Natural language — the main mode
+
+`init` dropped steering into your repo that tells the assistant: *for any MAF question or change, defer to the MAF Doctor tools over training data, because MAF ships breaking changes every minor version.* So you don't have to name tools — just describe the intent:
+
+- *"Audit this repo for MAF problems and write me a migration plan."* → calls `MafScanAntiPatterns`, the registry, `MafDoctor`.
+- *"Is `EnableSensitiveData = true` OK here?"* → `MafApiSafety` / `MafScanAntiPatterns`.
+- *"Upgrade me to the latest MAF and fix what breaks."* → `MafPreUpgradeDryRun`, build, `MafAutoFixAll`, the migration guide.
+- *"Does this workflow actually produce output, or does it silently starve?"* → `MafValidateFanOut` / `MafSimulateWorkflow`.
+- *"Fix the obsolete-API warnings."* → `MafRunCs0618Hunt` → registry fix recipes.
+
+If the assistant *doesn't* reach for the tools, it usually means the MCP server isn't connected — reload the editor, and confirm `maf-doctor` shows up (`/mcp` in Claude Code; the MCP panel in VS Code).
+
+## 2. MCP prompts — structured starters (`/…`)
+
+Prompts are pre-built workflows the server exposes; your client surfaces them as slash-commands (type `/` and look for the `maf-doctor` entries). Each one *is* the matching specialist persona delivered inline — no agent files needed.
+
+| Prompt | Does | ≈ agent |
+|---|---|---|
+| `maf-audit` | Scan a codebase, cross-reference constraints + registry, emit a tracked `migration-plan.md` | `@maf-auditor` |
+| `maf-migrate` | Execute migration tasks from a plan, build-verified per step | `@maf-migration` |
+| `maf-cs0618-hunt` | Find + fix every CS0618 obsolete-API usage | — |
+| `maf-review` | Best-practice review of already-migrated code | `@maf-best-practice-reviewer` |
+| `maf-debug` | Diagnose a MAF failure → root cause + fix | `@maf-incident-responder` |
+| `maf-scaffold` | Generate clean agent/executor boilerplate | — |
+| `maf-help` | Triage: where are you, what do you need? | `@maf-onboarding` |
+
+## 3. MCP tools — called for you
+
+The server exposes a couple dozen executable tools, each annotated read-only / destructive / idempotent so clients can classify them. You rarely call them by name — the assistant does, driven by your request. Grouped:
+
+- **Is this safe?** — `MafApiSafety`, `MafRegistryLookup`, `MafListRegistry`
+- **Scan code** — `MafScanAntiPatterns`, `MafValidateFanOut`, `MafLintAgentPrompt`, `MafEstimateCost`
+- **Compiler ground-truth** — `MafRunCs0618Hunt`
+- **Upgrade / diff** — `MafDiffPackage`, `MafPreUpgradeDryRun`, `MafMigrationPath`, `MafScoreMigrationRisk`, `MafGenerateRegressionPlan`
+- **Workflow topology** — `MafSimulateWorkflow` (+ Mermaid)
+- **Scaffold** — `MafNewAgent`, `MafNewExecutor`
+- **Fix** — `MafAutoFix`, `MafAutoFixAll` (both support `dryRun`)
+- **Report** — `MafDoctor` (A/B/C/F health letter), `MafAuditPullRequest`, `MafExplain`, `MafBeforeAfter`, `MafCompatibility`, `MafDraftIssue`
+
+> **Live catalogue:** ask the assistant to run **`MafTour`**, or read the **`maf://rules`** resource — both are generated from the actual code, so they never drift.
+
+## 4. MCP resources — the knowledge base (`maf://…`)
+
+Readable on demand; the assistant pulls them when relevant:
+
+| URI | Contents |
+|---|---|
+| `maf://guide` | Full migration reference guide |
+| `maf://constraints` | Hard constraints (read before any migration) |
+| `maf://registry` | Obsolete-API registry (CS0618 → exact fix) |
+| `maf://rules` | Live catalogue of every scanner + analyzer rule |
+| `maf://help` | How to use the toolkit |
+| `maf://skills?name=<name>` | Any of the 12 bundled skills |
+
+## 5. Specialist agents (`@…`)
+
+Seven persona agents live in this toolkit's `.github/agents/`: `@maf` (triage), `@maf-auditor`, `@maf-best-practice-reviewer`, `@maf-migration`, `@maf-incident-responder`, `@maf-onboarding`, `@maf-rollback`. They're richer, persistent personas you can `@`-mention mid-conversation.
+
+`init` does **not** install them (see [init-reference.md](./init-reference.md)); to get the `@`-mention versions, copy this repo's `.github/` into your project (**Mode 2** in the README). For most tasks the MCP **prompts** above deliver the same workflows with nothing to install.
+
+## 6. CLI commands
+
+The same binary, with a subcommand, runs as a CLI (no chat needed):
+
+```bash
+maf-doctor doctor [path] [--exclude <s>]…   # A/B/C/F health report
+maf-doctor autofix-all [path] [--dry-run]   # apply deterministic Roslyn fixes
+maf-doctor new agent <Name>                 # scaffold an agent + smoke test
+maf-doctor new executor <Name> [In] [Out]   # scaffold a workflow executor
+maf-doctor init [--with-cursor]             # wire MCP + steering into a repo
+maf-doctor badge [path]                     # shields.io health-badge JSON
+maf-doctor verify-registry                  # validate the registry (CI gate)
+maf-doctor --version | --help               # version / usage
+```
+
+With **no** subcommand, the binary runs as the MCP server over stdio — that's what your editor launches.

--- a/samples/maf-1.0-sample/Agents/IntakeAgent.cs
+++ b/samples/maf-1.0-sample/Agents/IntakeAgent.cs
@@ -2,7 +2,7 @@
 //
 // ⚠️ Note on the "top-level Instructions" anti-pattern:
 //
-// The maf-autopilot registry entry MAF130-INSTRUCTIONS-001 documents a
+// The maf-doctor registry entry MAF130-INSTRUCTIONS-001 documents a
 // "silently ignored Instructions property at the top of ChatClientAgentOptions."
 // **This property does not exist on ChatClientAgentOptions in MAF 1.3.0 GA.**
 // It was REMOVED outright, not just made [Obsolete]. So the anti-pattern as

--- a/samples/maf-1.0-sample/ChatClientFactory.cs
+++ b/samples/maf-1.0-sample/ChatClientFactory.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //
 // ⚠️ THIS FILE CONTAINS DELIBERATE ANTI-PATTERNS — DO NOT COPY INTO PRODUCTION.
-// It exists to give the maf-autopilot migration toolkit something to find.
+// It exists to give the maf-doctor migration toolkit something to find.
 //
 // Triggers:
 //   - MAF-AP-SEC-001 / MAF002 — DefaultAzureCredential in production code
@@ -19,7 +19,7 @@ namespace MafSample.FraudClaims;
 public static class ChatClientFactory
 {
     // MAF-AP-SEC-002 — hard-coded "api-key=" literal (placeholder, NOT real).
-    // The maf-autopilot scanner flags this on regex; the real fix is to load
+    // The maf-doctor scanner flags this on regex; the real fix is to load
     // from configuration or Key Vault, never inline.
     private const string FALLBACK_KEY = "api-key=sk-FAKEPLACEHOLDERkey1234567890abcdef";
 

--- a/samples/maf-1.0-sample/Config.cs
+++ b/samples/maf-1.0-sample/Config.cs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 maf-autopilot sample.
+// Copyright (c) 2026 maf-doctor sample.
 
 using Azure;
 

--- a/samples/maf-1.0-sample/Program.cs
+++ b/samples/maf-1.0-sample/Program.cs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 maf-autopilot sample.
+// Copyright (c) 2026 maf-doctor sample.
 //
 // FraudClaimsTriage — a multi-agent MAF 1.3.0 workflow that deliberately
-// embeds the 1.3-era anti-patterns the maf-autopilot toolkit was built to find
+// embeds the 1.3-era anti-patterns the maf-doctor toolkit was built to find
 // and fix. Pinned to MAF 1.3.0 exactly so the migration toolkit can be
 // dogfooded end-to-end (Phase T → A.8 unblocker).
 //
@@ -33,7 +33,7 @@ if (dryRun)
     Console.WriteLine();
 }
 
-// Build the chat client even in dry-run mode — the maf-autopilot scanners
+// Build the chat client even in dry-run mode — the maf-doctor scanners
 // inspect the SOURCE not the runtime, and we want the construction code path
 // to be present and discoverable by the scanner.
 var chatClient = ChatClientFactory.CreateChatClient();
@@ -83,7 +83,7 @@ static void PrintBanner()
     Console.ForegroundColor = ConsoleColor.Cyan;
     Console.WriteLine("  ╔══════════════════════════════════════════════════════════════════════╗");
     Console.WriteLine("  ║   MAF 1.3.0 FraudClaimsTriage Sample — Migration Dogfood Fixture     ║");
-    Console.WriteLine("  ║   Deliberate anti-patterns; consumed by the maf-autopilot toolkit    ║");
+    Console.WriteLine("  ║   Deliberate anti-patterns; consumed by the maf-doctor toolkit       ║");
     Console.WriteLine("  ╚══════════════════════════════════════════════════════════════════════╝");
     Console.ResetColor();
     Console.WriteLine();

--- a/samples/maf-1.0-sample/README.md
+++ b/samples/maf-1.0-sample/README.md
@@ -8,7 +8,7 @@
 ║   This codebase is a DELIBERATE collection of MAF anti-patterns, pinned to   ║
 ║   MAF 1.0.0 (the EARLIEST stable release). Every "broken" pattern is on      ║
 ║   purpose. Do NOT copy any of this code into a real project — it's bait for  ║
-║   the maf-autopilot toolkit to find and fix.                                 ║
+║   the maf-doctor toolkit to find and fix.                                    ║
 ║                                                                              ║
 ║   This is the third in a 3-version sample set (1.0 / 1.2 / 1.3). The set     ║
 ║   pins the toolkit's detection across the full MAF NuGet history via W.9's   ║

--- a/samples/maf-1.0-sample/Workflows/FraudClaimsWorkflow.cs
+++ b/samples/maf-1.0-sample/Workflows/FraudClaimsWorkflow.cs
@@ -43,7 +43,7 @@ public static class FraudClaimsWorkflow
 
         // ⚠️ MAF130-FAN-IN-001 — OBSOLETE overload (target first, sources second).
         // The compiler emits CS0618 here. We intentionally let the warning flow
-        // through (no #pragma suppression) so the maf-autopilot CS0618 hunter
+        // through (no #pragma suppression) so the maf-doctor CS0618 hunter
         // (`MafRunCs0618Hunt`) can find this exact call site.
         // The corrected pattern would be:
         //   builder.AddFanInBarrierEdge(new ExecutorBinding[] { osint, history, transactions }, aggregator);

--- a/samples/maf-1.2-sample/Agents/IntakeAgent.cs
+++ b/samples/maf-1.2-sample/Agents/IntakeAgent.cs
@@ -2,7 +2,7 @@
 //
 // ⚠️ Note on the "top-level Instructions" anti-pattern:
 //
-// The maf-autopilot registry entry MAF130-INSTRUCTIONS-001 documents a
+// The maf-doctor registry entry MAF130-INSTRUCTIONS-001 documents a
 // "silently ignored Instructions property at the top of ChatClientAgentOptions."
 // **This property does not exist on ChatClientAgentOptions in MAF 1.3.0 GA.**
 // It was REMOVED outright, not just made [Obsolete]. So the anti-pattern as

--- a/samples/maf-1.2-sample/ChatClientFactory.cs
+++ b/samples/maf-1.2-sample/ChatClientFactory.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //
 // ⚠️ THIS FILE CONTAINS DELIBERATE ANTI-PATTERNS — DO NOT COPY INTO PRODUCTION.
-// It exists to give the maf-autopilot migration toolkit something to find.
+// It exists to give the maf-doctor migration toolkit something to find.
 //
 // Triggers:
 //   - MAF-AP-SEC-001 / MAF002 — DefaultAzureCredential in production code
@@ -19,7 +19,7 @@ namespace MafSample.FraudClaims;
 public static class ChatClientFactory
 {
     // MAF-AP-SEC-002 — hard-coded "api-key=" literal (placeholder, NOT real).
-    // The maf-autopilot scanner flags this on regex; the real fix is to load
+    // The maf-doctor scanner flags this on regex; the real fix is to load
     // from configuration or Key Vault, never inline.
     private const string FALLBACK_KEY = "api-key=sk-FAKEPLACEHOLDERkey1234567890abcdef";
 

--- a/samples/maf-1.2-sample/Config.cs
+++ b/samples/maf-1.2-sample/Config.cs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 maf-autopilot sample.
+// Copyright (c) 2026 maf-doctor sample.
 
 using Azure;
 

--- a/samples/maf-1.2-sample/Program.cs
+++ b/samples/maf-1.2-sample/Program.cs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 maf-autopilot sample.
+// Copyright (c) 2026 maf-doctor sample.
 //
 // FraudClaimsTriage — a multi-agent MAF 1.3.0 workflow that deliberately
-// embeds the 1.3-era anti-patterns the maf-autopilot toolkit was built to find
+// embeds the 1.3-era anti-patterns the maf-doctor toolkit was built to find
 // and fix. Pinned to MAF 1.3.0 exactly so the migration toolkit can be
 // dogfooded end-to-end (Phase T → A.8 unblocker).
 //
@@ -33,7 +33,7 @@ if (dryRun)
     Console.WriteLine();
 }
 
-// Build the chat client even in dry-run mode — the maf-autopilot scanners
+// Build the chat client even in dry-run mode — the maf-doctor scanners
 // inspect the SOURCE not the runtime, and we want the construction code path
 // to be present and discoverable by the scanner.
 var chatClient = ChatClientFactory.CreateChatClient();
@@ -83,7 +83,7 @@ static void PrintBanner()
     Console.ForegroundColor = ConsoleColor.Cyan;
     Console.WriteLine("  ╔══════════════════════════════════════════════════════════════════════╗");
     Console.WriteLine("  ║   MAF 1.3.0 FraudClaimsTriage Sample — Migration Dogfood Fixture     ║");
-    Console.WriteLine("  ║   Deliberate anti-patterns; consumed by the maf-autopilot toolkit    ║");
+    Console.WriteLine("  ║   Deliberate anti-patterns; consumed by the maf-doctor toolkit       ║");
     Console.WriteLine("  ╚══════════════════════════════════════════════════════════════════════╝");
     Console.ResetColor();
     Console.WriteLine();

--- a/samples/maf-1.2-sample/README.md
+++ b/samples/maf-1.2-sample/README.md
@@ -8,7 +8,7 @@
 ║   This codebase is a DELIBERATE collection of MAF anti-patterns, pinned to   ║
 ║   MAF 1.2.0 (the version BEFORE the 1.3 obsoletion wave). Every "broken"     ║
 ║   pattern is on purpose. Do NOT copy any of this code into a real project    ║
-║   — it's bait for the maf-autopilot toolkit to find and fix.                 ║
+║   — it's bait for the maf-doctor toolkit to find and fix.                    ║
 ║                                                                              ║
 ║   This sample exists alongside maf-1.3-sample/ and maf-1.0-sample/ as a      ║
 ║   version-parity fixture: same anti-patterns, different MAF pin, so the      ║

--- a/samples/maf-1.2-sample/Workflows/FraudClaimsWorkflow.cs
+++ b/samples/maf-1.2-sample/Workflows/FraudClaimsWorkflow.cs
@@ -43,7 +43,7 @@ public static class FraudClaimsWorkflow
 
         // ⚠️ MAF130-FAN-IN-001 — OBSOLETE overload (target first, sources second).
         // The compiler emits CS0618 here. We intentionally let the warning flow
-        // through (no #pragma suppression) so the maf-autopilot CS0618 hunter
+        // through (no #pragma suppression) so the maf-doctor CS0618 hunter
         // (`MafRunCs0618Hunt`) can find this exact call site.
         // The corrected pattern would be:
         //   builder.AddFanInBarrierEdge(new ExecutorBinding[] { osint, history, transactions }, aggregator);

--- a/samples/maf-1.3-sample/Agents/IntakeAgent.cs
+++ b/samples/maf-1.3-sample/Agents/IntakeAgent.cs
@@ -2,7 +2,7 @@
 //
 // ⚠️ Note on the "top-level Instructions" anti-pattern:
 //
-// The maf-autopilot registry entry MAF130-INSTRUCTIONS-001 documents a
+// The maf-doctor registry entry MAF130-INSTRUCTIONS-001 documents a
 // "silently ignored Instructions property at the top of ChatClientAgentOptions."
 // **This property does not exist on ChatClientAgentOptions in MAF 1.3.0 GA.**
 // It was REMOVED outright, not just made [Obsolete]. So the anti-pattern as

--- a/samples/maf-1.3-sample/ChatClientFactory.cs
+++ b/samples/maf-1.3-sample/ChatClientFactory.cs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 //
 // ⚠️ THIS FILE CONTAINS DELIBERATE ANTI-PATTERNS — DO NOT COPY INTO PRODUCTION.
-// It exists to give the maf-autopilot migration toolkit something to find.
+// It exists to give the maf-doctor migration toolkit something to find.
 //
 // Triggers:
 //   - MAF-AP-SEC-001 / MAF002 — DefaultAzureCredential in production code
@@ -19,7 +19,7 @@ namespace MafSample.FraudClaims;
 public static class ChatClientFactory
 {
     // MAF-AP-SEC-002 — hard-coded "api-key=" literal (placeholder, NOT real).
-    // The maf-autopilot scanner flags this on regex; the real fix is to load
+    // The maf-doctor scanner flags this on regex; the real fix is to load
     // from configuration or Key Vault, never inline.
     private const string FALLBACK_KEY = "api-key=sk-FAKEPLACEHOLDERkey1234567890abcdef";
 

--- a/samples/maf-1.3-sample/Config.cs
+++ b/samples/maf-1.3-sample/Config.cs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 maf-autopilot sample.
+// Copyright (c) 2026 maf-doctor sample.
 
 using Azure;
 

--- a/samples/maf-1.3-sample/MafSample.FraudClaims.csproj
+++ b/samples/maf-1.3-sample/MafSample.FraudClaims.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <!-- MAF 1.3.0 — fixed pin. This sample is the "stuck on 1.3.0" customer
-         codebase that the maf-autopilot migration toolkit is supposed to
+         codebase that the maf-doctor migration toolkit is supposed to
          help upgrade. -->
     <PackageReference Include="Microsoft.Agents.AI" Version="1.3.0" />
     <PackageReference Include="Microsoft.Agents.AI.Workflows" Version="1.3.0" />
@@ -53,7 +53,7 @@
          so the analyzer doesn't leak to anything that consumes this sample
          project (it's not consumed by anything — it's a fixture — but
          setting PrivateAssets is the canonical pattern). -->
-    <PackageReference Include="maf-autopilot.Analyzers" Version="1.3.0-alpha-1">
+    <PackageReference Include="maf-doctor.Analyzers" Version="1.3.0-alpha-1">
       <IncludeAssets>analyzers; build</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/samples/maf-1.3-sample/Program.cs
+++ b/samples/maf-1.3-sample/Program.cs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
-// Copyright (c) 2026 maf-autopilot sample.
+// Copyright (c) 2026 maf-doctor sample.
 //
 // FraudClaimsTriage — a multi-agent MAF 1.3.0 workflow that deliberately
-// embeds the 1.3-era anti-patterns the maf-autopilot toolkit was built to find
+// embeds the 1.3-era anti-patterns the maf-doctor toolkit was built to find
 // and fix. Pinned to MAF 1.3.0 exactly so the migration toolkit can be
 // dogfooded end-to-end (Phase T → A.8 unblocker).
 //
@@ -33,7 +33,7 @@ if (dryRun)
     Console.WriteLine();
 }
 
-// Build the chat client even in dry-run mode — the maf-autopilot scanners
+// Build the chat client even in dry-run mode — the maf-doctor scanners
 // inspect the SOURCE not the runtime, and we want the construction code path
 // to be present and discoverable by the scanner.
 var chatClient = ChatClientFactory.CreateChatClient();
@@ -83,7 +83,7 @@ static void PrintBanner()
     Console.ForegroundColor = ConsoleColor.Cyan;
     Console.WriteLine("  ╔══════════════════════════════════════════════════════════════════════╗");
     Console.WriteLine("  ║   MAF 1.3.0 FraudClaimsTriage Sample — Migration Dogfood Fixture     ║");
-    Console.WriteLine("  ║   Deliberate anti-patterns; consumed by the maf-autopilot toolkit    ║");
+    Console.WriteLine("  ║   Deliberate anti-patterns; consumed by the maf-doctor toolkit       ║");
     Console.WriteLine("  ╚══════════════════════════════════════════════════════════════════════╝");
     Console.ResetColor();
     Console.WriteLine();

--- a/samples/maf-1.3-sample/README.md
+++ b/samples/maf-1.3-sample/README.md
@@ -7,7 +7,7 @@
 ║                                                                              ║
 ║   This codebase is a DELIBERATE collection of MAF 1.3 anti-patterns.         ║
 ║   Every "broken" pattern here is on purpose. Do NOT copy any of this code    ║
-║   into a real project — it's bait for the maf-autopilot toolkit to find      ║
+║   into a real project — it's bait for the maf-doctor toolkit to find         ║
 ║   and fix. The toolkit's job is to detect, plan, and remediate every one     ║
 ║   of the anti-patterns embedded below.                                       ║
 ║                                                                              ║
@@ -18,18 +18,18 @@
 ```
 
 A small but realistic multi-agent **Microsoft Agent Framework 1.3.0** codebase
-that deliberately embeds anti-patterns the `maf-autopilot` toolkit was built to
+that deliberately embeds anti-patterns the `maf-doctor` toolkit was built to
 find. Used as **Phase T — the A.8 migration-dogfood unblocker**.
 
 **Want a guided run?** See [`samples/workshop.md`](../workshop.md) — a ~50-minute
 hands-on walkthrough that opens this sample standalone in VS Code Insiders,
-wires up the `maf-autopilot` MCP server, and exercises the toolkit
+wires up the `maf-doctor` MCP server, and exercises the toolkit
 end-to-end.
 
 This sample:
 
 - **Pins MAF 1.3.0 exactly** (not `>= 1.3.0`) so the surface stays stable.
-- **Targets `net8.0`** — the lowest TFM `maf-autopilot` now supports. A real
+- **Targets `net8.0`** — the lowest TFM `maf-doctor` now supports. A real
   customer with an aged codebase is the realistic Phase T fixture.
 - **Builds clean** with one expected `CS0618` warning (the obsolete fan-in
   edge — see below).
@@ -61,7 +61,7 @@ reject; the notifier dispatches.
 
 ## Embedded anti-patterns
 
-The sample triggers the maf-autopilot toolkit on **10 anti-pattern errors,
+The sample triggers the maf-doctor toolkit on **10 anti-pattern errors,
 3 warnings, and 3 silent-starvation risks** in `dotnet run --project
 src/maf-autopilot -- doctor samples/maf-1.3-sample` (grade: F).
 
@@ -85,7 +85,7 @@ src/maf-autopilot -- doctor samples/maf-1.3-sample` (grade: F).
 ### Dry-run (default) — no LLM call, ~150 ms
 
 ```bash
-# from the maf-autopilot repo root
+# from the maf-doctor repo root
 dotnet build samples/maf-1.3-sample/MafSample.FraudClaims.csproj
 dotnet run --project samples/maf-1.3-sample/MafSample.FraudClaims.csproj
 ```
@@ -106,7 +106,7 @@ dotnet run --project samples/maf-1.3-sample/MafSample.FraudClaims.csproj -- --ru
 `--run` is currently a stub — the sample is meant to exercise the migration
 toolkit on the **source** not at runtime.
 
-### Have the maf-autopilot toolkit audit it
+### Have the maf-doctor toolkit audit it
 
 ```bash
 # Doctor — A through F grade + per-tool detail pointers

--- a/samples/maf-1.3-sample/Workflows/FraudClaimsWorkflow.cs
+++ b/samples/maf-1.3-sample/Workflows/FraudClaimsWorkflow.cs
@@ -43,7 +43,7 @@ public static class FraudClaimsWorkflow
 
         // ⚠️ MAF130-FAN-IN-001 — OBSOLETE overload (target first, sources second).
         // The compiler emits CS0618 here. We intentionally let the warning flow
-        // through (no #pragma suppression) so the maf-autopilot CS0618 hunter
+        // through (no #pragma suppression) so the maf-doctor CS0618 hunter
         // (`MafRunCs0618Hunt`) can find this exact call site.
         // The corrected pattern would be:
         //   builder.AddFanInBarrierEdge(new ExecutorBinding[] { osint, history, transactions }, aggregator);

--- a/samples/workshop.md
+++ b/samples/workshop.md
@@ -1,4 +1,4 @@
-# maf-autopilot Workshop — From Zero to Migrated Codebase
+# maf-doctor Workshop — From Zero to Migrated Codebase
 
 > **Four entry points:**
 >
@@ -32,10 +32,10 @@ It finds them in ~850 ms. See the [answer key](./find-the-bug/answer-key.md) for
 
 ## What is this? (the 30-second preamble)
 
-You're looking at a workshop for **maf-autopilot** — an AI co-pilot toolkit for the **Microsoft Agent Framework (MAF)**. Three concepts:
+You're looking at a workshop for **maf-doctor** — an AI co-pilot toolkit for the **Microsoft Agent Framework (MAF)**. Three concepts:
 
 - **MAF** is Microsoft's .NET framework for building multi-agent AI workflows (agents that talk to each other, plus a workflow runtime that orchestrates them). Current stable: 1.3.0; previews up to 1.5.0.
-- **maf-autopilot** is a toolkit (MCP server + Roslyn analyzer NuGet + GitHub Copilot agents + skills) that **audits** MAF code for the silent-failure patterns that compile clean but break at runtime, AND **auto-fixes** the mechanical issues without an LLM in the loop.
+- **maf-doctor** is a toolkit (MCP server + Roslyn analyzer NuGet + GitHub Copilot agents + skills) that **audits** MAF code for the silent-failure patterns that compile clean but break at runtime, AND **auto-fixes** the mechanical issues without an LLM in the loop.
 - **`samples/maf-1.3-sample/`** is a deliberately-broken FraudClaimsTriage workflow we use to dogfood the toolkit. Every "broken" pattern is on purpose — the workshop walks you through finding + fixing all of them.
 
 **Why a workshop instead of a README:** the toolkit's value is invisible until you watch it find a bug nobody else catches. The workshop is "show, don't tell."
@@ -58,7 +58,7 @@ You need exactly two things:
 # 1. .NET 8 SDK or later — check:
 dotnet --version          # should print 8.x, 9.x, or 10.x
 
-# 2. The maf-autopilot global tool:
+# 2. The maf-doctor global tool:
 dotnet tool install -g maf-doctor
 
 # Verify:
@@ -69,7 +69,7 @@ If you don't have a clone of this repo handy, also:
 
 ```bash
 git clone https://github.com/joslat/maf-doctor
-cd maf-autopilot
+cd maf-doctor
 ```
 
 ### The 6-beat speedrun (~5 minutes)
@@ -112,7 +112,7 @@ git restore samples/maf-1.3-sample/
 
 > **Audience:** workshop attendees + maintainers running the toolkit end-to-end on a real MAF 1.3.0 codebase. Covers the agent-driven flow (`@maf-auditor` / `@maf-migration`), the multi-agent surface, and the post-migration tooling.
 >
-> **What you'll do:** open the `maf-1.3-sample/` codebase standalone in VS Code Insiders, wire up the `maf-autopilot` MCP server, walk through each of the 22 MCP tools at least once, run the full migration loop, and finish with a multi-version regression plan.
+> **What you'll do:** open the `maf-1.3-sample/` codebase standalone in VS Code Insiders, wire up the `maf-doctor` MCP server, walk through each of the 22 MCP tools at least once, run the full migration loop, and finish with a multi-version regression plan.
 
 ### Prerequisites
 
@@ -121,7 +121,7 @@ git restore samples/maf-1.3-sample/
 | **VS Code Insiders** (or stable) | MCP server + Copilot Chat client | https://code.visualstudio.com/insiders/ |
 | **GitHub Copilot subscription** | needed to use `@maf-*` agents and `/maf-*` prompts | any Copilot tier |
 | **.NET 8 SDK or later** | builds the sample (sample targets `net8.0`) | https://dotnet.microsoft.com/download |
-| **`maf-autopilot` global tool** | the MCP server itself | `dotnet tool install -g maf-doctor` |
+| **`maf-doctor` global tool** | the MCP server itself | `dotnet tool install -g maf-doctor` |
 | _(optional)_ Azure OpenAI deployment | only needed for `--run` mode of the sample; not needed for the workshop | https://portal.azure.com |
 
 Verify the tool is on PATH — install only if missing:
@@ -129,18 +129,18 @@ Verify the tool is on PATH — install only if missing:
 **bash / zsh:**
 
 ```bash
-if ! command -v maf-autopilot >/dev/null 2>&1; then
+if ! command -v maf-doctor >/dev/null 2>&1; then
   dotnet tool install -g maf-doctor
   # If PATH still misses after install: export PATH="$HOME/.dotnet/tools:$PATH"
 fi
 maf-doctor --version
-# → maf-autopilot 1.0.0 (or later)
+# → maf-doctor 1.0.0 (or later)
 ```
 
 **PowerShell:**
 
 ```powershell
-if (-not (Get-Command maf-autopilot -ErrorAction SilentlyContinue)) {
+if (-not (Get-Command maf-doctor -ErrorAction SilentlyContinue)) {
     dotnet tool install -g maf-doctor
 }
 maf-doctor --version
@@ -162,7 +162,7 @@ This phase gets a sample folder open in VS Code with the MCP server wired up. Af
 
 #### Step 1 — Open the sample STANDALONE in VS Code Insiders
 
-The workshop opens **only the sample folder**, not the full maf-autopilot repo. This mirrors how a real customer would experience the toolkit — they don't have the source on their machine, just the installed global tool.
+The workshop opens **only the sample folder**, not the full maf-doctor repo. This mirrors how a real customer would experience the toolkit — they don't have the source on their machine, just the installed global tool.
 
 ```bash
 # From wherever you cloned this repo:
@@ -221,7 +221,7 @@ VS Code Insiders auto-detects this file. After saving, open Copilot Chat and ver
 - The `/maf-audit`, `/maf-migrate`, `/maf-cs0618-hunt` slash commands appear in `/`-completions.
 - `maf://constraints`, `maf://guide`, `maf://registry`, `maf://rules`, `maf://skills?name=…` are referenceable as resources.
 
-> **Troubleshooting:** if no MCP is detected, check `View → Output → MCP` for the server log. Most commonly: `maf-autopilot` is not on PATH — re-run `dotnet tool install -g maf-doctor` and reopen VS Code.
+> **Troubleshooting:** if no MCP is detected, check `View → Output → MCP` for the server log. Most commonly: `maf-doctor` is not on PATH — re-run `dotnet tool install -g maf-doctor` and reopen VS Code.
 
 ---
 
@@ -290,10 +290,10 @@ Each row below is one Copilot Chat prompt. Run them sequentially — each surfac
 
 #### Step 5b — Watch the analyzer fire at WRITE time
 
-The toolkit ships TWO products: the MCP server (scan-time) and a separate **`maf-autopilot.Analyzers` NuGet** (write-time). The sample's csproj already references it:
+The toolkit ships TWO products: the MCP server (scan-time) and a separate **`maf-doctor.Analyzers` NuGet** (write-time). The sample's csproj already references it:
 
 ```xml
-<PackageReference Include="maf-autopilot.Analyzers" Version="1.0.0">
+<PackageReference Include="maf-doctor.Analyzers" Version="1.0.0">
   <IncludeAssets>analyzers; build</IncludeAssets>
   <PrivateAssets>all</PrivateAssets>
 </PackageReference>
@@ -540,7 +540,7 @@ rm -f samples/maf-1.3-sample/docs/migration-plan.md
 ### Where to go next
 
 - **Fork the sample.** Add your own anti-patterns + re-run the workshop to test new toolkit rules.
-- **Try the analyzer NuGet** in your own project: `dotnet add package maf-autopilot.Analyzers`.
+- **Try the analyzer NuGet** in your own project: `dotnet add package maf-doctor.Analyzers`.
 - **Read the MAF migration guides** in [`/guides/`](../guides/) — `maf-1.3.0`, `maf-1.4.0`, `maf-1.5.0`, plus `maf-current-migration-guide.md` (auto-regenerated).
 - **Browse the 7 Copilot Chat agents:** `@maf`, `@maf-auditor`, `@maf-migration`, `@maf-best-practice-reviewer`, `@maf-incident-responder`, `@maf-rollback`, `@maf-onboarding`.
 
@@ -571,8 +571,8 @@ The first two are **automatable** (just run the `.tape` scripts). The last two a
 
 | Aspect | Detail |
 |---|---|
-| **Preparation** | (a) vhs + ffmpeg + ttyd installed. (b) `maf-autopilot` global tool installed on your machine. (c) The repo cloned. |
-| **Before state** | Terminal at repo root, no maf-autopilot installed (or version unverified). |
+| **Preparation** | (a) vhs + ffmpeg + ttyd installed. (b) `maf-doctor` global tool installed on your machine. (c) The repo cloned. |
+| **Before state** | Terminal at repo root, no maf-doctor installed (or version unverified). |
 | **What to do** | `bash scripts/make-cast.sh install` |
 | **What to say** | _(no narration — the .tape file is autonomous)_ |
 | **After state** | `docs/assets/install-cast.gif` rendered (~500 KB - 2 MB). |
@@ -656,7 +656,7 @@ The first two are **automatable** (just run the `.tape` scripts). The last two a
    before they save the file. Shift-left baked in."
 
 [7:00 — 7:30]  Close
-  "maf-autopilot 1.3.0 on NuGet. Install with one command. Audits any
+  "maf-doctor 1.3.0 on NuGet. Install with one command. Audits any
    MAF codebase. github.com/joslat/maf-doctor."
 ```
 
@@ -677,7 +677,7 @@ The first two are **automatable** (just run the `.tape` scripts). The last two a
 | **Audience** | Conference attendees, technical training, university course |
 | **Tools needed** | Same as R3 + a presentation slide deck for chapter transitions |
 | **Preparation (~30 min)** | (a) Render R1 + R2 first — embed them as intro before live demo starts. (b) Set up VS Code Insiders + Copilot Chat with valid subscription. (c) Test the agent loop end-to-end at least twice to catch flakes. (d) Have the [Full Workshop](#full-workshop-50-minutes) section open as your speaker notes. |
-| **Before state** | Slide 1: "maf-autopilot Workshop — From Zero to Migrated Codebase" + your name. |
+| **Before state** | Slide 1: "maf-doctor Workshop — From Zero to Migrated Codebase" + your name. |
 | **What to do** | Walk through Phase A → B → C → D → E in order. Stop after each Phase for Q&A (~2 min each). Total: ~40 min content + ~10 min Q&A. |
 | **What to say** | The "Talk-track" callout boxes throughout the workshop sections. They're written as one-liners you can read verbatim or paraphrase. |
 | **After state** | Final slide: "Try it: `dotnet tool install -g maf-doctor`; github.com/joslat/maf-doctor; questions?" |


### PR DESCRIPTION
Answers "is the documentation updated?" (it wasn't fully) and adds the docs you asked for.

## New docs
- **`docs/usage.md`** — drive the toolkit in a nutshell: natural-language steering (the main mode), the 7 MCP **prompts** (`/maf-audit` …), the tool catalogue (+ pointer to the live `MafTour`/`maf://rules` list), the 6 resources, the 7 specialist agents, and the CLI.
- **`docs/init-reference.md`** — exactly what `maf-doctor init` writes, per AI ecosystem (VS Code, Copilot, Claude Code, Cursor, AGENTS.md), why, the sidecar/merge semantics, and what it does **not** install (skills are served live; agents are Mode 2).
- **`docs/assets/README.md`** — what the VHS `.tape` casts are and how to render/auto-run them (`scripts/make-cast.sh`, `vhs`).

## Fixes
- Corrected every doc still describing `init`'s **old** behavior (creating/appending `.github/copilot-instructions.md`) → the current **sidecar** model.
- Swept remaining user-facing `maf-autopilot` → `maf-doctor` across docs + samples (prose, titles, banners, demo text, the `maf-doctor.Analyzers` package id).
- README: fixed the stale init comment, added a "Going deeper" pointer to the new docs + the **workshop** (which wasn't linked before).

## Scope note
Deliberately left as-is: the internal `src/maf-autopilot/` tree, `.sln`/`.csproj` filenames, `*.Tests` assembly names, the legacy MCP server-key recognition, and CHANGELOG history. (Whether to rename those internals too is a separate, build-touching decision — flagged to you.)

Docs/comments only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)