### PR TITLE
feat(doctor): add --all/--full flag to list every finding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.11] - 2026-06-18
+
+### Added
+
+- **`doctor --all` / `--full` lists every finding.** The health report ranks all findings by impact but only printed the top 3, with the rest invisible. The new flag prints every finding (anti-pattern, fan-out, prompt-lint, cost) — one line each, ordered by impact — so you can see the full backlog in one pass. Default output is unchanged (top 3) and now ends with a "…and N more. Run with `--all`" hint when findings are hidden. The MCP `MafDoctor` tool gains a matching `full` parameter (`MafDoctor(full: true)`), and the JSON format includes the full `findings` array when `--all` is set.
+
 ## [1.2.10] - 2026-06-18
 
 ### Fixed

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -14,7 +14,7 @@
 
     <!-- NuGet packaging -->
     <PackageId>maf-doctor.Analyzers</PackageId>
-    <Version>1.2.10</Version>
+    <Version>1.2.11</Version>
     <Authors>joslat</Authors>
     <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) — write-time enforcement of fan-out safety, secure credentials, and observability defaults (MAF001-MAF003). Companion to the maf-doctor .NET global tool / MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -106,6 +106,22 @@ public class DoctorToolTests
             .ToList();
         var summary = DoctorTool.Grade(antiPatterns, []);
         Assert.Equal(3, summary.TopFixes.Count);
+        // --all / full surfaces EVERY finding, not just the top 3.
+        Assert.Equal(10, summary.AllFixes.Count);
+    }
+
+    [Fact]
+    public void Full_ReportListsEveryFinding()
+    {
+        // 6 distinct anti-pattern errors → default shows 3, full shows all 6.
+        var antiPatterns = Enumerable.Range(0, 6)
+            .Select(i => new AntiPatternFinding($"MAF-AP-R{i}", $"rule {i}", AntiPatternSeverity.Error, $"File{i}.cs", i + 1, "m"))
+            .ToList();
+        var summary = DoctorTool.Grade(antiPatterns, []);
+        Assert.Equal(3, summary.TopFixes.Count);
+        Assert.Equal(6, summary.AllFixes.Count);
+        // Every finding carries a one-line Description (what the --all report prints).
+        Assert.All(summary.AllFixes, f => Assert.False(string.IsNullOrWhiteSpace(f.Description)));
     }
 
     // -------------------------------------------------------------------------

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -42,7 +42,7 @@ if (args.Length > 0 && (args[0] is "--help" or "-h" or "help"))
         Commands:
           init [--with-cursor]              Wire the MCP server + steering into the current repo
                                             (.vscode/mcp.json, .mcp.json, instructions, agents).
-          doctor [path] [--exclude <s>]...  Health report with an A/B/C/F grade.
+          doctor [path] [--exclude <s>] [--all]  A/B/C/F health report (--all = every finding, not just top 3).
           autofix-all [path] [--dry-run]    Apply deterministic Roslyn fixes.
           new agent <Name>                  Scaffold a MAF agent + smoke test.
           new executor <Name> [In] [Out]    Scaffold a workflow executor + smoke test.
@@ -75,15 +75,18 @@ if (args.Length >= 1 && args[0] == "doctor")
     // Repeatable `--exclude` skips files whose repo-relative path contains the
     // substring — used by the drift detector to scan product code only (skip
     // samples/ + test fixtures). The first non-flag arg is the path (default cwd).
+    // `--all` / `--full` lists EVERY finding (one line each) instead of the top 3.
     var excludes = new List<string>();
     string? path = null;
+    var full = false;
     for (int i = 1; i < args.Length; i++)
     {
         if (args[i] == "--exclude" && i + 1 < args.Length) { excludes.Add(args[++i]); continue; }
+        if (args[i] is "--all" or "--full") { full = true; continue; }
         if (path is null && !args[i].StartsWith("--", StringComparison.Ordinal)) path = args[i];
     }
     path ??= Directory.GetCurrentDirectory();
-    var report = new MafDoctor.Tools.DoctorTool().Run(path, "markdown", excludes);
+    var report = new MafDoctor.Tools.DoctorTool().Run(path, "markdown", excludes, full);
     Console.WriteLine(report);
     Environment.Exit(0);
     return;

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -42,8 +42,10 @@ public sealed class DoctorTool
     public string MafDoctor(
         [Description("Absolute path to the repository root.")] string repoPath,
         [Description("Output format: 'markdown' (default, human-readable) or 'json' (machine-readable for CI/dashboards).")]
-        string format = "markdown")
-        => RunCore(repoPath, format, excludes: null);
+        string format = "markdown",
+        [Description("When true, list EVERY finding (one line each) instead of only the top 3 fixes. Use for full triage / CI.")]
+        bool full = false)
+        => RunCore(repoPath, format, excludes: null, full: full);
 
     /// <summary>
     /// CLI entry point. Identical to <see cref="MafDoctor"/> but accepts
@@ -53,10 +55,10 @@ public sealed class DoctorTool
     /// bait. Deliberately NOT an MCP tool — keeping it off the tool surface
     /// preserves the stable MafDoctor schema for clients.
     /// </summary>
-    internal string Run(string repoPath, string format, IReadOnlyList<string>? excludes)
-        => RunCore(repoPath, format, excludes);
+    internal string Run(string repoPath, string format, IReadOnlyList<string>? excludes, bool full = false)
+        => RunCore(repoPath, format, excludes, full);
 
-    private string RunCore(string repoPath, string format, IReadOnlyList<string>? excludes)
+    private string RunCore(string repoPath, string format, IReadOnlyList<string>? excludes, bool full = false)
     {
         if (PathGuard.ValidateRepoPath(repoPath) is { } err) return err;
 
@@ -64,11 +66,11 @@ public sealed class DoctorTool
 
         if (format.Equals("json", StringComparison.OrdinalIgnoreCase))
         {
-            var result = BuildJsonResult(repoPath, summary);
+            var result = BuildJsonResult(repoPath, summary, full);
             return JsonSerializer.Serialize(result, DoctorJsonContext.Default.DoctorJsonResult);
         }
 
-        return FormatReport(repoPath, summary);
+        return FormatReport(repoPath, summary, full);
     }
 
     // -------------------------------------------------------------------------
@@ -132,7 +134,7 @@ public sealed class DoctorTool
 
         // Top 3 fixes: prioritise silent-starvation risks, then errors (anti-pattern + prompt),
         // then warnings (anti-pattern + prompt + cost).
-        var topFixes = handlers
+        var allFixes = handlers
             .Where(h => h.Verdict == FanOutVerdict.SilentStarvationRisk
                      || h.Verdict == FanOutVerdict.LikelyInvalid)
             .Select(h => new DoctorRecommendation(
@@ -194,7 +196,6 @@ public sealed class DoctorTool
                     FixDescription: GetAntiPatternFix(a.RuleId),
                     AutoFixable: IsAutoFixable(a.RuleId))))
             .OrderBy(r => r.Priority)
-            .Take(3)
             .ToList();
 
         return new DoctorSummary(
@@ -209,17 +210,18 @@ public sealed class DoctorTool
             PromptWarnings: promptWarnings,
             UnboundedCostSites: unboundedCostSites,
             AgentCallSitesChecked: costFindings.Count,
-            TopFixes: topFixes);
+            TopFixes: allFixes.Take(3).ToList(),
+            AllFixes: allFixes);
     }
 
     // -------------------------------------------------------------------------
     // JSON output support
     // -------------------------------------------------------------------------
 
-    private static DoctorJsonResult BuildJsonResult(string repoPath, DoctorSummary s)
+    private static DoctorJsonResult BuildJsonResult(string repoPath, DoctorSummary s, bool full = false)
     {
-        var markdownSummary = FormatReport(repoPath, s);
-        var findings = s.TopFixes
+        var markdownSummary = FormatReport(repoPath, s, full);
+        var findings = (full ? s.AllFixes : s.TopFixes)
             .Select(f => new DoctorJsonFinding(
                 RuleId: f.RuleId,
                 Severity: f.Priority switch { 1 => "starvation_risk", 2 => "error", _ => "warning" },
@@ -308,7 +310,7 @@ public sealed class DoctorTool
     private static string MakeRelative(string root, string file)
         => SourceFileWalker.MakeRelative(root, file);
 
-    private static string FormatReport(string repoPath, DoctorSummary s)
+    private static string FormatReport(string repoPath, DoctorSummary s, bool full = false)
     {
         var sb = new StringBuilder();
         var emoji = s.Grade switch
@@ -338,17 +340,25 @@ public sealed class DoctorTool
         sb.AppendLine($"| `RunAsync` / `RunStreamingAsync` sites inspected | {s.AgentCallSitesChecked} |");
         sb.AppendLine();
 
-        if (s.TopFixes.Count > 0)
+        var fixes = full ? s.AllFixes : s.TopFixes;
+        if (fixes.Count > 0)
         {
-            sb.AppendLine("### Top fixes (ordered by impact)");
+            sb.AppendLine(full
+                ? $"### All findings ({fixes.Count}, ordered by impact)"
+                : "### Top fixes (ordered by impact)");
             sb.AppendLine();
             var i = 1;
-            foreach (var fix in s.TopFixes)
+            foreach (var fix in fixes)
             {
                 sb.AppendLine($"{i}. **[{fix.Source}]** {fix.Description}");
                 i++;
             }
             sb.AppendLine();
+            if (!full && s.AllFixes.Count > s.TopFixes.Count)
+            {
+                sb.AppendLine($"_…and {s.AllFixes.Count - s.TopFixes.Count} more. Run with `--all` (CLI) or `full: true` (MafDoctor) for every finding._");
+                sb.AppendLine();
+            }
         }
         else
         {
@@ -380,7 +390,8 @@ public sealed record DoctorSummary(
     int PromptWarnings,
     int UnboundedCostSites,
     int AgentCallSitesChecked,
-    IReadOnlyList<DoctorRecommendation> TopFixes);
+    IReadOnlyList<DoctorRecommendation> TopFixes,
+    IReadOnlyList<DoctorRecommendation> AllFixes);
 
 public sealed record DoctorRecommendation(
     int Priority,

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -17,7 +17,7 @@
          release.yml overrides this from the pushed tag and keeps the analyzer
          package in lockstep, so the canonical version is the git tag (`vX.Y.Z`).
          This value is the local/dev default. -->
-    <Version>1.2.10</Version>
+    <Version>1.2.11</Version>
     <Authors>joslat</Authors>
     <Description>MAF Doctor — a .NET global tool and MCP server for Microsoft Agent Framework (MAF). Diagnoses, explains, and auto-fixes MAF agents and workflows: A-F health grades, deterministic Roslyn rewriters, anti-pattern and fan-out scanning, and a self-updating obsolete-API registry. Use it from Copilot / Claude / Cursor via MCP, or standalone as a CLI.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>


### PR DESCRIPTION
## What

Adds a `--all` (alias `--full`) flag to the `doctor` health report so it lists **every** finding, not just the top 3.

### Why

The report already ranks all findings by impact, but `.Take(3)` hid the rest. Users asked to see the full backlog in one pass. The default (top 3) is unchanged.

### Changes

- `DoctorSummary` gains `AllFixes` (full ordered list); `TopFixes` stays the top 3.
- `doctor [path] --all` / `--full` (CLI) prints every finding, one line each, ordered by impact.
- Default output gains a "…and N more. Run with `--all`" hint when findings are hidden.
- MCP `MafDoctor` tool gains a `full` parameter (`MafDoctor(full: true)`); JSON format emits the full `findings` array when set.
- `--help` text updated.
- Tests: extended cap test (`AllFixes.Count == 10`) + new `Full_ReportListsEveryFinding`.
- Both packages bumped to **1.2.11**; CHANGELOG entry added.

### Verification

- `dotnet test` green (750 + 15 across net8/9/10).
- `doctor samples/maf-1.3-sample` → 3 findings; `--all` → 16 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)