### PR TITLE
docs: drop migration-cast demo for now; make tape/doc honest

### DIFF
--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,17 +1,17 @@
 # `docs/assets/` — the README demo casts
 
-This folder holds the two animated terminal demos shown in the top-level `README.md`:
+This folder holds the terminal demo casts for the project:
 
 | Source (`.tape`) | Renders to | Shows |
 |---|---|---|
-| `install-cast.tape` | `install-cast.gif` | Install the tool + `maf-doctor doctor .` → grade **F** + top fixes |
-| `migration-cast.tape` | `migration-cast.gif` | `maf-doctor autofix-all .` → grade **F → A**, deterministic |
+| `install-cast.tape` | `install-cast.gif` (committed, shown in the top-level `README.md`) | Install the tool + `maf-doctor doctor .` → grade **F** + top fixes |
+| `migration-cast.tape` | _(not rendered/committed yet)_ | `maf-doctor autofix-all .` → deterministic Roslyn rewriters clear the **mechanical** anti-patterns; the **semantic** fan-out fixes (`ValueTask` → `Task<T>`) are left for the `@maf-migration` agent. It does **not** reach grade A on its own — that needs the agent pass. |
 
 ## What the `.tape` files are
 
 They're **[VHS](https://github.com/charmbracelet/vhs)** scripts (by Charm). VHS reads a `.tape` file — a list of `Type`, `Enter`, `Sleep`, `Set` directives — drives a **headless terminal**, runs the commands for real, and records the session to a `.gif`. So the casts aren't hand-made screen recordings: they're reproducible scripts you re-run whenever the CLI output changes.
 
-The `.gif` outputs are **not committed** — they're build artifacts you render on demand (which is why the README's `<img>` tags were removed until someone renders + commits them).
+`install-cast.gif` is committed and embedded in the top-level README. `migration-cast.gif` is **not** rendered/committed yet — the agent-driven migration it should show needs a Copilot/Claude session, so it's deferred. Render any cast on demand from its `.tape`.
 
 ## How to render them ("auto-run")
 

--- a/docs/assets/migration-cast.tape
+++ b/docs/assets/migration-cast.tape
@@ -1,12 +1,14 @@
-# vhs script for the maf-doctor migration demo.
+# vhs script for the maf-doctor auto-fix demo.
 #
-# Companion to install-cast.tape. While that cast shows install + audit,
-# THIS cast shows the auto-fix loop: a broken codebase migrates to
-# grade A in ~30 seconds, deterministically.
+# Honest companion to install-cast.tape. It shows the DETERMINISTIC auto-fix
+# pass on a broken MAF 1.3.0 codebase — and is truthful that autofix clears the
+# mechanical anti-patterns while the silent fan-out starvation bugs are left for
+# the migration agent (flipping ValueTask -> Task<T> is a semantic change the
+# rewriter won't guess). No `dotnet build` here: doctor/autofix are static
+# Roslyn analysis, so the cast needs no package restore and stays fast.
 #
-# Render locally:
-#   bash scripts/make-cast.sh           # produces docs/assets/migration-cast.gif
-#   pwsh scripts/make-cast.ps1
+# Render (Docker, no local vhs/ttyd) — see private/castforge/SKILL.md:
+#   docker run --rm -v "$PWD:/vhs" -w /vhs vhs-dotnet docs/assets/migration-cast.tape
 #
 # Source: https://github.com/charmbracelet/vhs
 
@@ -20,51 +22,43 @@ Set Padding 24
 Set TypingSpeed 45ms
 Set Shell "bash"
 
-# ───────── beat 1: arrive at a broken sample ─────────
-Type "# A real customer codebase, pinned to MAF 1.3.0 with 10 anti-patterns"
+# ───────── beat 1: a broken MAF 1.3.0 codebase ─────────
+Type "# A customer codebase pinned to MAF 1.3.0 — 10 anti-patterns, 3 of them silent"
 Enter
 Sleep 1s
-
 Type "cd samples/maf-1.3-sample"
 Sleep 200ms
 Enter
 Sleep 400ms
 
-# ───────── beat 2: prove it's broken ─────────
-Type "dotnet build  # 1 CS0618 + 3 MAF001 warnings — analyzer + compiler agree"
-Sleep 200ms
-Enter
-Sleep 4s
-
-# ───────── beat 3: get the diagnosis ─────────
-Type "maf-doctor doctor .  # full health report"
+# ───────── beat 2: diagnose ─────────
+Type "maf-doctor doctor ."
 Sleep 200ms
 Enter
 Sleep 5s
 
-# ───────── beat 4: fix everything fixable ─────────
-Type "# One command. Every mechanical rule. Deterministic — no LLM."
+# ───────── beat 3: the deterministic pass ─────────
+Type "# Roslyn rewriters, no LLM — the deterministic mechanical fixes."
 Enter
-Sleep 800ms
-
+Sleep 700ms
 Type "maf-doctor autofix-all ."
 Sleep 200ms
 Enter
 Sleep 4s
 
-# ───────── beat 5: prove it's fixed ─────────
-Type "maf-doctor doctor .  # re-audit"
+# ───────── beat 4: re-audit — honest about what remains ─────────
+Type "maf-doctor doctor ."
 Sleep 200ms
 Enter
-Sleep 4s
+Sleep 5s
 
-# ───────── beat 6: clean build ─────────
-Type "dotnet build  # 0 warnings, 0 errors"
-Sleep 200ms
+# ───────── beat 5: the honest punchline + agent handoff ─────────
+Type "# 🟡 autofix cleared the mechanical anti-patterns (no LLM)."
 Enter
-Sleep 3s
-
-# ───────── beat 7: punchline ─────────
-Type "# 🟢 Grade A. Migrated in ~30 seconds. Deterministically."
+Sleep 700ms
+Type "# The 3 silent-starvation fan-out bugs remain on purpose: ValueTask -> Task<T>"
 Enter
-Sleep 2500ms
+Sleep 500ms
+Type "# is a semantic change autofix won't guess. Those go to @maf-migration."
+Enter
+Sleep 2800ms


### PR DESCRIPTION
Per the decision to **defer the migration cast** until the agent-driven flow can be shown (Copilot credits return ~July):

- Removes the held `migration-cast.gif`.
- Replaces the committed `migration-cast.tape` (which claimed deterministic autofix "migrates to grade A in ~30 seconds" / "🟢 Grade A") with the **honest** rewrite — `autofix-all` clears the *mechanical* anti-patterns; the *semantic* fan-out fixes (`ValueTask` → `Task<T>`) go to the `@maf-migration` agent, so the deterministic pass alone does **not** reach grade A.
- Fixes the same false `F → A` claim + a stale "GIFs not committed" note in `docs/assets/README.md`.

Docs/tape only — no code, no version bump.

> Note: `samples/workshop.md` still carries the same "F → A, no agents" framing — flagged separately for a deliberate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)