### PR TITLE
feat(doctor): doctor-suggestions overhaul (Tiers 1–3) + NuGet README hotfix → 1.3.0

### DIFF
--- a/.github/skills/maf-anti-pattern-scanner/SKILL.md
+++ b/.github/skills/maf-anti-pattern-scanner/SKILL.md
@@ -50,7 +50,7 @@ Each is a "rule" with a unique ID, a `severity`, and a deterministic search patt
 **Source:** `maf-constraints.instructions.md` hard rule #2.
 
 #### `MAF-AP-CONC-002` — `.Result` / `.Wait()` on async  (severity: warning)
-**Pattern:** `\.Result\b` or `\.Wait\(\)` immediately following an awaitable expression in agent / executor code.
+**Pattern:** `\)\s*\.(?:Result|Wait)\b` — a `.Result` / `.Wait()` immediately following a method CALL (e.g. `SomeAsync().Result`). Deliberately anchored on the call's close-paren rather than the bare member name: matching `task.Result` on *any* member would false-fire on the many non-Task `.Result` / `.Wait` properties in real code, so the bare-member form is intentionally out of scope (pinned by a regression test).
 **Why:** Sync-over-async deadlocks under SynchronizationContext. Agent runtimes pump async; mixing sync waits is a latent hang.
 **Fix:** `await` the expression. Make the calling method `async`.
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,48 @@
+name: build-test
+
+# Builds and runs the full .NET test suite on every PR and push to main.
+#
+# Why this exists: before this workflow, `dotnet test` ran ONLY in release.yml
+# (triggered by a release tag), so the entire test suite — including the rewriter
+# compile-roundtrip corruption guard (RewriterCompileRoundtripTests, which catches
+# the CS1995 / CS4004 "await injected into an await-illegal context" class of source
+# corruption) — never gated a pull request. It surfaced only weeks later, at release.
+#
+# This makes the suite a real pre-merge gate: a rewriter (or any) regression fails
+# here, on the PR, before merge.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: Build + test (net8/9/10)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup .NET (all three runtimes — project multi-targets net8/9/10)
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Restore
+        run: dotnet restore maf-autopilot.sln
+
+      - name: Build
+        run: dotnet build maf-autopilot.sln --configuration Release --no-restore
+
+      - name: Test (solution-level — gates analyzer + main project + rewriter compile-roundtrip guard)
+        run: |
+          dotnet test maf-autopilot.sln \
+            --configuration Release \
+            --no-build \
+            --logger "console;verbosity=minimal"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.12] - 2026-06-18
+
+### Fixed
+
+- **NuGet package page no longer shows raw HTML.** The shared README's centered hero (`<p align="center">…<br/><em>…</em></p>`) rendered as literal HTML text on nuget.org (its README renderer escapes HTML it doesn't fully support). Both packages now ship a dedicated **pure-markdown `NUGET_README.md`** as their `PackageReadmeFile`, so the package page renders cleanly. The GitHub README keeps its centered HTML hero.
+
+### Added
+
+- **NuGet README explains the install.** The new package README spells out that **`init` is non-destructive — it attaches and updates only, never overwriting your files** (adds its own MCP server entry + regenerates self-contained steering sidecars), lists what you get (MCP server / CLI / plugin / analyzers), and highlights recent features (`doctor --all`, self-update, security hardening). The same non-destructive framing was added to the main README's Quick Start.
+
 ## [1.2.11] - 2026-06-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,8 +238,10 @@ The full attack-surface map + closure list is in
 - **`ai_review_build_prompt.py` PR-registry injection** — each changed
   registry entry now fenced before embedding in the GPT-4o review prompt.
 - **`ExecutorSealedRewriter` produces uncompilable `abstract sealed class`** —
-  abstract / static guard skips with leading-trivia warning comment.
-  Idempotence via source-text dedup so repeat passes don't duplicate.
+  abstract / static Executors are left UNCHANGED (parity with the WF-001 scanner,
+  which skips abstract Executors), so `MafAutoFix` / `MafBeforeAfter` honestly
+  report "no change" instead of dirtying a scanner-clean file with an advisory
+  comment.
 - **`SyncOverAsyncRewriter` produces uncompilable `await`** — lock-block /
   non-async-method / accessor / non-async-lambda guards. Same idempotence pattern.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.12] - 2026-06-18
+## [1.3.0] - 2026-06-18
 
-### Fixed
-
-- **NuGet package page no longer shows raw HTML.** The shared README's centered hero (`<p align="center">…<br/><em>…</em></p>`) rendered as literal HTML text on nuget.org (its README renderer escapes HTML it doesn't fully support). Both packages now ship a dedicated **pure-markdown `NUGET_README.md`** as their `PackageReadmeFile`, so the package page renders cleanly. The GitHub README keeps its centered HTML hero.
+Doctor-suggestions overhaul — three tiers that turn each finding from a terse label into something a developer can act on in one read. Each tier shipped after two adversarial multi-agent review passes.
 
 ### Added
 
-- **NuGet README explains the install.** The new package README spells out that **`init` is non-destructive — it attaches and updates only, never overwriting your files** (adds its own MCP server entry + regenerates self-contained steering sidecars), lists what you get (MCP server / CLI / plugin / analyzers), and highlights recent features (`doctor --all`, self-update, security hardening). The same non-destructive framing was added to the main README's Quick Start.
+- **Richer, actionable suggestions (Tier 1).** Every finding now carries a one-line **Why** (the concrete failure mode) and surfaces its **Fix** + an "auto-fixable / needs your judgment" tag + a "N of M auto-fixable → `autofix-all`" hint directly in the human markdown report (previously the fix string was JSON-only). The report shows the **offending source line** for each finding, with content-aware secret redaction (a line matching the hard-coded-key pattern is never echoed). `doctor --all` now **groups findings by rule** (rule-generic header, ×N, severity emoji, ordered by impact). New CLI `--json` flag (JSON was MCP-only). The JSON finding gains an additive `why` field (schema_version stays `"1"`).
+- **`MafExplainFinding` tool + `maf-explain-finding` prompt (Tier 2).** Deep-dive a single finding: given its `file:line` (as printed by the report), the tool returns the offending code in context plus the rule's why / fix / auto-fixability and grounding pointers — the substrate a host model (Copilot / Claude / Cursor) uses to explain and propose the fix without spending our own LLM budget. The prompt drives that flow grounded in `maf://constraints` + `maf://guide`.
+- **`doctor --plan` / `MafDoctor(format: "plan")` (Tier 3).** Turns the findings into an ordered, checkboxed **remediation plan** for a GitHub issue: Phase 1 batches every auto-fixable finding into one `autofix-all` step; Phase 2 lists the semantic fixes as impact-ordered `- [ ]` tasks (why / fix / file:line, tagged `@maf-migration`). Covers every finding regardless of `--all`; emits no source snippets, so it never echoes a secret.
+- **NuGet README explains the install.** A dedicated package README spells out that **`init` is non-destructive — it attaches and updates only, never overwriting your files** (adds its own MCP server entry + regenerates self-contained steering sidecars), lists what you get (MCP server / CLI / plugin / analyzers), and highlights recent features. The same non-destructive framing was added to the main README's Quick Start.
+
+### Fixed
+
+- **NuGet package page no longer shows raw HTML.** The shared README's centered hero (`<p align="center">…<br/><em>…</em></p>`) rendered as literal HTML text on nuget.org (its renderer escapes HTML it doesn't fully support). Both packages now ship a pure-markdown `NUGET_README.md` as their `PackageReadmeFile`; the GitHub README keeps its centered hero.
+- **Fan-out findings report the signature line**, not the `[MessageHandler]` attribute line above it — so the offending return type lands on the reported line and in the snippet.
+- **`MafDoctor` markdown report no longer dead-ends.** The "Want more" footer advertised MCP-only tool calls to CLI users; it now lists surface-neutral commands (`--all` / `--json` / `--plan` for the CLI, `full:`/`format:` for MCP) and points at `MafExplainFinding`.
 
 ## [1.2.11] - 2026-06-18
 

--- a/NUGET_README.md
+++ b/NUGET_README.md
@@ -33,7 +33,7 @@ Uninstall is just as clean: `dotnet tool uninstall --global maf-doctor`, then de
 
 ## What you get
 
-- **MCP server** — 25 tools, 6 resources, and 7 prompts for GitHub Copilot / Claude Code / Cursor.
+- **MCP server** — 26 tools, 6 resources, and 8 prompts for GitHub Copilot / Claude Code / Cursor.
 - **CLI** — `doctor`, `autofix-all`, `new agent`, `init`, and more.
 - **Plugin** — 12 bundled skills + 7 specialist agents wired into Copilot's and Claude's agentic loops.
 - A companion **[maf-doctor.Analyzers](https://www.nuget.org/packages/maf-doctor.Analyzers)** package — 3 Roslyn analyzers (MAF001 / MAF002 / MAF003) for IDE write-time enforcement.
@@ -45,7 +45,7 @@ Uninstall is just as clean: `dotnet tool uninstall --global maf-doctor`, then de
 - 🆕 **`doctor --all`** — list *every* finding (not just the top 3), grouped by rule and ordered by impact, each with a one-line *why* and the offending source line. Full triage in one pass.
 - 🆕 **`doctor --plan`** — turn the findings into an ordered, checkboxed **remediation plan** (Phase 1: one `autofix-all` for the mechanical fixes; Phase 2: the semantic fixes as impact-ordered tasks) you can drop straight into a GitHub issue.
 - 📖 **It updates itself** — a weekly GitHub Actions watcher refreshes the migration guide, compatibility matrix, and obsolete-API registry as new MAF versions ship, so you don't pin to a MAF version or wait on a maintainer release.
-- 🔐 **Security-hardened** — closes the named MCP attack lattice (path-escape, annotation drift, scaffold code-injection, prompt-injection, workflow-dispatch input injection). Cisco mcp-scanner: 25/25 tools SAFE, 0 findings.
+- 🔐 **Security-hardened** — closes the named MCP attack lattice (path-escape, annotation drift, scaffold code-injection, prompt-injection, workflow-dispatch input injection). Cisco mcp-scanner: all tools SAFE, 0 findings.
 
 ## Full docs
 

--- a/NUGET_README.md
+++ b/NUGET_README.md
@@ -42,7 +42,7 @@ Uninstall is just as clean: `dotnet tool uninstall --global maf-doctor`, then de
 
 - 🔍 **Catches bugs that compile clean** — fan-out/fan-in silent failures where a workflow exits successfully but produces no output. Zero build signal.
 - 🩺 **Compiler ground-truth for CS0618** — obsolete-API usage mapped to its exact replacement pattern. Deterministic fixes, not hallucinated ones.
-- 🆕 **`doctor --all`** — list *every* finding (not just the top 3), one line each, ordered by impact. Full triage in one pass.
+- 🆕 **`doctor --all`** — list *every* finding (not just the top 3), grouped by rule and ordered by impact, each with a one-line *why* and the offending source line. Full triage in one pass.
 - 📖 **It updates itself** — a weekly GitHub Actions watcher refreshes the migration guide, compatibility matrix, and obsolete-API registry as new MAF versions ship, so you don't pin to a MAF version or wait on a maintainer release.
 - 🔐 **Security-hardened** — closes the named MCP attack lattice (path-escape, annotation drift, scaffold code-injection, prompt-injection, workflow-dispatch input injection). Cisco mcp-scanner: 25/25 tools SAFE, 0 findings.
 

--- a/NUGET_README.md
+++ b/NUGET_README.md
@@ -43,6 +43,7 @@ Uninstall is just as clean: `dotnet tool uninstall --global maf-doctor`, then de
 - 🔍 **Catches bugs that compile clean** — fan-out/fan-in silent failures where a workflow exits successfully but produces no output. Zero build signal.
 - 🩺 **Compiler ground-truth for CS0618** — obsolete-API usage mapped to its exact replacement pattern. Deterministic fixes, not hallucinated ones.
 - 🆕 **`doctor --all`** — list *every* finding (not just the top 3), grouped by rule and ordered by impact, each with a one-line *why* and the offending source line. Full triage in one pass.
+- 🆕 **`doctor --plan`** — turn the findings into an ordered, checkboxed **remediation plan** (Phase 1: one `autofix-all` for the mechanical fixes; Phase 2: the semantic fixes as impact-ordered tasks) you can drop straight into a GitHub issue.
 - 📖 **It updates itself** — a weekly GitHub Actions watcher refreshes the migration guide, compatibility matrix, and obsolete-API registry as new MAF versions ship, so you don't pin to a MAF version or wait on a maintainer release.
 - 🔐 **Security-hardened** — closes the named MCP attack lattice (path-escape, annotation drift, scaffold code-injection, prompt-injection, workflow-dispatch input injection). Cisco mcp-scanner: 25/25 tools SAFE, 0 findings.
 

--- a/NUGET_README.md
+++ b/NUGET_README.md
@@ -1,0 +1,53 @@
+# MAF Doctor
+
+**One install — a .NET global tool, an MCP server, and an IDE plugin — for Microsoft Agent Framework (MAF).**
+
+Diagnose, explain, prescribe, and verify MAF agents and workflows: an A–F health letter, deterministic Roslyn auto-fixes, fan-out/fan-in silent-failure detection, compiler-ground-truth CS0618 hunts, and a self-updating obsolete-API registry.
+
+![Install, then run maf-doctor doctor on any MAF codebase — an A–F health letter plus the top fixes, in seconds.](https://raw.githubusercontent.com/joslat/maf-doctor/main/docs/assets/install-cast.gif)
+
+## Install
+
+```
+dotnet tool install --global maf-doctor     # first time
+dotnet tool update  --global maf-doctor     # upgrade later
+```
+
+Then, in any MAF repo:
+
+```
+maf-doctor doctor .          # instant A–F health grade + the top fixes (add --all for every finding)
+maf-doctor autofix-all .     # apply every deterministic Roslyn rewriter
+maf-doctor init              # wire the MCP server + MAF steering into this repo
+```
+
+## `init` is non-destructive — it attaches and updates only
+
+Running `maf-doctor init` **never overwrites or merges into your own files.** It only:
+
+- **Adds its own MCP server entry** to **VS Code** (`.vscode/mcp.json`) and **Claude Code** (`.mcp.json`) — existing entries are left untouched.
+- **Drops MAF steering as self-contained sidecars** in each tool's convention directory — `.github/instructions/` (Copilot), `.claude/` plus a one-line import in `CLAUDE.md` (Claude Code), and a clearly-delimited managed block in `AGENTS.md`.
+- These sidecars are **regenerated on every re-run**, so re-initializing after an upgrade is always safe and idempotent — your hand-authored instructions are never edited.
+
+Uninstall is just as clean: `dotnet tool uninstall --global maf-doctor`, then delete the sidecars.
+
+## What you get
+
+- **MCP server** — 25 tools, 6 resources, and 7 prompts for GitHub Copilot / Claude Code / Cursor.
+- **CLI** — `doctor`, `autofix-all`, `new agent`, `init`, and more.
+- **Plugin** — 12 bundled skills + 7 specialist agents wired into Copilot's and Claude's agentic loops.
+- A companion **[maf-doctor.Analyzers](https://www.nuget.org/packages/maf-doctor.Analyzers)** package — 3 Roslyn analyzers (MAF001 / MAF002 / MAF003) for IDE write-time enforcement.
+
+## Highlights
+
+- 🔍 **Catches bugs that compile clean** — fan-out/fan-in silent failures where a workflow exits successfully but produces no output. Zero build signal.
+- 🩺 **Compiler ground-truth for CS0618** — obsolete-API usage mapped to its exact replacement pattern. Deterministic fixes, not hallucinated ones.
+- 🆕 **`doctor --all`** — list *every* finding (not just the top 3), one line each, ordered by impact. Full triage in one pass.
+- 📖 **It updates itself** — a weekly GitHub Actions watcher refreshes the migration guide, compatibility matrix, and obsolete-API registry as new MAF versions ship, so you don't pin to a MAF version or wait on a maintainer release.
+- 🔐 **Security-hardened** — closes the named MCP attack lattice (path-escape, annotation drift, scaffold code-injection, prompt-injection, workflow-dispatch input injection). Cisco mcp-scanner: 25/25 tools SAFE, 0 findings.
+
+## Full docs
+
+📖 **[github.com/joslat/maf-doctor](https://github.com/joslat/maf-doctor)** — 3-minute quickstart, `init` reference, usage guide (prompts / tools / agents + natural-language steering), hands-on workshop, and security docs.
+
+_MIT licensed._

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **MAF Doctor** is a **.NET global tool** (installed from NuGet) that does three things in one install:
 
-1. **An MCP server** — exposes 25 executable tools, 6 resources, and 7 prompts to GitHub Copilot / Claude Code / Cursor.
+1. **An MCP server** — exposes 26 executable tools, 6 resources, and 8 prompts to GitHub Copilot / Claude Code / Cursor.
 2. **A CLI** — **doctor** for an A–F health letter, **autofix-all** for deterministic rewriters, **new agent** to scaffold, **init** to wire up your repo, and more.
 3. **A plugin** — init drops steering snippets and wires the MCP server into both VS Code and Claude Code, so Copilot's and Claude's agentic loops gain MAF-specific knowledge (12 bundled skills + 7 specialist agents).
 
@@ -30,7 +30,7 @@ Plus a separate **maf-doctor.Analyzers** NuGet package with 3 Roslyn analyzers (
 - 🤖 **Fully agentic loop** — Copilot audits your codebase, generates a tracked migration plan, and executes it task-by-task, building after every step.
 - 🧰 **Deterministic fixes, not guesses** — the obsolete-API registry maps every known CS0618 warning to its exact replacement pattern. No hallucinated fixes.
 - 📖 **It updates itself** — as new MAF versions ship, the toolkit refreshes its own migration knowledge automatically. [How →](#it-updates-itself)
-- 🔐 **Hardened against the named MCP attack lattice** — a comprehensive security pass closes the critical- and high-tier MCP attack classes (path-escape, annotation drift, scaffold code-injection, prompt-injection via release notes, workflow-dispatch input injection), with defense-in-depth helpers and CI-enforced invariants. Cisco mcp-scanner: 25/25 tools SAFE, 0 findings. See [SECURITY.md](SECURITY.md) and [docs/security.md](docs/security.md).
+- 🔐 **Hardened against the named MCP attack lattice** — a comprehensive security pass closes the critical- and high-tier MCP attack classes (path-escape, annotation drift, scaffold code-injection, prompt-injection via release notes, workflow-dispatch input injection), with defense-in-depth helpers and CI-enforced invariants. Cisco mcp-scanner: all tools SAFE, 0 findings. See [SECURITY.md](SECURITY.md) and [docs/security.md](docs/security.md).
 
 ## It updates itself
 
@@ -50,9 +50,9 @@ The practical upshot: you don't pin to a MAF version in these docs, and you don'
 
 MAF Doctor is a **[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server** packaged as a .NET global tool. With no subcommand it runs in MCP mode and exposes:
 
-- **25 executable tools**, each annotated with MCP behavior hints (read-only / destructive / idempotent / open-world) so clients can auto-classify them — registry lookup, code scanning, build-verified CS0618 hunts, NuGet diffing, workflow simulation, scaffolding, PR-scoped audits, version planning, and a single-command health letter. The anti-pattern and fan-out scanners emit SARIF for GitHub Advanced Security; the two destructive tools (auto-fix and auto-fix-all) support a dry-run.
+- **26 executable tools**, each annotated with MCP behavior hints (read-only / destructive / idempotent / open-world) so clients can auto-classify them — registry lookup, code scanning, build-verified CS0618 hunts, NuGet diffing, workflow simulation, scaffolding, PR-scoped audits, version planning, and a single-command health letter. The anti-pattern and fan-out scanners emit SARIF for GitHub Advanced Security; the two destructive tools (auto-fix and auto-fix-all) support a dry-run.
 - **6 resources** — the migration guide, constraints, registry, rules, help, and per-name skills — readable on demand.
-- **7 prompts** — audit, migrate, cs0618-hunt, review, debug, scaffold, and help.
+- **8 prompts** — audit, migrate, cs0618-hunt, review, debug, explain-finding, scaffold, and help.
 - **3 Roslyn analyzers** (in the separate maf-doctor.Analyzers package) — MAF001 (fan-out), MAF002 (DefaultAzureCredential), MAF003 (EnableSensitiveData). Write-time enforcement.
 
 With a subcommand, the same binary runs as a CLI tool — see Quick Start below.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ cd your-maf-project
 maf-doctor init
 ```
 
-init wires the MCP server into both **VS Code** (.vscode/mcp.json) and **Claude Code** (.mcp.json), and drops auto-loaded steering in each tool's convention dir — .github/instructions/ for Copilot, .claude/ plus a one-line CLAUDE.md import for Claude Code, and an AGENTS.md managed block. These are refreshed on every re-run and never merged into your own files. Your assistant picks the server up automatically and gains live tool calls, resource reads, and structured prompts.
+`init` is **non-destructive — it attaches and updates only, never overwriting your files.** It adds its own MCP server entry to both **VS Code** (.vscode/mcp.json) and **Claude Code** (.mcp.json), and drops auto-loaded steering as self-contained sidecars in each tool's convention dir — .github/instructions/ for Copilot, .claude/ plus a one-line CLAUDE.md import for Claude Code, and an AGENTS.md managed block. These sidecars are refreshed on every re-run and never merged into your hand-authored files, so re-running `init` after an upgrade is always safe. Your assistant picks the server up automatically and gains live tool calls, resource reads, and structured prompts.
 
 > 📖 **Going deeper:** [what `init` installs (and why)](docs/init-reference.md) · [using MAF Doctor — prompts, tools, agents & natural-language steering](docs/usage.md) · [hands-on workshop](samples/workshop.md).
 

--- a/docs/output-schemas.md
+++ b/docs/output-schemas.md
@@ -9,19 +9,20 @@ Pass `format: "json"` to get machine-readable output.
 ```json
 {
   "schema_version": "1",
-  "verdict": "B",
-  "errors_count": 0,
-  "warnings_count": 3,
+  "verdict": "C",
+  "errors_count": 1,
+  "warnings_count": 0,
   "silent_starvation_risks": 0,
   "top_fixes": [
     {
       "rule_id": "MAF-AP-SEC-003",
-      "severity": "warning",
+      "severity": "error",
       "file": "src/MyAgent.cs",
       "line": 42,
       "issue": "EnableSensitiveData = true",
       "fix_description": "Remove EnableSensitiveData = true from non-dev configurations.",
-      "auto_fixable": true
+      "auto_fixable": true,
+      "why": "Sensitive-data logging writes prompts and responses (often PII / secrets) to your telemetry sink — acceptable in dev, a data-leak in production."
     }
   ],
   "summary_md": "...the full markdown report that format:markdown would emit..."
@@ -35,7 +36,7 @@ Pass `format: "json"` to get machine-readable output.
 - `errors_count`: anti-pattern errors + prompt-lint errors (integer)
 - `warnings_count`: anti-pattern warnings + prompt-lint warnings (integer)
 - `silent_starvation_risks`: fan-out handler violations (integer)
-- `top_fixes`: array of 0-3 highest-priority finding objects
+- `top_fixes`: array of finding objects — the top 3 by default, or **every** finding when `--all` / `full: true` is set (the key name is retained for schema-v1 stability)
   - `rule_id`: the canonical rule identifier (e.g., `MAF-AP-SEC-001`, `MAF001`, `COST-001`)
   - `severity`: `"error"` | `"warning"` | `"starvation_risk"`
   - `file`: relative path to the file containing the finding (links directly to source)
@@ -43,14 +44,16 @@ Pass `format: "json"` to get machine-readable output.
   - `issue`: short, human-readable title of the finding
   - `fix_description`: one-line actionable fix; `MafAutoFixAll` uses this as its rewrite spec
   - `auto_fixable`: `true` if `MafAutoFixAll` has a deterministic rewriter for this rule
+  - `why`: one-line consequence / rationale for the finding. **Always present**; the empty string `""` when no rationale is defined for the rule.
 - `summary_md`: the same markdown that `format: "markdown"` would emit (for hybrid consumers)
 
 ### Usage in CI
 
 ```bash
-# Get JSON output and check verdict
-OUTPUT=$(maf-doctor doctor . --format json 2>/dev/null || \
-  dotnet run --project src/maf-autopilot/ -- doctor . --format json)
+# Get JSON output and check verdict.
+# CLI flag is `--json` (boolean); the MCP tool parameter is `format: "json"`.
+OUTPUT=$(maf-doctor doctor . --json 2>/dev/null || \
+  dotnet run --project src/maf-autopilot/ -- doctor . --json)
 
 VERDICT=$(echo "$OUTPUT" | jq -r '.verdict')
 if [ "$VERDICT" = "F" ]; then
@@ -59,7 +62,7 @@ if [ "$VERDICT" = "F" ]; then
 fi
 ```
 
-Or via the MCP tool from your AI client:
+Or via the MCP tool from your AI client (note: the MCP parameter is `format: "json"`, not the CLI's `--json` flag):
 ```
 MafDoctor(repoPath: ".", format: "json")
 ```

--- a/docs/output-schemas.md
+++ b/docs/output-schemas.md
@@ -13,6 +13,7 @@ Pass `format: "json"` to get machine-readable output.
   "errors_count": 1,
   "warnings_count": 0,
   "silent_starvation_risks": 0,
+  "unbounded_cost_sites": 0,
   "top_fixes": [
     {
       "rule_id": "MAF-AP-SEC-003",
@@ -34,18 +35,20 @@ Pass `format: "json"` to get machine-readable output.
 - `schema_version`: `"1"` — increments only on breaking schema changes (new 1.x releases keep schema v1)
 - `verdict`: `"A"` | `"B"` | `"C"` | `"F"` per the grading rubric in `DoctorTool` description
 - `errors_count`: anti-pattern errors + prompt-lint errors (integer)
-- `warnings_count`: anti-pattern warnings + prompt-lint warnings (integer)
+- `warnings_count`: anti-pattern warnings + prompt-lint warnings + info notes (integer)
 - `silent_starvation_risks`: fan-out handler violations (integer)
+- `unbounded_cost_sites`: agent call sites with no `MaxOutputTokens` cap (integer)
+- The four counts above **reconcile with `top_fixes`** in full mode: `errors_count + warnings_count + silent_starvation_risks + unbounded_cost_sites == top_fixes.length`.
 - `top_fixes`: array of finding objects — the top 3 by default, or **every** finding when `--all` / `full: true` is set (the key name is retained for schema-v1 stability)
   - `rule_id`: the canonical rule identifier (e.g., `MAF-AP-SEC-001`, `MAF001`, `COST-001`)
-  - `severity`: `"error"` | `"warning"` | `"starvation_risk"`
+  - `severity`: `"error"` | `"warning"` | `"starvation_risk"` | `"cost"`
   - `file`: relative path to the file containing the finding (links directly to source)
   - `line`: line number within that file (1-based integer)
   - `issue`: short, human-readable title of the finding
   - `fix_description`: one-line actionable fix; `MafAutoFixAll` uses this as its rewrite spec
   - `auto_fixable`: `true` if `MafAutoFixAll` has a deterministic rewriter for this rule
   - `why`: one-line consequence / rationale for the finding. **Always present**; the empty string `""` when no rationale is defined for the rule.
-- `summary_md`: the same markdown that `format: "markdown"` would emit (for hybrid consumers)
+- `summary_md`: the same markdown that `format: "markdown"` would emit (for hybrid consumers). It includes the offending source line per finding, so it inherits the markdown report's **best-effort, content-aware secret redaction** — the structured `top_fixes` array carries no source text and is the safer channel for machine consumers.
 
 ### Usage in CI
 
@@ -66,6 +69,23 @@ Or via the MCP tool from your AI client (note: the MCP parameter is `format: "js
 ```
 MafDoctor(repoPath: ".", format: "json")
 ```
+
+---
+
+## `MafDoctor` plan output (`--plan` / `format: "plan"`)
+
+A **markdown-only** remediation plan (no JSON/SARIF schema) — an ordered, checkboxed
+punch list you can paste into a GitHub issue:
+
+- **Phase 1 — Quick wins:** every auto-fixable finding, batched into one `autofix-all`
+  step, with the cleared rules listed. (Note: `autofix-all` also applies build-surfaced
+  rewriters such as the fan-in arg-order swap (`MAF130-FAN-IN-001`) that the scan-time
+  grader doesn't flag — so it may change more than the plan enumerates.)
+- **Phase 2 — Semantic fixes:** the non-auto-fixable findings as impact-ordered `- [ ]`
+  tasks (why / fix / `file:line`), tagged for the `@maf-migration` agent.
+
+It **always covers every finding**, ignoring `--all` / `full`, and emits **no source
+snippets** — only `file:line` — so it never echoes a secret.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -73,7 +73,7 @@ Seven persona agents live in this toolkit's `.github/agents/`: `@maf` (triage), 
 The same binary, with a subcommand, runs as a CLI (no chat needed):
 
 ```bash
-maf-doctor doctor [path] [--exclude <s>]…   # A/B/C/F health report
+maf-doctor doctor [path] [--exclude <s>]… [--all] [--json]   # A/B/C/F health report (--all = every finding; --json = machine output)
 maf-doctor autofix-all [path] [--dry-run]   # apply deterministic Roslyn fixes
 maf-doctor new agent <Name>                 # scaffold an agent + smoke test
 maf-doctor new executor <Name> [In] [Out]   # scaffold a workflow executor

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -31,6 +31,7 @@ Prompts are pre-built workflows the server exposes; your client surfaces them as
 | `maf-cs0618-hunt` | Find + fix every CS0618 obsolete-API usage | — |
 | `maf-review` | Best-practice review of already-migrated code | `@maf-best-practice-reviewer` |
 | `maf-debug` | Diagnose a MAF failure → root cause + fix | `@maf-incident-responder` |
+| `maf-explain-finding` | Deep-dive + fix ONE doctor finding (file + line) | — |
 | `maf-scaffold` | Generate clean agent/executor boilerplate | — |
 | `maf-help` | Triage: where are you, what do you need? | `@maf-onboarding` |
 
@@ -45,7 +46,7 @@ The server exposes a couple dozen executable tools, each annotated read-only / d
 - **Workflow topology** — `MafSimulateWorkflow` (+ Mermaid)
 - **Scaffold** — `MafNewAgent`, `MafNewExecutor`
 - **Fix** — `MafAutoFix`, `MafAutoFixAll` (both support `dryRun`)
-- **Report** — `MafDoctor` (A/B/C/F health letter), `MafAuditPullRequest`, `MafExplain`, `MafBeforeAfter`, `MafCompatibility`, `MafDraftIssue`
+- **Report** — `MafDoctor` (A/B/C/F health letter), `MafExplainFinding` (deep-dive one finding), `MafAuditPullRequest`, `MafExplain`, `MafBeforeAfter`, `MafCompatibility`, `MafDraftIssue`
 
 > **Live catalogue:** ask the assistant to run **`MafTour`**, or read the **`maf://rules`** resource — both are generated from the actual code, so they never drift.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -74,7 +74,7 @@ Seven persona agents live in this toolkit's `.github/agents/`: `@maf` (triage), 
 The same binary, with a subcommand, runs as a CLI (no chat needed):
 
 ```bash
-maf-doctor doctor [path] [--exclude <s>]… [--all] [--json]   # A/B/C/F health report (--all = every finding; --json = machine output)
+maf-doctor doctor [path] [--exclude <s>]… [--all] [--json|--plan]   # A/B/C/F health report (--all = every finding; --json = machine output; --plan = remediation plan)
 maf-doctor autofix-all [path] [--dry-run]   # apply deterministic Roslyn fixes
 maf-doctor new agent <Name>                 # scaffold an agent + smoke test
 maf-doctor new executor <Name> [In] [Out]   # scaffold a workflow executor

--- a/samples/maf-1.0-sample/.expected-doctor.yaml
+++ b/samples/maf-1.0-sample/.expected-doctor.yaml
@@ -1,6 +1,6 @@
 # Expected MafDoctor output for the MAF 1.0.0 version-parity sample.
 # Same anti-pattern coverage as the 1.3 sample (different MAF pin — earliest).
 grade: F
-anti_pattern_errors: 10
+anti_pattern_errors: 7
 anti_pattern_warnings: 3
 silent_starvation_risks: 3

--- a/samples/maf-1.2-sample/.expected-doctor.yaml
+++ b/samples/maf-1.2-sample/.expected-doctor.yaml
@@ -1,6 +1,6 @@
 # Expected MafDoctor output for the MAF 1.2.0 version-parity sample.
 # Same anti-pattern coverage as the 1.3 sample (different MAF pin).
 grade: F
-anti_pattern_errors: 10
+anti_pattern_errors: 7
 anti_pattern_warnings: 3
 silent_starvation_risks: 3

--- a/samples/maf-1.3-sample/.expected-doctor.yaml
+++ b/samples/maf-1.3-sample/.expected-doctor.yaml
@@ -3,6 +3,6 @@
 # the regression ships. Update this file in lockstep with intentional sample
 # or toolkit changes. See src/maf-autopilot.Tests/SampleRegressionTests.cs.
 grade: F
-anti_pattern_errors: 10
+anti_pattern_errors: 7
 anti_pattern_warnings: 3
 silent_starvation_risks: 3

--- a/samples/workshop.md
+++ b/samples/workshop.md
@@ -104,7 +104,7 @@ git restore samples/maf-1.3-sample/
 
 - **Total command count: 6 commands.** No more than what fits on a slide.
 - **No Copilot Chat required.** No agent setup. No tokens consumed. Pure CLI.
-- **One "whoa" per beat.** Build warnings (beat 2) → grade F (3) → preview (4) → fix (5) → grade A (6). Each beat adds one piece of evidence.
+- **One "whoa" per beat.** Build warnings (beat 2) → grade F (3) → preview (4) → fix (5) → still F but errors cleared 7→4 (6) → plan (7). Each beat adds one piece of evidence; grade A comes later, in the agent flow.
 - **Resettable in one line.** Re-run the speedrun on any laptop without setup cost.
 
 ---

--- a/samples/workshop.md
+++ b/samples/workshop.md
@@ -44,7 +44,7 @@ You're looking at a workshop for **maf-doctor** — an AI co-pilot toolkit for t
 
 ## ⚡ Quick Speedrun — 5-10 minutes of "wow"
 
-> **Goal:** minimum time-to-wow. By minute 10 you've installed the toolkit, watched it diagnose a broken codebase, watched it auto-fix every mechanical issue, and watched the grade go from F → A. **No Copilot Chat. No agents. No setup beyond the .NET SDK.**
+> **Goal:** minimum time-to-wow. By minute 10 you've installed the toolkit, watched it diagnose a broken codebase (including silent-starvation bugs the build never warns about), and watched it **deterministically clear the mechanical errors** with one command — with the remaining *semantic* issues clearly flagged for the agent phase. **No Copilot Chat. No agents. No setup beyond the .NET SDK.** (Grade A comes later, in the agent-driven Phase D — deterministic auto-fix alone doesn't claim it.)
 >
 > **Audience:** someone who hasn't installed anything yet and wants the elevator pitch in real time.
 >
@@ -80,10 +80,11 @@ Run these in your terminal, one beat at a time. Each beat is 30-60 seconds with 
 |---|---|---|---|
 | **1** | `cd samples/maf-1.3-sample` | — | _"This is a real MAF 1.3.0 codebase. A small fraud-claims triage workflow. Looks fine. Let's see if it is."_ |
 | **2** | `dotnet build` | 4 Warning(s), 0 Error(s) — 1 × `CS0618` + 3 × `MAF001` | _"Builds clean — well, with 4 warnings the developer probably dismissed. The analyzer's already firing on three executor methods. We'll see why in a second."_ |
-| **3** | `maf-doctor doctor .` | 🔴 **Grade F** — 10 errors + 3 silent-starvation risks | _"The toolkit grades it: F. Ten anti-pattern errors. Three of them are silent-starvation risks — these compile clean and BREAK at runtime. No build warning. No exception. Just silently wrong output."_ |
-| **4** | `maf-doctor autofix-all . --dry-run` | JSON: 6 files would change across 5 rule families | _"This is what would change — preview only. Six files, five rule families. Deterministic. No LLM in this loop."_ |
-| **5** | `maf-doctor autofix-all .` | JSON: 6 files changed | _"Apply for real. Roslyn rewriters under the hood — same code path you'd trust in a Microsoft refactor extension."_ |
-| **6** | `maf-doctor doctor .` | 🟢 **Grade A** — 0 errors | _"And we're at grade A. Zero errors. The whole audit-fix-verify loop just ran in under 30 seconds, deterministically, on a real broken MAF codebase. That's what the toolkit does."_ |
+| **3** | `maf-doctor doctor .` | 🔴 **Grade F** — 7 errors + 3 silent-starvation risks | _"The toolkit grades it: F. Seven anti-pattern errors — and three silent-starvation risks that compile clean and BREAK at runtime. No build warning. No exception. Just silently wrong output."_ |
+| **4** | `maf-doctor autofix-all . --dry-run` | JSON: 4 files would change across 5 rule families | _"This is what would change — preview only. Four files, five rule families. Deterministic. No LLM in this loop."_ |
+| **5** | `maf-doctor autofix-all .` | JSON: 4 files changed | _"Apply for real. Roslyn rewriters under the hood — same code path you'd trust in a Microsoft refactor extension."_ |
+| **6** | `maf-doctor doctor .` | 🟠 **Grade F** — 4 errors + 3 starvation (down from 7+3) | _"Three mechanical errors gone — deterministically, no LLM. Still F: the rest are semantic — a hard-coded key, shared provider state, and the fan-out starvation bugs — and those need judgment. That's the hand-off to the `@maf-migration` agent (next section), which is what drives the grade to A."_ |
+| **7** | `maf-doctor doctor . --plan` | ordered remediation plan | _"And here's the punch list: Phase 1 was the autofix we just ran; Phase 2 is the semantic work, as checkboxes you can paste into a GitHub issue or hand to the agent."_ |
 
 ### Visual bonus beat (~30 seconds, optional but high impact)
 
@@ -389,10 +390,10 @@ Expected JSON output:
     "MAF130-FAN-IN-001",
     "MAF-AP-CONC-002"
   ],
-  "totalDistinctFilesChanged": 6,
+  "totalDistinctFilesChanged": 4,
   "affectedFiles": [
     "ChatClientFactory.cs",
-    "Executors/HistoryInvestigator.cs",
+    "Executors/TransactionInvestigator.cs",
     ...
   ]
 }
@@ -406,9 +407,9 @@ Re-run the doctor:
 maf-doctor doctor .
 ```
 
-Should report **grade A** — auto-fix handled all 5 mechanical rule families.
+Should still report **grade F**, but with **errors down from 7 to 4** — auto-fix cleared the mechanical rule families (DefaultAzureCredential, EnableSensitiveData, the `sealed partial` executor, the fan-in arg-order swap, and the sync-over-async warning). The remaining errors are *semantic* — a hard-coded API key and shared `AIContextProvider` state — and the 3 fan-out starvation risks need a return-type change that's a judgment call. Those go to the agent flow (Step 9), which is what drives the grade to A.
 
-> **Talk-track:** _"Five rules. Six files. Zero LLM calls. Took 800 milliseconds. A CI bot can do this on every PR — no Copilot subscription required, no token costs, fully deterministic."_
+> **Talk-track:** _"Five rule families. Four files. Zero LLM calls. Took 800 milliseconds. A CI bot can do this on every PR — no Copilot subscription required, no token costs, fully deterministic. It won't reach grade A on its own — the semantic fixes need the agent — but it clears the mechanical backlog every time."_
 
 #### Step 9 — The agent-driven flow (`@maf-auditor` + `@maf-migration`)
 

--- a/samples/workshop.md
+++ b/samples/workshop.md
@@ -72,7 +72,7 @@ git clone https://github.com/joslat/maf-doctor
 cd maf-doctor
 ```
 
-### The 6-beat speedrun (~5 minutes)
+### The 7-beat speedrun (~5 minutes)
 
 Run these in your terminal, one beat at a time. Each beat is 30-60 seconds with narration.
 
@@ -92,7 +92,7 @@ If you can show your IDE alongside the terminal:
 
 | # | Action | What attendees see | What to say |
 |---|---|---|---|
-| **7** | `code samples/maf-1.3-sample/` then open `Executors/OsintInvestigator.cs` | Red squiggly under `ValueTask` return type; hover shows `MAF001` with the explanation | _"And it's not just the CLI. The same rule fires write-time — the developer sees the squiggle before they even save the file. Shift-left baked in."_ |
+| **8** | `code samples/maf-1.3-sample/` then open `Executors/OsintInvestigator.cs` | Red squiggly under `ValueTask` return type; hover shows `MAF001` with the explanation | _"And it's not just the CLI. The same rule fires write-time — the developer sees the squiggle before they even save the file. Shift-left baked in."_ |
 
 ### Reset for the next attendee (~10 seconds)
 
@@ -102,7 +102,7 @@ git restore samples/maf-1.3-sample/
 
 ### Why this works as a 5-minute demo
 
-- **Total command count: 6 commands.** No more than what fits on a slide.
+- **Total command count: 7 commands.** No more than what fits on a slide.
 - **No Copilot Chat required.** No agent setup. No tokens consumed. Pure CLI.
 - **One "whoa" per beat.** Build warnings (beat 2) → grade F (3) → preview (4) → fix (5) → still F but errors cleared 7→4 (6) → plan (7). Each beat adds one piece of evidence; grade A comes later, in the agent flow.
 - **Resettable in one line.** Re-run the speedrun on any laptop without setup cost.
@@ -113,7 +113,7 @@ git restore samples/maf-1.3-sample/
 
 > **Audience:** workshop attendees + maintainers running the toolkit end-to-end on a real MAF 1.3.0 codebase. Covers the agent-driven flow (`@maf-auditor` / `@maf-migration`), the multi-agent surface, and the post-migration tooling.
 >
-> **What you'll do:** open the `maf-1.3-sample/` codebase standalone in VS Code Insiders, wire up the `maf-doctor` MCP server, walk through each of the 22 MCP tools at least once, run the full migration loop, and finish with a multi-version regression plan.
+> **What you'll do:** open the `maf-1.3-sample/` codebase standalone in VS Code Insiders, wire up the `maf-doctor` MCP server, walk through each of the 26 MCP tools at least once, run the full migration loop, and finish with a multi-version regression plan.
 
 ### Prerequisites
 
@@ -261,16 +261,27 @@ Switch to Copilot Chat (still inside the sample folder):
 Expected:
 
 ```
-🔴 MAF health grade: F
+## 🔴 MAF health grade: F
 
-10 anti-pattern errors + 3 silent-starvation risk(s)
+_7 error(s) + 3 silent-starvation risk(s)_
 
-Top fixes (ordered by impact):
-  1. HandleAsync at Executors/HistoryInvestigator.cs:19   returns ValueTask
-  2. HandleAsync at Executors/OsintInvestigator.cs:23     returns ValueTask
-  3. HandleAsync at Executors/TransactionInvestigator.cs:21 returns ValueTask
+| Metric | Count |
+|---|---:|
+| Anti-pattern errors | 7 |
+| Anti-pattern warnings | 3 |
+| Silent-starvation risks (fan-out handlers) | 3 |
 
-Run `MafScanAntiPatterns(repoPath)` for the full breakdown.
+### Top fixes (ordered by impact)
+
+1. [MafValidateFanOut] HandleAsync at Executors/HistoryInvestigator.cs:21 returns ValueTask — fan-out handler must return Task<T> · needs your judgment
+   - Why: a fan-out handler that doesn't return Task<T>/ValueTask<T>/IAsyncEnumerable<T> yields no message to the fan-in barrier — aggregation silently runs on partial data, no exception.
+   - Fix: change the return type to Task<T>, ValueTask<T>, or IAsyncEnumerable<T>.
+2. [MafValidateFanOut] HandleAsync at Executors/OsintInvestigator.cs:25 returns ValueTask — …
+3. [MafValidateFanOut] HandleAsync at Executors/TransactionInvestigator.cs:23 returns ValueTask — …
+
+_…and 10 more. Run with `--all` (CLI) or `full: true` (MafDoctor) for every finding._
+
+💡 3 of 13 finding(s) are auto-fixable — apply with `maf-doctor autofix-all .`. The rest need your judgment.
 ```
 
 > **What `MafDoctor` does under the hood:** composes 4 scanners — anti-pattern (Roslyn + regex), fan-out validator (Roslyn), prompt-lint, and token-cap auditor — into a single weighted grade. The verdict is the single most actionable signal in the toolkit.
@@ -281,7 +292,7 @@ Each row below is one Copilot Chat prompt. Run them sequentially — each surfac
 
 | # | Ask Copilot | Tool invoked | What you'll see |
 |---|---|---|---|
-| **5a** | "show me every anti-pattern in this code" | `MafScanAntiPatterns` | 10 errors + 3 warnings; each finding with file + line + rule ID |
+| **5a** | "show me every anti-pattern in this code" | `MafScanAntiPatterns` | 7 errors + 3 warnings; each finding with file + line + rule ID |
 | **5b** | "check the fan-out executors for silent-starvation risks" | `MafValidateFanOut` | The 3 investigators flagged — `HandleAsync` returns `ValueTask` not `ValueTask<T>` |
 | **5c** | "diagram the workflow topology" | `MafSimulateWorkflow` | Mermaid graph: intake → fan-out → fan-in → decision → notify |
 | **5d** | "find any CS0618 warnings the compiler reports" | `MafRunCs0618Hunt` | `WorkflowBuilder.AddFanInBarrierEdge` obsolete overload at `Workflows/FraudClaimsWorkflow.cs:50` |
@@ -327,10 +338,10 @@ Expected JSON output (paraphrased):
 ```json
 {
   "verdict": "HARD",
-  "score": 22,
+  "score": 17,
   "thresholds": { "easyBelow": 5, "hardAtOrAbove": 15 },
   "breakdown": {
-    "antiPatternErrors": 10,
+    "antiPatternErrors": 7,
     "silentStarvationRisks": 3,
     "cs0246Count": 0,
     "cs0618Count": 1,
@@ -533,7 +544,7 @@ rm -f samples/maf-1.3-sample/docs/migration-plan.md
 ### Takeaways
 
 - The sample is a **fixed-cost regression artefact** — every future MAF version can be regression-tested against the same sample by re-running the migration loop.
-- The toolkit detects **10 distinct anti-pattern errors + 3 silent-starvation risks** from a single ~150-LoC codebase.
+- The toolkit detects **7 distinct anti-pattern errors + 3 silent-starvation risks** from a single ~150-LoC codebase.
 - **Two complementary paths:** deterministic (`MafAutoFix --all`, ~5 seconds, no LLM) for the mechanical 80% of rules; agent-driven (`@maf-migration`) for the judgement-bound 20%.
 - The whole detect → score → preview → fix → verify → retrospective → multi-version loop runs in **~50 minutes of chat interaction**.
 - The 3 registry-drift findings recorded during Phase T are the kind of corrections that only surface from real-world dogfooding — exactly the value-add Phase T was meant to produce.
@@ -607,11 +618,11 @@ The first two are **automatable** (just run the `.tape` scripts). The last two a
 | **Length target** | 5-10 minutes (try for 7) |
 | **Audience** | Conference attendee at a booth, prospect on a sales call, manager getting a 1-on-1 demo |
 | **Tools needed** | OBS Studio (or QuickTime on macOS) for screen-record; a mic for voiceover; a clean shell + a code editor side-by-side |
-| **Preparation (~10 min)** | (a) Fresh terminal session in `samples/maf-1.3-sample/` (sample in broken state). (b) VS Code Insiders open with `Executors/OsintInvestigator.cs` already focused. (c) Have the 6-beat script open on a second monitor for reference. (d) Run through it once dry to time yourself. |
+| **Preparation (~10 min)** | (a) Fresh terminal session in `samples/maf-1.3-sample/` (sample in broken state). (b) VS Code Insiders open with `Executors/OsintInvestigator.cs` already focused. (c) Have the 7-beat script open on a second monitor for reference. (d) Run through it once dry to time yourself. |
 | **Before state** | Terminal: empty prompt at `samples/maf-1.3-sample/`. VS Code: OsintInvestigator.cs visible, MAF001 squiggly already showing on the `ValueTask` return type. |
-| **What to do** | Follow the 6-beat speedrun above, in order. Each beat ~30-60 seconds with voiceover. |
+| **What to do** | Follow the 7-beat speedrun above, in order. Each beat ~30-60 seconds with voiceover. |
 | **What to say** | The "What to say" column of the speedrun table. Adapt the wording to your voice. |
-| **After state** | Terminal: doctor reports grade A. VS Code: OsintInvestigator.cs squiggle is gone after the refresh. |
+| **After state** | Terminal: doctor reports grade **F** — 4 errors (down from 7) + 3 starvation; the remaining errors are semantic, so Grade A is the next-section agent flow, NOT the autofix. VS Code: the OsintInvestigator.cs MAF001 squiggle is STILL there (fan-out starvation needs judgment, not auto-fix). |
 | **Cleanup (~30 sec)** | `git restore samples/maf-1.3-sample/` then refresh VS Code so the squiggles come back for the next take. |
 | **Where it goes** | YouTube / Loom / Mux / wherever you host. Embed in `/README.md` as a "Watch the 7-minute demo" link below the GIFs. |
 
@@ -631,14 +642,14 @@ The first two are **automatable** (just run the `.tape` scripts). The last two a
 
 [1:30 — 3:00]  Beat 3 — the doctor
   maf-doctor doctor .
-  "Grade F. Ten anti-pattern errors. Three silent-starvation risks.
+  "Grade F. Seven anti-pattern errors. Three silent-starvation risks.
    These compile clean and break at runtime. No build warning, no
    exception, just silently wrong output. The toolkit found them all
    in 850 milliseconds."
 
 [3:00 — 4:00]  Beat 4 — preview
   maf-doctor autofix-all . --dry-run
-  "This is what would change — preview only. Six files, five rule
+  "This is what would change — preview only. Four files, five rule
    families. Deterministic — no LLM in this loop."
 
 [4:00 — 5:00]  Beat 5 — fix for real
@@ -648,11 +659,16 @@ The first two are **automatable** (just run the `.tape` scripts). The last two a
 
 [5:00 — 6:00]  Beat 6 — verify
   maf-doctor doctor .
-  "Grade A. Zero errors. The audit-fix-verify loop just ran in under
-   30 seconds, deterministically, on a real broken MAF codebase."
+  "Still Grade F — but three mechanical errors are gone, 7 down to 4,
+   deterministically, in under 30 seconds. The rest are semantic — a
+   hard-coded key, shared provider state, the fan-out starvation bugs —
+   and THOSE are the hand-off to the @maf-migration agent, which is what
+   drives the grade to A in the next section."
 
 [6:00 — 7:00]  Visual bonus — VS Code analyzer
-  (switch to VS Code, show squiggle is gone)
+  (switch to VS Code; the MAF001 squiggle on the ValueTask return is
+   STILL there — this is the write-time DETECTION angle, not a fix; the
+   fan-out starvation is one of the semantic bugs the agent handles)
   "Same rule fires write-time too. Your developer sees the squiggle
    before they save the file. Shift-left baked in."
 

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -14,7 +14,7 @@
 
     <!-- NuGet packaging -->
     <PackageId>maf-doctor.Analyzers</PackageId>
-    <Version>1.2.12</Version>
+    <Version>1.3.0</Version>
     <Authors>joslat</Authors>
     <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) — write-time enforcement of fan-out safety, secure credentials, and observability defaults (MAF001-MAF003). Companion to the maf-doctor .NET global tool / MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -14,13 +14,13 @@
 
     <!-- NuGet packaging -->
     <PackageId>maf-doctor.Analyzers</PackageId>
-    <Version>1.2.11</Version>
+    <Version>1.2.12</Version>
     <Authors>joslat</Authors>
     <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) — write-time enforcement of fan-out safety, secure credentials, and observability defaults (MAF001-MAF003). Companion to the maf-doctor .NET global tool / MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/joslat/maf-doctor</RepositoryUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageIcon>MAFDoctorIcon.png</PackageIcon>
     <DevelopmentDependency>true</DevelopmentDependency>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -66,7 +66,7 @@
   <ItemGroup>
     <!-- Ship the analyzer DLL inside the analyzers/ NuGet folder so it's picked up automatically. -->
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" Visible="false" />
+    <None Include="..\..\NUGET_README.md" Pack="true" PackagePath="\" Visible="false" />
     <None Include="..\..\assets\MAFDoctorIcon.png" Pack="true" PackagePath="\" Visible="false" />
   </ItemGroup>
 

--- a/src/maf-autopilot.Tests/AntiPatternScannerToolTests.cs
+++ b/src/maf-autopilot.Tests/AntiPatternScannerToolTests.cs
@@ -210,6 +210,23 @@ public class AntiPatternScannerToolTests
         Assert.Contains(findings, f => f.RuleId == "MAF-AP-OBS-001");
     }
 
+    [Fact]
+    public void Obs001_TypeReferenceOnly_DoesNotFlag()
+    {
+        // A bare TYPE reference (parameter type, field type, nameof) is not building
+        // an agent — only a `new AIAgentBuilder(...)` / `new ChatClientAgent(...)`
+        // CONSTRUCTION should fire. The earlier identifier-match over-flagged these.
+        const string source = """
+            public class AgentSetup
+            {
+                private AIAgentBuilder _cached;
+                public void Configure(AIAgentBuilder builder) { var n = nameof(AIAgentBuilder); }
+            }
+            """;
+        var findings = AntiPatternScannerTool.ScanFile(source, "src/AgentSetup.cs");
+        Assert.DoesNotContain(findings, f => f.RuleId == "MAF-AP-OBS-001");
+    }
+
     // -------------------------------------------------------------------------
     // MAF-AP-AGENT-001 — Instructions at top of ChatClientAgentOptions (silent ignore)
     // -------------------------------------------------------------------------
@@ -314,6 +331,23 @@ public class AntiPatternScannerToolTests
             """;
         var findings = AntiPatternScannerTool.ScanFile(source, "src/FraudExecutor.cs");
         Assert.Contains(findings, f => f.RuleId == "MAF-AP-WF-001");
+    }
+
+    [Fact]
+    public void Wf001_StaticExecutor_NotFlagged_ParityWithRewriter()
+    {
+        // A static class can't derive from Executor (compile error) — not fixable, so
+        // the scanner skips it, matching ExecutorSealedRewriter which leaves it
+        // untouched (detector⇆rewriter parity; previously the scanner flagged it).
+        const string source = """
+            public static class HelperExecutor : Executor
+            {
+                [MessageHandler]
+                public static System.Threading.Tasks.Task<int> Handle(string s) => System.Threading.Tasks.Task.FromResult(0);
+            }
+            """;
+        var findings = AntiPatternScannerTool.ScanFile(source, "src/HelperExecutor.cs");
+        Assert.DoesNotContain(findings, f => f.RuleId == "MAF-AP-WF-001");
     }
 
     // -------------------------------------------------------------------------

--- a/src/maf-autopilot.Tests/AntiPatternScannerToolTests.cs
+++ b/src/maf-autopilot.Tests/AntiPatternScannerToolTests.cs
@@ -162,6 +162,54 @@ public class AntiPatternScannerToolTests
         Assert.DoesNotContain(findings, f => f.RuleId == "MAF-AP-OBS-001");
     }
 
+    [Fact]
+    public void Obs001_BuilderMentionedOnlyInComment_DoesNotFlag()
+    {
+        // Round-8 regression: the builder type appears ONLY in a comment — no agent
+        // is actually constructed. The node-based rule must not fire (comments are
+        // trivia, never syntax nodes).
+        const string source = """
+            public class AgentSetup
+            {
+                // example: var a = new AIAgentBuilder(client).Build();
+                public int Compute() => 1 + 2;
+            }
+            """;
+        var findings = AntiPatternScannerTool.ScanFile(source, "src/AgentSetup.cs");
+        Assert.DoesNotContain(findings, f => f.RuleId == "MAF-AP-OBS-001");
+    }
+
+    [Fact]
+    public void Obs001_BuilderMentionedOnlyInStringLiteral_DoesNotFlag()
+    {
+        // Round-8 regression: a string body that mentions AIAgentBuilder is data,
+        // not code — a literal token, not an identifier node.
+        const string source = """
+            public class Docs
+            {
+                public string Help => "see the AIAgentBuilder docs for telemetry";
+            }
+            """;
+        var findings = AntiPatternScannerTool.ScanFile(source, "src/Docs.cs");
+        Assert.DoesNotContain(findings, f => f.RuleId == "MAF-AP-OBS-001");
+    }
+
+    [Fact]
+    public void Obs001_ChatClientAgentConstruction_Flags()
+    {
+        // The `new ChatClientAgent(...)` construction path (not just AIAgentBuilder)
+        // must also fire when telemetry is absent.
+        const string source = """
+            public class AgentSetup
+            {
+                public void Build(object client, object opts)
+                    => _ = new ChatClientAgent(client, opts);
+            }
+            """;
+        var findings = AntiPatternScannerTool.ScanFile(source, "src/AgentSetup.cs");
+        Assert.Contains(findings, f => f.RuleId == "MAF-AP-OBS-001");
+    }
+
     // -------------------------------------------------------------------------
     // MAF-AP-AGENT-001 — Instructions at top of ChatClientAgentOptions (silent ignore)
     // -------------------------------------------------------------------------
@@ -252,6 +300,22 @@ public class AntiPatternScannerToolTests
         Assert.DoesNotContain(findings, f => f.RuleId == "MAF-AP-WF-001");
     }
 
+    [Fact]
+    public void Wf001_GenericExecutorBase_Flags()
+    {
+        // Round-8 regression: a generic `Executor<…>` base was missed because the
+        // old check compared the base-type STRING against "Executor"/".Executor".
+        const string source = """
+            public class FraudExecutor : Microsoft.Agents.AI.Workflows.Executor<string, int>
+            {
+                [MessageHandler]
+                public Task<int> Handle(string s) => Task.FromResult(0);
+            }
+            """;
+        var findings = AntiPatternScannerTool.ScanFile(source, "src/FraudExecutor.cs");
+        Assert.Contains(findings, f => f.RuleId == "MAF-AP-WF-001");
+    }
+
     // -------------------------------------------------------------------------
     // MAF-AP-MID-001 — Middleware Use() must provide both callbacks
     // -------------------------------------------------------------------------
@@ -306,6 +370,37 @@ public class AntiPatternScannerToolTests
                             runStreamingFunc: (m, o, n, ct) => n(m, o, ct))
                         .Build();
                 }
+            }
+            """;
+        var findings = AntiPatternScannerTool.ScanFile(source, "src/Setup.cs");
+        Assert.DoesNotContain(findings, f => f.RuleId == "MAF-AP-MID-001");
+    }
+
+    [Fact]
+    public void Mid001_PositionalArgNamedRunFunc_DoesNotFlag()
+    {
+        // Round-8 regression: a positional local named `runFunc` (no `runFunc:` label)
+        // must NOT fire — the old substring scan false-fired on the bare text.
+        const string source = """
+            public class Setup
+            {
+                public void Build(object pipeline, object runFunc) => pipeline.Use(runFunc);
+            }
+            """;
+        var findings = AntiPatternScannerTool.ScanFile(source, "src/Setup.cs");
+        Assert.DoesNotContain(findings, f => f.RuleId == "MAF-AP-MID-001");
+    }
+
+    [Fact]
+    public void Mid001_SubstringInUnrelatedIdentifier_DoesNotFlag()
+    {
+        // Round-8 regression: an identifier that merely CONTAINS "runFunc"
+        // (e.g. `computeMyrunFunc()`) must NOT fire.
+        const string source = """
+            public class Setup
+            {
+                object computeMyrunFunc() => null;
+                public void Build(object obj) => obj.Use(computeMyrunFunc());
             }
             """;
         var findings = AntiPatternScannerTool.ScanFile(source, "src/Setup.cs");

--- a/src/maf-autopilot.Tests/AutoFixToolTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixToolTests.cs
@@ -804,12 +804,14 @@ public class AutoFixToolTests
     // mutually exclusive). Pre-fix the rewriter happily inserted `sealed` on
     // any class deriving from Executor with a [MessageHandler], producing
     // uncompilable user code when the source class was abstract. Same for
-    // `sealed static class` (also rejected by the compiler). Now: skip the
-    // rewrite and emit a leading-trivia comment explaining why.
+    // `sealed static class` (also rejected by the compiler). Now: leave abstract
+    // and static Executors UNCHANGED — parity with the scanner, which skips them
+    // (so autofix/preview honestly report "no change" instead of dirtying a
+    // scanner-clean file with an advisory comment).
     // -------------------------------------------------------------------------
 
     [Fact]
-    public void ExecutorSealedRewriter_AbstractClass_NotRewritten_WithWarningComment()
+    public void ExecutorSealedRewriter_AbstractClass_LeftUnchanged()
     {
         var src = """
             using Microsoft.Agents.AI.Workflow;
@@ -821,12 +823,12 @@ public class AutoFixToolTests
             """;
         var output = ApplyRewriter(new ExecutorSealedRewriter(), src);
 
-        // The output must NOT contain the uncompilable `sealed abstract` order
-        // (the unguarded path would insert `sealed` right after `abstract`,
-        // producing `abstract sealed class`).
+        // Parity with the scanner: an abstract Executor is left UNTOUCHED — no
+        // `sealed` (which would be the uncompilable `abstract sealed`), and no
+        // advisory comment that would dirty a scanner-clean file.
         Assert.DoesNotContain("sealed", output);
-        // The skip-warning comment is present.
-        Assert.Contains("cannot seal an abstract Executor", output);
+        Assert.DoesNotContain("cannot seal", output);
+        Assert.Equal(src, output.TrimEnd());
     }
 
     [Fact]

--- a/src/maf-autopilot.Tests/AutoFixToolTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixToolTests.cs
@@ -318,6 +318,22 @@ public class AutoFixToolTests
         Assert.Equal(input, output.TrimEnd());
     }
 
+    [Fact]
+    public void ExecutorSealedRewriter_GenericExecutorBase_AddsSealedPartial()
+    {
+        // Round-8 parity: a generic `Executor<…>` base must be sealed/partial'd too,
+        // matching the now generic-aware WF-001 scanner (shared IsExecutorBaseType).
+        var input = """
+            public class MyExec : Microsoft.Agents.AI.Workflows.Executor<string, int>
+            {
+                [MessageHandler]
+                public Task<int> Handle(string s) => Task.FromResult(0);
+            }
+            """;
+        var output = ApplyRewriter(new ExecutorSealedRewriter(), input);
+        Assert.Contains("sealed partial class MyExec", output);
+    }
+
     // -------------------------------------------------------------------------
     // FanInArgOrderRewriter (MAF130-FAN-IN-001)
     // -------------------------------------------------------------------------
@@ -376,6 +392,54 @@ public class AutoFixToolTests
         // Named labels stripped + args reordered.
         Assert.DoesNotContain("target:", output);
         Assert.DoesNotContain("sources:", output);
+    }
+
+    [Fact]
+    public void FanInArgOrderRewriter_DoesNotDropInterArgComment()
+    {
+        // Round-8 regression: a comment carried on the separator (between the two
+        // arguments) must survive the swap — the old SeparatedList(values) discarded
+        // the original separator and lost it.
+        var input = """
+            class C
+            {
+                void F(object builder, object target, object s1, object s2)
+                {
+                    builder.AddFanInBarrierEdge(
+                        target,            // the join node
+                        new[] { s1, s2 });
+                }
+            }
+            """;
+        var output = ApplyRewriter(new FanInArgOrderRewriter(), input);
+        Assert.Contains("// the join node", output); // preserved, not dropped
+    }
+
+    [Fact]
+    public void FanInArgOrderRewriter_KeepsEachValuesOwnTrailingComment()
+    {
+        // Round-8 regression: each argument's own trailing comment travels with its
+        // VALUE, not its slot. Pre-fix WithTriviaFrom swapped them onto wrong args.
+        var input = """
+            class C
+            {
+                void F(object builder, object targetNode, object s1, object s2)
+                {
+                    builder.AddFanInBarrierEdge(targetNode /*T*/, new[] { s1, s2 } /*S*/);
+                }
+            }
+            """;
+        var output = ApplyRewriter(new FanInArgOrderRewriter(), input);
+        // New order: `new[] { s1, s2 } /*S*/, targetNode /*T*/`.
+        var idxArray = output.IndexOf("new[]", StringComparison.Ordinal);
+        var idxS = output.IndexOf("/*S*/", StringComparison.Ordinal);
+        var callStart = output.IndexOf("AddFanInBarrierEdge", StringComparison.Ordinal);
+        var idxTargetInCall = output.IndexOf("targetNode", callStart, StringComparison.Ordinal);
+        var idxT = output.IndexOf("/*T*/", StringComparison.Ordinal);
+        Assert.Contains("/*T*/", output);
+        Assert.Contains("/*S*/", output);
+        Assert.True(idxArray < idxS && idxS < idxTargetInCall, $"/*S*/ must stay with the array. Output:\n{output}");
+        Assert.True(idxTargetInCall < idxT, $"/*T*/ must stay with targetNode. Output:\n{output}");
     }
 
     // -------------------------------------------------------------------------

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -303,6 +303,280 @@ public class DoctorToolTests
     // `Run(..., excludes)` must skip those so the grade reflects product code.
     // -------------------------------------------------------------------------
 
+    // -------------------------------------------------------------------------
+    // Tier 1 — richer suggestions: Why + Fix + autofix hint + source line in the
+    // human markdown report (previously the fix string lived only in JSON), plus
+    // rule-grouped --all output and a `why` field in JSON.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Markdown_Report_ShowsWhy_Fix_SourceLine_AndAutofixHint()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-tier1-md-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "Bad.cs"), """
+                using Azure.Identity;
+                public class Bad
+                {
+                    public Bad() { var c = new DefaultAzureCredential(); }
+                }
+                """);
+            var output = new DoctorTool().MafDoctor(tempDir); // markdown (default)
+
+            Assert.Contains("**Why:**", output, StringComparison.Ordinal);
+            Assert.Contains("**Fix:**", output, StringComparison.Ordinal);
+            // Autofix one-liner — MAF-AP-SEC-001 is auto-fixable.
+            Assert.Contains("auto-fixable", output, StringComparison.Ordinal);
+            Assert.Contains("autofix-all", output, StringComparison.Ordinal);
+            // The offending SOURCE line is shown (only the source — not the rule name —
+            // contains the `new` keyword), proving we read the file, not just the location.
+            Assert.Contains("new DefaultAzureCredential", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void AllReport_GroupsRepeatedRule_WithCount()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-tier1-group-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Same rule (MAF-AP-SEC-001) in two files → one group ×2 in --all.
+            foreach (var name in new[] { "A.cs", "B.cs" })
+                File.WriteAllText(Path.Combine(tempDir, name), $$"""
+                    using Azure.Identity;
+                    public class {{name[..1]}}x
+                    {
+                        public {{name[..1]}}x() { var c = new DefaultAzureCredential(); }
+                    }
+                    """);
+
+            var output = new DoctorTool().Run(tempDir, "markdown", excludes: null, full: true);
+
+            Assert.Contains("`MAF-AP-SEC-001`", output, StringComparison.Ordinal);
+            Assert.Contains("×2", output, StringComparison.Ordinal);
+            Assert.Contains("grouped", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void Json_Finding_CarriesWhy()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-tier1-json-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "Bad.cs"), """
+                using Azure.Identity;
+                public class Bad
+                {
+                    public Bad() { var c = new DefaultAzureCredential(); }
+                }
+                """);
+            var output = new DoctorTool().MafDoctor(tempDir, format: "json");
+
+            using var doc = JsonDocument.Parse(output);
+            var fix = doc.RootElement.GetProperty("top_fixes")[0];
+            Assert.False(string.IsNullOrWhiteSpace(fix.GetProperty("why").GetString()),
+                "Tier 1 adds a non-empty `why` rationale to each known-rule finding.");
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void GetWhy_CoversEveryScannerAndPromptRule()
+    {
+        // Drift guard (registry-driven): every rule the scanner can actually emit,
+        // plus the prompt-lint rules and the fan-in registry rule, must have a
+        // non-empty Why. A new rule added to AllRules without a GetWhy arm would
+        // otherwise ship an empty rationale silently. (Fan-out MAF001 + COST-001
+        // carry their Why inline, not via GetWhy, so they're excluded here.)
+        var ruleIds = AntiPatternScannerTool.AllRules.Select(r => r.Id)
+            .Concat(new[] { "PROMPT-001", "PROMPT-002", "PROMPT-003", "PROMPT-004", "MAF130-FAN-IN-001" })
+            .Distinct();
+        foreach (var id in ruleIds)
+            Assert.False(string.IsNullOrWhiteSpace(DoctorTool.GetWhy(id)),
+                $"Rule {id} has no Why rationale — add a GetWhy arm.");
+    }
+
+    [Fact]
+    public void FanOut_Report_SnippetShowsSignatureNotAttribute()
+    {
+        // The fan-out finding's line must land on the signature (return type),
+        // not the [MessageHandler] attribute line — otherwise the snippet hides
+        // the very thing the finding is about (the wrong return type).
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-tier1-fanout-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "Wf.cs"), """
+                using System.Threading.Tasks;
+                public partial class Inv : Executor
+                {
+                    [MessageHandler]
+                    public ValueTask HandleAsync(string m) => default;
+                }
+                """);
+            var output = new DoctorTool().Run(tempDir, "markdown", excludes: null, full: true);
+            // Snippet shows the signature line, not the bare attribute.
+            Assert.Contains("public ValueTask HandleAsync", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("→ `[MessageHandler]`", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void GroupedHeader_ForFanOut_IsRuleGeneric_NotPerInstance()
+    {
+        // Two DISTINCT fan-out methods collapse into one MAF001 group ×2; the
+        // header must use a rule-generic title, not one method's specifics.
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-tier1-grouphdr-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "Wf.cs"), """
+                using System.Threading.Tasks;
+                public partial class Inv : Executor
+                {
+                    [MessageHandler]
+                    public ValueTask AlphaAsync(string m) => default;
+                    [MessageHandler]
+                    public ValueTask BetaAsync(string m) => default;
+                }
+                """);
+            var output = new DoctorTool().Run(tempDir, "markdown", excludes: null, full: true);
+            // The ×2 MAF001 header is generic — it does NOT name a single method.
+            Assert.Contains("`MAF001` — fan-out handler must return `Task<T>` ×2", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("`AlphaAsync` returns", output, StringComparison.Ordinal); // not in the header
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void SecretRule_SourceLine_IsRedactedNotEchoed()
+    {
+        // MAF-AP-SEC-002 (hard-coded key) must NOT echo the secret-bearing line
+        // into the report; the file:line locator stays, the snippet is redacted.
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-tier1-secret-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "Keys.cs"),
+                "public class Keys { const string K = \"sk-ABCDEF0123456789abcdef\"; }");
+            var output = new DoctorTool().Run(tempDir, "markdown", excludes: null, full: true);
+
+            Assert.Contains("MAF-AP-SEC-002", output, StringComparison.Ordinal); // finding present
+            Assert.Contains("redacted", output, StringComparison.Ordinal);       // redaction marker
+            Assert.DoesNotContain("sk-ABCDEF0123456789abcdef", output, StringComparison.Ordinal); // secret NOT echoed
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void SecretOnSharedLine_NotEchoed_EvenWhenSurfacedByAnotherRule()
+    {
+        // A secret literal co-located with a `.Result` (CONC-002, a non-secret
+        // rule) on one physical line: redaction is content-aware, so the line is
+        // withheld no matter which rule's locator renders it.
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-tier1-coleak-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // The `, 3)` (word char before `)`) is what trips CONC-002's `\b\)\.Result`;
+            // the secret literal sits earlier on the same physical line.
+            File.WriteAllText(Path.Combine(tempDir, "C.cs"),
+                "public class C { object Get(string s, int n) => s; public void M() { var r = Get(\"sk-ABCDEF0123456789abcdef\", 3).Result; } }");
+            var output = new DoctorTool().Run(tempDir, "markdown", excludes: null, full: true);
+
+            Assert.Contains("MAF-AP-CONC-002", output, StringComparison.Ordinal); // a non-secret rule fired on that line
+            Assert.DoesNotContain("sk-ABCDEF0123456789abcdef", output, StringComparison.Ordinal); // secret never echoed
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void Json_FullMode_SerializesAllFindings_NotJustTopThree()
+    {
+        // `--all --json` (full + json) must serialize every finding into top_fixes,
+        // not cap at 3. Seed >3 distinct findings and compare full vs default.
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-tier1-fulljson-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Five distinct findings: SEC-002 (key), SEC-001 (cred), SEC-003
+            // (sensitive data), WF-001 (missing sealed+partial), fan-out (void).
+            File.WriteAllText(Path.Combine(tempDir, "Bad.cs"), """
+                using Azure.Identity;
+                public class Inv : Executor
+                {
+                    const string K = "sk-ABCDEF0123456789abcdef";
+                    public Inv()
+                    {
+                        var c = new DefaultAzureCredential();
+                        var o = new O { EnableSensitiveData = true };
+                    }
+                    [MessageHandler]
+                    public void HandleAsync(string m) { }
+                }
+                """);
+            var tool = new DoctorTool();
+
+            int Count(bool full)
+            {
+                using var doc = JsonDocument.Parse(tool.Run(tempDir, "json", excludes: null, full: full));
+                return doc.RootElement.GetProperty("top_fixes").GetArrayLength();
+            }
+
+            var defaultCount = Count(false);
+            var fullCount = Count(true);
+            Assert.Equal(3, defaultCount);            // default caps at 3
+            Assert.True(fullCount > 3, $"full mode should serialize all findings, got {fullCount}");
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
+    // Tier 1 — doctor CLI arg parsing (extracted to DoctorCli for testability)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void DoctorCli_Parse_JsonFlag_SetsJsonFormat()
+    {
+        var (_, format, _, _) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--json" });
+        Assert.Equal("json", format);
+    }
+
+    [Fact]
+    public void DoctorCli_Parse_NoFormatFlag_DefaultsToMarkdown()
+    {
+        var (path, format, _, full) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", "." });
+        Assert.Equal(".", path);
+        Assert.Equal("markdown", format);
+        Assert.False(full);
+    }
+
+    [Fact]
+    public void DoctorCli_Parse_FlagBeforePath_StillCapturesPath()
+    {
+        // The `--` guard means a flag preceding the path isn't mistaken for it.
+        var (path, format, _, full) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", "--all", "--json", "myrepo" });
+        Assert.Equal("myrepo", path);
+        Assert.Equal("json", format);
+        Assert.True(full);
+    }
+
+    [Fact]
+    public void DoctorCli_Parse_ExcludeIsRepeatable()
+    {
+        var (_, _, excludes, _) = MafDoctor.Commands.DoctorCli.Parse(
+            new[] { "doctor", ".", "--exclude", "samples/", "--exclude", "tests/" });
+        Assert.Equal(new[] { "samples/", "tests/" }, excludes);
+    }
+
     [Fact]
     public void Run_ExcludedPaths_DoNotAffectGrade()
     {

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -577,6 +577,39 @@ public class DoctorToolTests
     }
 
     [Fact]
+    public void RegexRule_DetectsRealMatch_AfterAStringMatchOnSameLine()
+    {
+        // Regression: trivia-aware scan must inspect EVERY match on a line, not
+        // just the first — a real call after a string-literal mention is real.
+        const string src = "class C { void M() { var x = \"new DefaultAzureCredential()\"; var y = new DefaultAzureCredential(); } }";
+        var sec001 = AntiPatternScannerTool.ScanFile(src, "C.cs")
+            .Where(f => f.RuleId == "MAF-AP-SEC-001").ToList();
+        Assert.Single(sec001); // the real `new DefaultAzureCredential()`, not skipped
+    }
+
+    [Fact]
+    public void Sec003_OnlyFlagsRewriterFixableContexts()
+    {
+        // Statement assignment → fixable → flagged.
+        const string stmt = "class C { void M(Opts o) { o.EnableSensitiveData = true; } } class Opts { public bool EnableSensitiveData; }";
+        Assert.Single(AntiPatternScannerTool.ScanFile(stmt, "S.cs").Where(f => f.RuleId == "MAF-AP-SEC-003"));
+        // Expression-bodied lambda → the rewriter can't fix it → NOT flagged (no false auto-fixable).
+        const string lambda = "class C { System.Action F(Opts o) => () => o.EnableSensitiveData = true; } class Opts { public bool EnableSensitiveData; }";
+        Assert.Empty(AntiPatternScannerTool.ScanFile(lambda, "L.cs").Where(f => f.RuleId == "MAF-AP-SEC-003"));
+    }
+
+    [Fact]
+    public void Wf001_SkipsAbstractExecutor_ButFlagsConcrete()
+    {
+        // Abstract Executor can never be `sealed partial` → not flagged (no impossible auto-fix promise).
+        const string abstractCls = "public abstract class Base : Executor { [MessageHandler] public abstract System.Threading.Tasks.Task<int> H(string s); }";
+        Assert.Empty(AntiPatternScannerTool.ScanFile(abstractCls, "B.cs").Where(f => f.RuleId == "MAF-AP-WF-001"));
+        // Concrete Executor missing sealed/partial still fires.
+        const string concrete = "public class Conc : Executor { [MessageHandler] public System.Threading.Tasks.Task<int> H(string s) => null; }";
+        Assert.Single(AntiPatternScannerTool.ScanFile(concrete, "C.cs").Where(f => f.RuleId == "MAF-AP-WF-001"));
+    }
+
+    [Fact]
     public void Json_HasUnboundedCostSites_AndCountsReconcileWithTopFixes()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-jsonreconcile-" + Guid.NewGuid().ToString("N"));

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -540,6 +540,71 @@ public class DoctorToolTests
     }
 
     // -------------------------------------------------------------------------
+    // Deep-review regressions — prompt warnings listed, SEC-003 syntax-aware,
+    // JSON counts reconcile with top_fixes.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Grade_PromptWarnings_AreListed_NotJustCounted()
+    {
+        // Regression: prompt warnings were counted in the grade/metrics but never
+        // appeared in AllFixes — so --all/--json/--plan contradicted the metrics.
+        var prompts = new[]
+        {
+            new PromptFinding("PROMPT-001", PromptSeverity.Warning, "Instructions is empty", "A.cs", 5),
+            new PromptFinding("PROMPT-003", PromptSeverity.Warning, "no refusal clause", "A.cs", 6),
+        };
+        var summary = DoctorTool.Grade([], [], prompts, []);
+        Assert.Equal(2, summary.PromptWarnings);
+        Assert.Equal(2, summary.AllFixes.Count(f => f.RuleId.StartsWith("PROMPT-", StringComparison.Ordinal)));
+    }
+
+    [Fact]
+    public void Sec003_IsSyntaxAware_DetectsDictionaryForm_IgnoresComment()
+    {
+        // The dictionary-key form is the shape the rewriter fixes; a comment that
+        // merely mentions the rule must NOT fire.
+        const string src = """
+            using System.Collections.Generic;
+            class C { void M() {
+                // EnableSensitiveData = true   (just a comment — not a finding)
+                var d = new Dictionary<string, bool> { ["EnableSensitiveData"] = true };
+            } }
+            """;
+        var sec003 = AntiPatternScannerTool.ScanFile(src, "C.cs")
+            .Where(f => f.RuleId == "MAF-AP-SEC-003").ToList();
+        Assert.Single(sec003); // the real dict assignment only — not the comment
+    }
+
+    [Fact]
+    public void Json_HasUnboundedCostSites_AndCountsReconcileWithTopFixes()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-jsonreconcile-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // SEC-001 (error) + a real dictionary SEC-003 (error).
+            File.WriteAllText(Path.Combine(tempDir, "Bad.cs"), """
+                using Azure.Identity;
+                using System.Collections.Generic;
+                class C { void M() {
+                    var c = new DefaultAzureCredential();
+                    var d = new Dictionary<string, bool> { ["EnableSensitiveData"] = true };
+                } }
+                """);
+            using var doc = JsonDocument.Parse(new DoctorTool().Run(tempDir, "json", excludes: null, full: true));
+            var root = doc.RootElement;
+            Assert.True(root.TryGetProperty("unbounded_cost_sites", out _)); // new field present
+            var sum = root.GetProperty("errors_count").GetInt32()
+                + root.GetProperty("warnings_count").GetInt32()
+                + root.GetProperty("silent_starvation_risks").GetInt32()
+                + root.GetProperty("unbounded_cost_sites").GetInt32();
+            Assert.Equal(root.GetProperty("top_fixes").GetArrayLength(), sum); // counts == listed findings
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
     // Tier 3 — `--plan` / format:"plan": an ordered, checkboxed remediation plan.
     // -------------------------------------------------------------------------
 

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -706,6 +706,50 @@ public class DoctorToolTests
     }
 
     [Fact]
+    public void AutofixAll_DoesNotCorrupt_PrimaryConstructorBaseInitializer()
+    {
+        // Round-4 regression: a C# 12 primary-ctor base initializer can't be async.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002pc-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "PC.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class Base { public Base(int x) { } }
+                public static class H { public static Task<int> Foo() => Task.FromResult(1); }
+                public class Derived(int p) : Base(H.Foo().Result) { }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_StillRewrites_ResultInsideAsyncMethod()
+    {
+        // The whitelist must keep rewriting valid async contexts (no over-skip).
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002ok-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Ok.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class C { static Task<int> Foo() => Task.FromResult(1);
+                  public async Task<int> M() { return Foo().Result; } }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.Contains("(await", after, StringComparison.Ordinal); // rewritten in the async method
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
     public void ScanAntiPatterns_SarifOutput_RedactsSecret()
     {
         // Round-3 regression: the SARIF surface must redact the SEC-002 secret too.

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -806,6 +806,165 @@ public class DoctorToolTests
     }
 
     [Fact]
+    public void AutofixAll_DoesNotCorrupt_CatchFilter()
+    {
+        // Round-6 regression: `await` is illegal in a `catch when (...)` filter
+        // (CS7094) even inside an async method — must skip the filter expression.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002catch-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Catch.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class C {
+                  static Task<int> Foo() => Task.FromResult(1);
+                  public async Task M() {
+                    try { await Task.Yield(); }
+                    catch (System.Exception) when (Foo().Result > 0) { }
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await", after, StringComparison.Ordinal); // no `await` in the filter
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_StillRewrites_ResultInsideCatchBody()
+    {
+        // No over-skip: the catch BODY is await-legal in an async method, so the
+        // filter guard must not suppress a rewrite there.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002catchbody-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "CatchBody.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class C {
+                  static Task<int> Foo() => Task.FromResult(1);
+                  public async Task M() {
+                    try { await Task.Yield(); }
+                    catch (System.Exception) { var x = Foo().Result; }
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.Contains("(await Foo", after, StringComparison.Ordinal); // rewritten in the catch body
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_DoesNotCorrupt_UnsafeBlock()
+    {
+        // Round-6 regression: `await` is illegal in an unsafe context (CS4004) —
+        // an `unsafe { }` block must be skipped even inside an async method.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002unsafe-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Unsafe.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class C {
+                  static Task<int> Foo() => Task.FromResult(1);
+                  public async Task M() {
+                    unsafe { var x = Foo().Result; }
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_DoesNotCorrupt_FixedBlock()
+    {
+        // Round-6 regression: a `fixed ( )` block is an unsafe context (CS4004).
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002fixed-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Fixed.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class C {
+                  static Task<int> Foo() => Task.FromResult(1);
+                  public async Task M() {
+                    int[] arr = { 1 };
+                    unsafe { fixed (int* p = arr) { var x = Foo().Result; } }
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_DoesNotCorrupt_AsyncUnsafeMethod()
+    {
+        // Round-6 regression: the `unsafe` modifier on the enclosing method makes
+        // its whole body an unsafe context — `await` is illegal even with `async`.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002unsafemethod-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "UnsafeMethod.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class C {
+                  static Task<int> Foo() => Task.FromResult(1);
+                  public async unsafe Task M() { var x = Foo().Result; }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_DoesNotCorrupt_UnsafeType()
+    {
+        // Round-6 regression: the `unsafe` modifier on the enclosing TYPE makes
+        // every member body an unsafe context — walk all type ancestors for it.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002unsafetype-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "UnsafeType.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public unsafe class C {
+                  static Task<int> Foo() => Task.FromResult(1);
+                  public async Task M() { var x = Foo().Result; }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
     public void ScanAntiPatterns_SarifOutput_RedactsSecret()
     {
         // Round-3 regression: the SARIF surface must redact the SEC-002 secret too.

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -759,6 +759,75 @@ public class DoctorToolTests
     }
 
     [Fact]
+    public void AutofixAll_DoesNotCorrupt_NestedQueryJoinSourceInOuterIllegalClause()
+    {
+        // Round-9 regression: a `.Result` in an INNER query's join source that sits
+        // inside an OUTER query's await-illegal `let` clause must be skipped. The
+        // old IsInAwaitableQuerySource descended into the nested query and wrongly
+        // marked the outer position awaitable → injected `await` → CS1995 corruption.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002nestq-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "NestQ.cs");
+            File.WriteAllText(file, """
+                using System.Linq;
+                using System.Collections.Generic;
+                using System.Threading.Tasks;
+                public class C {
+                  Task<List<int>> Foo() => Task.FromResult(new List<int>());
+                  public async Task M() {
+                    var a = new List<int>();
+                    var b = new List<int>();
+                    var q = from i in a
+                            let k = (from x in b join y in Foo().Result on x equals y select x).Count()
+                            select i + k;
+                    await Task.Yield();
+                    _ = q.ToList();
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await Foo", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_Rewrites_ResultInTopLevelJoinSource()
+    {
+        // Control / no-over-skip: a `.Result` in the join source of a TOP-LEVEL query
+        // inside an async method IS await-legal (CS1995 explicitly permits await in a
+        // join collection expression), so it SHOULD rewrite.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002joinok-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "JoinOk.cs");
+            File.WriteAllText(file, """
+                using System.Linq;
+                using System.Collections.Generic;
+                using System.Threading.Tasks;
+                public class C {
+                  Task<List<int>> Foo() => Task.FromResult(new List<int>());
+                  public async Task M() {
+                    var b = new List<int>();
+                    var q = from x in b join y in Foo().Result on x equals y select x;
+                    await Task.Yield();
+                    _ = q.ToList();
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.Contains("(await Foo", after, StringComparison.Ordinal); // join source is awaitable
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
     public void AutofixAll_IsIdempotent_OnSkippedPrimaryCtorBase()
     {
         // Round-5 regression: the skip-TODO comment was re-stacked on a 2nd run

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -599,6 +599,87 @@ public class DoctorToolTests
     }
 
     [Fact]
+    public void Grade_TopFixes_AreDeterministicWithinPriority()
+    {
+        // Same priority bucket must order by file then line, so the top-3 headline
+        // and JSON top_fixes don't depend on filesystem enumeration order.
+        var aps = new[]
+        {
+            new AntiPatternFinding("MAF-AP-SEC-001", "n", AntiPatternSeverity.Error, "zzz.cs", 9, "m"),
+            new AntiPatternFinding("MAF-AP-SEC-001", "n", AntiPatternSeverity.Error, "aaa.cs", 2, "m"),
+            new AntiPatternFinding("MAF-AP-SEC-001", "n", AntiPatternSeverity.Error, "aaa.cs", 1, "m"),
+        };
+        var s = DoctorTool.Grade(aps, []);
+        Assert.Equal(new[] { ("aaa.cs", 1), ("aaa.cs", 2), ("zzz.cs", 9) },
+            s.AllFixes.Select(f => (f.File, f.Line)).ToArray());
+    }
+
+    [Fact]
+    public void Conc002_DetectsParameterlessCall_AndIsNotAutoFixable()
+    {
+        // Regression: leading `\b` made the canonical `Foo().Result` / `Foo().Wait()`
+        // miss. One finding per line, so put the two forms on separate lines.
+        const string src = "using System.Threading.Tasks;\nclass C {\n  void M() {\n    var a = Foo().Result;\n    Bar().Wait();\n  }\n  Task<int> Foo() => null;\n  Task Bar() => null;\n}";
+        var conc = AntiPatternScannerTool.ScanFile(src, "C.cs").Where(f => f.RuleId == "MAF-AP-CONC-002").ToList();
+        Assert.Equal(2, conc.Count); // both .Result and .Wait() forms
+        // Sync-over-async needs judgment (async-ify the caller) → NOT auto-fixable.
+        var summary = DoctorTool.Grade(conc, []);
+        Assert.All(summary.AllFixes.Where(f => f.RuleId == "MAF-AP-CONC-002"), f => Assert.False(f.AutoFixable));
+    }
+
+    [Fact]
+    public void Conc002_StillIgnoresPropertyAccess_NoCloseParen()
+    {
+        // `task.Result` (no call) must NOT match — only `<call>().Result`.
+        const string src = "using System.Threading.Tasks; class C { void M(Task<int> t) { var a = t.Result; } }";
+        Assert.Empty(AntiPatternScannerTool.ScanFile(src, "C.cs").Where(f => f.RuleId == "MAF-AP-CONC-002"));
+    }
+
+    [Fact]
+    public void Agent001_DetectsTargetTypedNew()
+    {
+        // Regression: target-typed `new()` placement of Instructions was never flagged.
+        const string src = "class C { void M() { ChatClientAgentOptions o = new() { Instructions = \"x\" }; } }";
+        Assert.Single(AntiPatternScannerTool.ScanFile(src, "C.cs").Where(f => f.RuleId == "MAF-AP-AGENT-001"));
+    }
+
+    [Fact]
+    public void BareSecretInComment_IsRedacted()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-baresecret-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "F.cs"),
+                "public class F { public F() { var c = new DefaultAzureCredential(); } } // rotate sk-BARESKabcdefghij1234567 now");
+            var output = new DoctorTool().Run(dir, "markdown", excludes: null, full: true);
+            Assert.Contains("MAF-AP-SEC-001", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("sk-BARESKabcdefghij1234567", output, StringComparison.Ordinal); // bare token redacted
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_DoesNotCorrupt_ExpressionBodiedPropertyWithResult()
+    {
+        // Regression (blocker): the CONC-002 rewriter inserted `await` into a
+        // non-async expression-bodied property → uncompilable. Must skip it.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002corrupt-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "P.cs");
+            File.WriteAllText(file,
+                "using System.Threading.Tasks; public class P { Task<string> Fetch() => Task.FromResult(\"x\"); public string Val => Fetch().Result; }");
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await", after, StringComparison.Ordinal);  // never injected the `(await …)` rewrite
+            Assert.Contains(".Result", after, StringComparison.Ordinal);       // left intact
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
     public void Wf001_SkipsAbstractExecutor_ButFlagsConcrete()
     {
         // Abstract Executor can never be `sealed partial` → not flagged (no impossible auto-fix promise).

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -540,6 +540,124 @@ public class DoctorToolTests
     }
 
     // -------------------------------------------------------------------------
+    // Tier 3 — `--plan` / format:"plan": an ordered, checkboxed remediation plan.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Plan_MixedFindings_HasBothPhasesAndCheckboxes()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-plan-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Auto-fixable (SEC-001, SEC-003, WF-001) + semantic (SEC-002 key, fan-out void).
+            File.WriteAllText(Path.Combine(tempDir, "Bad.cs"), """
+                using Azure.Identity;
+                public class Inv : Executor
+                {
+                    const string K = "sk-ABCDEF0123456789abcdef";
+                    public Inv()
+                    {
+                        var c = new DefaultAzureCredential();
+                        var o = new O { EnableSensitiveData = true };
+                    }
+                    [MessageHandler]
+                    public void HandleAsync(string m) { }
+                }
+                """);
+            var output = new DoctorTool().Run(tempDir, "plan", excludes: null);
+
+            Assert.Contains("remediation plan", output, StringComparison.Ordinal);
+            Assert.Contains("## Phase 1", output, StringComparison.Ordinal);
+            Assert.Contains("## Phase 2", output, StringComparison.Ordinal);
+            Assert.Contains("autofix-all", output, StringComparison.Ordinal);
+            Assert.Contains("- [ ]", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void Plan_DoesNotEchoSecret()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-plan-secret-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "Keys.cs"),
+                "public class Keys { const string K = \"sk-ABCDEF0123456789abcdef\"; }");
+            var output = new DoctorTool().Run(tempDir, "plan", excludes: null);
+
+            Assert.Contains("MAF-AP-SEC-002", output, StringComparison.Ordinal); // the task is listed
+            Assert.DoesNotContain("sk-ABCDEF0123456789abcdef", output, StringComparison.Ordinal); // but never the secret
+            // SEC-002 is NOT auto-fixable → Phase-2-only: Phase 1 must be absent.
+            Assert.DoesNotContain("## Phase 1", output, StringComparison.Ordinal);
+            Assert.Contains("## Phase 2", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void Plan_AllAutoFixable_HasPhase1Only()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-plan-p1-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Lone DefaultAzureCredential (SEC-001) — auto-fixable → Phase 1 only.
+            File.WriteAllText(Path.Combine(tempDir, "Bad.cs"), """
+                using Azure.Identity;
+                public class Bad { public Bad() { var c = new DefaultAzureCredential(); } }
+                """);
+            var output = new DoctorTool().Run(tempDir, "plan", excludes: null);
+
+            Assert.Contains("## Phase 1", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("## Phase 2", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void Plan_IgnoresFullFlag()
+    {
+        // `full` is documented as ignored for format "plan" (always covers all).
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-plan-full-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "Bad.cs"), """
+                using Azure.Identity;
+                public class Inv : Executor
+                {
+                    public Inv() { var c = new DefaultAzureCredential(); }
+                    [MessageHandler]
+                    public void HandleAsync(string m) { }
+                }
+                """);
+            var tool = new DoctorTool();
+            var withFull = tool.Run(tempDir, "plan", excludes: null, full: true);
+            var withoutFull = tool.Run(tempDir, "plan", excludes: null, full: false);
+            Assert.Equal(withoutFull, withFull);
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    [Fact]
+    public void Plan_CleanRepo_SaysNothingToDo()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-plan-clean-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "Clean.cs"),
+                "public class Clean { public int Add(int a, int b) => a + b; }");
+            var output = new DoctorTool().Run(tempDir, "plan", excludes: null);
+            Assert.Contains("Nothing to do", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("## Phase", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
     // Tier 1 — doctor CLI arg parsing (extracted to DoctorCli for testability)
     // -------------------------------------------------------------------------
 
@@ -548,6 +666,21 @@ public class DoctorToolTests
     {
         var (_, format, _, _) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--json" });
         Assert.Equal("json", format);
+    }
+
+    [Fact]
+    public void DoctorCli_Parse_PlanFlag_SetsPlanFormat()
+    {
+        var (_, format, _, _) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--plan" });
+        Assert.Equal("plan", format);
+    }
+
+    [Fact]
+    public void DoctorCli_Parse_LastFormatFlagWins()
+    {
+        // Documented contract: the last format flag wins.
+        Assert.Equal("plan", MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--json", "--plan" }).Format);
+        Assert.Equal("json", MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--plan", "--json" }).Format);
     }
 
     [Fact]

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -965,6 +965,149 @@ public class DoctorToolTests
     }
 
     [Fact]
+    public void AutofixAll_Rewrites_ResultInAsyncLambdaInsideLock()
+    {
+        // Round-8 regression: an async lambda is its OWN await context, so a
+        // `.Result` inside `async () => {}` nested in a `lock` is await-legal and
+        // SHOULD be rewritten. The old unconditional lock pre-pass over-skipped it
+        // and injected a factually wrong "cannot await inside a lock" comment.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002lamblock-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "LamLock.cs");
+            File.WriteAllText(file, """
+                using System;
+                using System.Threading.Tasks;
+                public class C {
+                  readonly object _lock = new();
+                  static Task<int> Foo() => Task.FromResult(1);
+                  public async Task M() {
+                    lock (_lock) { Func<Task> a = async () => { var x = Foo().Result; }; }
+                    await Task.Yield();
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.Contains("(await Foo", after, StringComparison.Ordinal);          // rewritten in the async lambda
+            Assert.DoesNotContain("cannot await inside a lock", after, StringComparison.Ordinal); // no false comment
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_Rewrites_ResultInAsyncLocalFunctionInsideLock()
+    {
+        // Round-8 regression: same boundary rule for an async LOCAL FUNCTION nested
+        // in a lock — its body is its own await context.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002lflock-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "LfLock.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class C {
+                  readonly object _lock = new();
+                  static Task<int> Foo() => Task.FromResult(1);
+                  public void M() {
+                    lock (_lock) { async Task Inner() { var x = Foo().Result; } _ = Inner(); }
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.Contains("(await Foo", after, StringComparison.Ordinal);
+            Assert.DoesNotContain("cannot await inside a lock", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_DoesNotCorrupt_ResultInAsyncLambdaInsideUnsafe()
+    {
+        // Round-8 boundary check: UNLIKE lock, an unsafe context propagates into a
+        // nested async lambda (CS4004), so it must STILL be skipped there.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002lambunsafe-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "LamUnsafe.cs");
+            File.WriteAllText(file, """
+                using System;
+                using System.Threading.Tasks;
+                public class C {
+                  static Task<int> Foo() => Task.FromResult(1);
+                  public async Task M() {
+                    unsafe { Func<Task> a = async () => { var x = Foo().Result; }; }
+                    await Task.Yield();
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await Foo", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_DoesNotCorrupt_ParameterDefault()
+    {
+        // Round-8 (signature-position guard): a `.Result` in a parameter default is
+        // await-illegal even inside an async method (it needs a compile-time
+        // constant), so the whitelist must skip before reaching the async boundary.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002paramdef-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "ParamDef.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class C {
+                  static int Foo() => 1;
+                  public async Task M(int x = Foo().Result) { await Task.Yield(); }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await Foo", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_DoesNotCorrupt_AttributeArgument()
+    {
+        // Round-8 (signature-position guard): a `.Result` in an attribute argument
+        // is await-illegal even on an async method.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002attrarg-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "AttrArg.cs");
+            File.WriteAllText(file, """
+                using System;
+                using System.Threading.Tasks;
+                public class MyAttr : Attribute { public MyAttr(int v) { } }
+                public class C {
+                  static Task<int> Foo() => null!;
+                  [MyAttr(Foo().Result)]
+                  public async Task M() { await Task.Yield(); }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await Foo", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
     public void ScanAntiPatterns_SarifOutput_RedactsSecret()
     {
         // Round-3 regression: the SARIF surface must redact the SEC-002 secret too.

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -1122,6 +1122,32 @@ public class DoctorToolTests
         finally { Directory.Delete(dir, recursive: true); }
     }
 
+    [Theory]
+    // Round-9 regression: the `unsafe` modifier on a NON-method member establishes an
+    // unsafe context that propagates into a nested async lambda — so a `.Result` there
+    // must be skipped (CS4004). The old guard only checked method/local-fn/type.
+    [InlineData("public unsafe int P { get { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; return 0; } }")]
+    [InlineData("public unsafe int this[int i] { get { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; return 0; } }")]
+    [InlineData("public static unsafe C operator +(C a, C b) { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; return a; }")]
+    [InlineData("public static unsafe implicit operator int(C c) { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; return 0; }")]
+    [InlineData("public unsafe C() { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; }")]
+    public void AutofixAll_DoesNotCorrupt_UnsafeMemberWithNestedAsyncLambda(string member)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002unsafemem-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "UnsafeMember.cs");
+            File.WriteAllText(file,
+                "using System.Threading.Tasks;\npublic class C {\n  static Task<int> Foo() => Task.FromResult(1);\n  " + member + "\n}\n");
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await Foo", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
     [Fact]
     public void AutofixAll_DoesNotCorrupt_ParameterDefault()
     {

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -729,6 +729,62 @@ public class DoctorToolTests
     }
 
     [Fact]
+    public void AutofixAll_DoesNotCorrupt_LinqQueryClause()
+    {
+        // Round-5 regression: `await` is illegal in a let/where/select clause
+        // (CS1995) even inside an async method — must skip.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002linq-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Q.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                using System.Linq;
+                public class Q {
+                  static Task<int> F() => Task.FromResult(1);
+                  public async Task M() {
+                    var q = from i in new[] { 1, 2 } let r = F().Result select r;
+                    await Task.Yield();
+                    _ = q.ToList();
+                  }
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await", after, StringComparison.Ordinal);
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void AutofixAll_IsIdempotent_OnSkippedPrimaryCtorBase()
+    {
+        // Round-5 regression: the skip-TODO comment was re-stacked on a 2nd run
+        // for contexts with no enclosing method (primary-ctor base initializer).
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002idem-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "PC.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class Base { public Base(int x) { } }
+                public static class H { public static Task<int> G() => Task.FromResult(1); }
+                public class Derived(int n) : Base(H.G().Result) { }
+                """);
+            var tool = new AutoFixTool();
+            tool.MafAutoFixAll(dir, dryRun: false);
+            var after1 = File.ReadAllText(file);
+            tool.MafAutoFixAll(dir, dryRun: false);
+            var after2 = File.ReadAllText(file);
+            Assert.Equal(after1, after2); // 2nd run is a no-op (no duplicate comment)
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
     public void AutofixAll_StillRewrites_ResultInsideAsyncMethod()
     {
         // The whitelist must keep rewriting valid async contexts (no over-skip).

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -680,6 +680,49 @@ public class DoctorToolTests
     }
 
     [Fact]
+    public void AutofixAll_DoesNotCorrupt_OperatorOrConversionBodyWithResult()
+    {
+        // Round-3 regression: operators / user-defined conversions can't be async,
+        // so the CONC-002 rewriter must NOT inject `await` into their bodies.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-conc002op-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Op.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class Op {
+                    static Task<int> Foo() => Task.FromResult(1);
+                    public static Op operator +(Op a, Op b) { var z = Foo().Result; return a; }
+                    public static explicit operator string(Op c) => Foo().Result.ToString();
+                }
+                """);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var after = File.ReadAllText(file);
+            Assert.DoesNotContain("(await", after, StringComparison.Ordinal); // no `await` in operator/conversion bodies
+            Assert.Contains(".Result", after, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void ScanAntiPatterns_SarifOutput_RedactsSecret()
+    {
+        // Round-3 regression: the SARIF surface must redact the SEC-002 secret too.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-sarifsecret-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "K.cs"),
+                "public class K { const string S = \"sk-abcdefghij1234567890\"; }");
+            var sarif = new AntiPatternScannerTool().MafScanAntiPatterns(dir, format: "sarif");
+            Assert.Contains("MAF-AP-SEC-002", sarif, StringComparison.Ordinal);
+            Assert.DoesNotContain("sk-abcdefghij1234567890", sarif, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
     public void Wf001_SkipsAbstractExecutor_ButFlagsConcrete()
     {
         // Abstract Executor can never be `sealed partial` → not flagged (no impossible auto-fix promise).

--- a/src/maf-autopilot.Tests/ExplainFindingToolTests.cs
+++ b/src/maf-autopilot.Tests/ExplainFindingToolTests.cs
@@ -1,0 +1,270 @@
+using MafDoctor.Prompts;
+using MafDoctor.Tools;
+using ModelContextProtocol.Protocol;
+using Xunit;
+
+namespace MafDoctor.Tests;
+
+public class ExplainFindingToolTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-explainfinding-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void RealFinding_ReturnsGroundedSubstrate()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Bad.cs"), """
+                using Azure.Identity;
+                public class Bad
+                {
+                    public Bad() { var c = new DefaultAzureCredential(); }
+                }
+                """);
+            // Find the actual line of the offending code (robust to formatting).
+            var lines = File.ReadAllLines(Path.Combine(dir, "Bad.cs"));
+            var line = Array.FindIndex(lines, l => l.Contains("DefaultAzureCredential")) + 1;
+
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Bad.cs", line);
+
+            Assert.Contains("MAF-AP-SEC-001", output, StringComparison.Ordinal);
+            Assert.Contains("Code in context", output, StringComparison.Ordinal);
+            Assert.Contains("**Why:**", output, StringComparison.Ordinal);
+            Assert.Contains("**Fix:**", output, StringComparison.Ordinal);
+            Assert.Contains("auto-fixable", output, StringComparison.Ordinal);   // SEC-001 is auto-fixable
+            Assert.Contains("maf://constraints", output, StringComparison.Ordinal);
+            Assert.Contains("new DefaultAzureCredential", output, StringComparison.Ordinal); // the code window shows the line
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void SecretLine_RedactedInCodeWindow()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Keys.cs"),
+                "public class Keys { const string K = \"sk-ABCDEF0123456789abcdef\"; }");
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Keys.cs", 1);
+
+            Assert.Contains("MAF-AP-SEC-002", output, StringComparison.Ordinal);
+            Assert.Contains("redacted", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("sk-ABCDEF0123456789abcdef", output, StringComparison.Ordinal); // never echoed
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void NoFindingAtLine_ReturnsGracefulMessage()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Clean.cs"),
+                "public class Clean { public int Add(int a, int b) => a + b; }");
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Clean.cs", 1);
+
+            Assert.Contains("No active finding", output, StringComparison.Ordinal);
+            // Still shows the code window for orientation.
+            Assert.Contains("Code in context", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void NonexistentFile_ReturnsError()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Nope.cs", 1);
+            Assert.Contains("Error", output, StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void EmptyRepoPath_ReturnsError()
+    {
+        var output = new ExplainFindingTool().MafExplainFinding("", "x.cs", 1);
+        Assert.Contains("Error", output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PathTraversalInFile_ReturnsError()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "../../etc/passwd", 1);
+            Assert.Contains("Error", output, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("Code in context", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void HugeContext_IsClampedToMax()
+    {
+        // 80-line file, finding in the middle, context far past the cap → the
+        // window must stay bounded (a line >30 away must NOT appear).
+        var dir = NewTempDir();
+        try
+        {
+            var fileBody = new System.Text.StringBuilder();
+            for (var i = 1; i <= 80; i++)
+                fileBody.AppendLine(i == 1 ? "// FAR_MARKER_TOP"
+                    : i == 40 ? "var c = new DefaultAzureCredential();"
+                    : $"// filler {i}");
+            File.WriteAllText(Path.Combine(dir, "Big.cs"), fileBody.ToString());
+
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Big.cs", 40, context: 9999);
+
+            Assert.Contains("MAF-AP-SEC-001", output, StringComparison.Ordinal);   // finding surfaced
+            Assert.DoesNotContain("FAR_MARKER_TOP", output, StringComparison.Ordinal); // line 1 is 39 away → clamped out
+            Assert.Contains("// filler 39", output, StringComparison.Ordinal);     // line 39 is in-window
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void NearbyFinding_WidensToNearest_AndMarksTheRealLine()
+    {
+        // Finding sits 2 lines off the requested line → ±2 widening fires.
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Bad.cs"), """
+                // padding line 1
+                // padding line 2
+                // padding line 3
+                var c = new DefaultAzureCredential();
+                """);
+            // Finding is on line 4; ask about line 2 (distance 2).
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Bad.cs", 2);
+
+            Assert.Contains("showing the nearest within", output, StringComparison.Ordinal); // widened note
+            Assert.Contains("MAF-AP-SEC-001", output, StringComparison.Ordinal);
+            // The marker (`>`) is on the real finding line (4), not the asked line (2).
+            Assert.Contains("> 4 |", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void FindingMoreThanTwoLinesAway_ReturnsNoActiveFinding()
+    {
+        // Distance 3 is outside the ±2 widening window.
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Bad.cs"), """
+                // padding line 1
+                // padding line 2
+                // padding line 3
+                // padding line 4
+                var c = new DefaultAzureCredential();
+                """);
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Bad.cs", 2); // finding on line 5
+            Assert.Contains("No active finding", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void MultipleFindingsOnOneLine_RendersPluralHeader()
+    {
+        // SEC-001 (cred) + SEC-002 (key) both fire on the same physical line.
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Bad.cs"),
+                "public class Bad { public Bad() { var c = new DefaultAzureCredential(); var k = \"sk-ABCDEF0123456789abcdef\"; } }");
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Bad.cs", 1);
+
+            Assert.Contains("2 findings at this line", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("sk-ABCDEF0123456789abcdef", output, StringComparison.Ordinal); // window line redacted
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void ContextZero_ShowsOnlyTheFindingLine()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Bad.cs"), """
+                // line before
+                var c = new DefaultAzureCredential();
+                // line after
+                """);
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Bad.cs", 2, context: 0);
+
+            Assert.Contains("MAF-AP-SEC-001", output, StringComparison.Ordinal);
+            Assert.Contains("> 2 |", output, StringComparison.Ordinal);     // the finding line, marked
+            Assert.DoesNotContain("line before", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("line after", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void SecretOnContextLine_IsRedacted()
+    {
+        // The secret is on a CONTEXT line (not the requested finding line) — it
+        // must still be redacted across the whole window.
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Bad.cs"), """
+                var c = new DefaultAzureCredential();
+                const string K = "sk-ABCDEF0123456789abcdef";
+                """);
+            var output = new ExplainFindingTool().MafExplainFinding(dir, "Bad.cs", 1); // ask about line 1 (SEC-001)
+
+            Assert.Contains("MAF-AP-SEC-001", output, StringComparison.Ordinal);
+            Assert.Contains("redacted", output, StringComparison.Ordinal);
+            Assert.DoesNotContain("sk-ABCDEF0123456789abcdef", output, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
+    // The companion prompt
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ExplainFindingPrompt_BuildsGroundedInstruction()
+    {
+        var messages = MafPrompts.ExplainFinding("Executors/Foo.cs", "42", "/repo");
+        var msg = Assert.Single(messages);
+        Assert.Equal(Role.User, msg.Role);
+        var text = Assert.IsType<TextContentBlock>(msg.Content).Text;
+
+        Assert.Contains("MafExplainFinding", text, StringComparison.Ordinal);
+        Assert.Contains("maf://constraints", text, StringComparison.Ordinal);
+        Assert.Contains("maf://guide", text, StringComparison.Ordinal);
+        Assert.Contains("Executors/Foo.cs", text, StringComparison.Ordinal);
+        Assert.Contains("42", text, StringComparison.Ordinal);
+        Assert.Contains("Repository: /repo", text, StringComparison.Ordinal); // repoPath rendered when supplied
+    }
+
+    [Fact]
+    public void ExplainFindingPrompt_StripsHtmlCommentsFromInputs()
+    {
+        // Echoed params are HTML-comment-stripped (prompt-injection defense, house style).
+        var messages = MafPrompts.ExplainFinding("Foo.cs<!-- inject -->", "1", null);
+        var text = Assert.IsType<TextContentBlock>(Assert.Single(messages).Content).Text;
+        Assert.DoesNotContain("<!--", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("inject", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("Repository:", text, StringComparison.Ordinal); // null repoPath → line omitted
+    }
+}

--- a/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
+++ b/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
@@ -83,7 +83,32 @@ public class RewriterCompileRoundtripTests
                 string.Join("\n  ", outErrors.Select(d => $"{d.Id}: {d.GetMessage()}")) +
                 $"\n--- rewritten output ---\n{newRoot.ToFullString()}");
         }
+
+        // Coverage assertion: the rule this fixture targets must actually ENGAGE
+        // (rewrite OR add a skip-comment). Otherwise a future regression that makes a
+        // rewriter silently stop matching would leave the fixture vacuously green —
+        // "the output compiles" is trivially true when nothing changed. `-noop-`
+        // fixtures are the deliberate exception (the rule must NOT touch them).
+        var expectedRule = ExpectedRuleFor(label);
+        Assert.True(AutoFixTool.TryCreateRewriter(expectedRule, out var targeted) && targeted is not null,
+            $"could not create rewriter for {expectedRule}");
+        var engaged = !ReferenceEquals(targeted!.Visit(inputRoot), inputRoot);
+        var shouldEngage = !label.Contains("-noop-", StringComparison.Ordinal);
+        Assert.True(engaged == shouldEngage,
+            $"[{label}] expected rule '{expectedRule}' to {(shouldEngage ? "ENGAGE (rewrite or add a skip-comment)" : "be a NO-OP")}, " +
+            $"but it {(engaged ? "changed" : "did NOT change")} the input — coverage silently lost.");
     }
+
+    // Maps a fixture label's prefix to the rule whose rewriter it targets.
+    private static string ExpectedRuleFor(string label) => label.Split('-')[0] switch
+    {
+        "conc002" => "MAF-AP-CONC-002",
+        "wf001"   => "MAF-AP-WF-001",
+        "fanin"   => "MAF130-FAN-IN-001",
+        "sec001"  => "MAF-AP-SEC-001",
+        "sec003"  => "MAF-AP-SEC-003",
+        var other => throw new InvalidOperationException($"fixture label '{label}' has an unknown rule prefix '{other}'"),
+    };
 
     // -------------------------------------------------------------------------
     // Corpus. Each entry is a self-contained, clean-compiling C# program.
@@ -181,6 +206,69 @@ public class RewriterCompileRoundtripTests
             public class C {
               static Task<int> Foo() => Task.FromResult(1);
               public async Task M() { unsafe { Func<Task> f = async () => { var x = Foo().Result; }; } await Task.Yield(); }
+            }
+            """);
+
+        yield return F("conc002-skip-fixed-block-result", """
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> Foo() => Task.FromResult(1);
+              int[] _a = new int[4];
+              public async Task M() {
+                unsafe { fixed (int* p = _a) { var x = Foo().Result; } }
+                await Task.Yield();
+              }
+            }
+            """);
+
+        yield return F("conc002-skip-fixed-block-wait", """
+            using System.Threading.Tasks;
+            public class C {
+              static Task Foo() => Task.CompletedTask;
+              int[] _a = new int[4];
+              public async Task M() {
+                unsafe { fixed (int* p = _a) { Foo().Wait(); } }
+                await Task.Yield();
+              }
+            }
+            """);
+
+        yield return F("conc002-skip-unsafe-local-function", """
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> Foo() => Task.FromResult(1);
+              public async Task M() {
+                unsafe void Local() { var x = Foo().Result; }
+                Local();
+                await Task.Yield();
+              }
+            }
+            """);
+
+        yield return F("conc002-skip-query-secondary-from", """
+            using System.Linq;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            public class C {
+              static Task<List<int>> F() => Task.FromResult(new List<int>());
+              public async Task M() {
+                var q = from i in new[] { 1, 2 } from j in F().Result select i + j;
+                await Task.Yield();
+                _ = q.ToList();
+              }
+            }
+            """);
+
+        yield return F("conc002-skip-query-orderby", """
+            using System.Linq;
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> F() => Task.FromResult(1);
+              public async Task M() {
+                var q = from i in new[] { 1, 2 } orderby F().Result select i;
+                await Task.Yield();
+                _ = q.ToList();
+              }
             }
             """);
 
@@ -287,6 +375,49 @@ public class RewriterCompileRoundtripTests
                 object o1 = null, o2 = null;
                 b.AddFanInBarrierEdge(agg, new[] { o1, o2 }); // swapped to (sources, target)
               }
+            }
+            """);
+
+        yield return F("fanin-rewrite-named-args", """
+            public class B {
+              public void AddFanInBarrierEdge(object[] sources, object target) { }
+            }
+            public class C {
+              void F() {
+                var b = new B();
+                object agg = null;
+                object o1 = null, o2 = null;
+                b.AddFanInBarrierEdge(target: agg, sources: new[] { o1, o2 }); // labels stripped on swap
+              }
+            }
+            """);
+
+        yield return F("fanin-rewrite-collection-expression-source", """
+            public class B {
+              public void AddFanInBarrierEdge(object target, System.Collections.Generic.List<object> sources) { }
+              public void AddFanInBarrierEdge(System.Collections.Generic.List<object> sources, object target) { }
+            }
+            public class C {
+              void F() {
+                var b = new B();
+                object agg = null;
+                object o1 = null, o2 = null;
+                b.AddFanInBarrierEdge(agg, [o1, o2]); // collection-expression source
+              }
+            }
+            """);
+
+        // ---- SEC-001 / SEC-003: output of the security rewrites must compile. ----
+        yield return F("sec001-rewrite-default-azure-credential", """
+            public class DefaultAzureCredential { public DefaultAzureCredential() { } }
+            public class ManagedIdentityCredential { public ManagedIdentityCredential() { } }
+            public class C { object _c = new DefaultAzureCredential(); }
+            """);
+
+        yield return F("sec003-rewrite-embedded-if-assignment", """
+            public class Options { public bool EnableSensitiveData { get; set; } }
+            public class C {
+              void M(Options opts, bool flag) { if (flag) opts.EnableSensitiveData = true; }
             }
             """);
     }

--- a/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
+++ b/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
@@ -110,6 +110,38 @@ public class RewriterCompileRoundtripTests
         var other => throw new InvalidOperationException($"fixture label '{label}' has an unknown rule prefix '{other}'"),
     };
 
+    [Fact]
+    public void EveryRewriterHasRoundtripCoverage()
+    {
+        // Durable guard against the corpus silently falling behind: every distinct
+        // rewriter TYPE that AutoFixTool can dispatch must have at least one fixture
+        // targeting it. A newly-added rewriter therefore cannot ship without a
+        // compile-roundtrip fixture — the exact gap that left SEC-001 / SEC-003
+        // unexercised until the adversarial review caught it.
+        var fixtureRules = Fixtures()
+            .Select(f => ExpectedRuleFor((string)f[0]))
+            .ToHashSet();
+
+        var ruleToType = new Dictionary<string, Type>();
+        foreach (var id in AutoFixTool.SupportedRuleIds)
+            if (AutoFixTool.TryCreateRewriter(id, out var r) && r is not null)
+                ruleToType[id] = r.GetType();
+
+        var coveredTypes = fixtureRules
+            .Where(ruleToType.ContainsKey)
+            .Select(id => ruleToType[id])
+            .ToHashSet();
+
+        var uncovered = ruleToType.Values.Distinct()
+            .Where(t => !coveredTypes.Contains(t))
+            .Select(t => t.Name)
+            .ToList();
+
+        Assert.True(uncovered.Count == 0,
+            "Rewriter type(s) with NO compile-roundtrip fixture — add one to Fixtures() " +
+            "(label prefix must map via ExpectedRuleFor): " + string.Join(", ", uncovered));
+    }
+
     // -------------------------------------------------------------------------
     // Corpus. Each entry is a self-contained, clean-compiling C# program.
     // -------------------------------------------------------------------------

--- a/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
+++ b/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
@@ -1,0 +1,295 @@
+using System.Collections.Immutable;
+using MafDoctor.Tools;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace MafDoctor.Tests;
+
+/// <summary>
+/// Compile-roundtrip safety net for EVERY <c>IRuleRewriter</c>.
+///
+/// For a corpus of VALID (clean-compiling) C# fixtures, running a rewriter must
+/// NOT introduce a new compiler ERROR. Two real source-corruption bugs —
+/// <c>CS1995</c> (await injected into a nested-query clause) and <c>CS4004</c>
+/// (await injected into an <c>unsafe</c> member) — shipped past the string-assertion
+/// unit tests and were caught ONLY by compiling the rewritten output. This test
+/// makes that check permanent: any future rewriter change that injects an
+/// <c>await</c> (or otherwise breaks compilation) into a context the C# spec
+/// forbids fails CI immediately, instead of silently corrupting user source.
+///
+/// Scope note: the corpus contains only VALID inputs — that is the whole point
+/// (a rewriter must never turn compilable code into uncompilable code). Cases
+/// where the INPUT is already uncompilable (e.g. a <c>.Result</c> in a parameter
+/// default) cannot occur in real code and are covered by the rewriter's own unit
+/// tests, not here. Several rule IDs share one rewriter; rewriters that don't
+/// match a given fixture are no-ops and are skipped (no compile attempt).
+/// </summary>
+public class RewriterCompileRoundtripTests
+{
+    // Full framework reference set so fixtures using Task / LINQ / unsafe compile.
+    private static readonly MetadataReference[] References =
+        ((string)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES")!)
+        .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+        .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+        .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+        .ToArray();
+
+    private static readonly CSharpParseOptions ParseOpts = new(LanguageVersion.Latest);
+
+    private static readonly CSharpCompilationOptions CompileOpts =
+        new(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true);
+
+    private static ImmutableArray<Diagnostic> CompileErrors(SyntaxNode root)
+    {
+        var comp = CSharpCompilation.Create(
+            "roundtrip",
+            new[] { root.SyntaxTree },
+            References,
+            CompileOpts);
+        return comp.GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToImmutableArray();
+    }
+
+    [Theory]
+    [MemberData(nameof(Fixtures))]
+    public void Rewriter_NeverIntroducesACompilerError(string label, string source)
+    {
+        var inputTree = CSharpSyntaxTree.ParseText(source, ParseOpts);
+        var inputRoot = inputTree.GetRoot();
+        var inputErrors = CompileErrors(inputRoot);
+
+        // The fixture itself must be valid C# — otherwise the test is meaningless
+        // (a rewriter can only be blamed for breaking code that compiled to begin with).
+        Assert.True(inputErrors.IsEmpty,
+            $"[{label}] FIXTURE does not compile clean (fix the test, not the rewriter): " +
+            string.Join("; ", inputErrors.Select(d => $"{d.Id} {d.GetMessage()}")));
+
+        foreach (var ruleId in AutoFixTool.SupportedRuleIds)
+        {
+            Assert.True(AutoFixTool.TryCreateRewriter(ruleId, out var rewriter) && rewriter is not null,
+                $"could not create rewriter for {ruleId}");
+
+            var newRoot = rewriter!.Visit(inputRoot);
+            if (ReferenceEquals(newRoot, inputRoot)) continue; // rewriter didn't match this fixture
+
+            var rewritten = CSharpSyntaxTree.ParseText(newRoot.ToFullString(), ParseOpts).GetRoot();
+            var outErrors = CompileErrors(rewritten);
+
+            // inputErrors is empty (asserted above), so ANY output error is new.
+            Assert.True(outErrors.IsEmpty,
+                $"[{label}] rewriter '{ruleId}' INTRODUCED a compiler error — source corruption:\n  " +
+                string.Join("\n  ", outErrors.Select(d => $"{d.Id}: {d.GetMessage()}")) +
+                $"\n--- rewritten output ---\n{newRoot.ToFullString()}");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Corpus. Each entry is a self-contained, clean-compiling C# program.
+    // -------------------------------------------------------------------------
+
+    public static IEnumerable<object[]> Fixtures()
+    {
+        // ---- CONC-002: REGRESSION shapes (the two historical corruptions). ----
+        // The rewriter must SKIP these (await is illegal here); the skip-with-comment
+        // output still compiles, so the roundtrip passes. If the guard regresses,
+        // an injected `await` makes the output fail to compile and this test goes red.
+
+        yield return F("conc002-regression-nested-query-join-in-let", """
+            using System.Linq;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            public class C {
+              Task<List<int>> Foo() => Task.FromResult(new List<int>());
+              public async Task M() {
+                var a = new List<int>();
+                var b = new List<int>();
+                var q = from i in a
+                        let k = (from x in b join y in Foo().Result on x equals y select x).Count()
+                        select i + k;
+                await Task.Yield();
+                _ = q.ToList();
+              }
+            }
+            """);
+
+        foreach (var (kind, member) in new[]
+        {
+            ("property",   "public unsafe int P { get { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; return 0; } }"),
+            ("indexer",    "public unsafe int this[int i] { get { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; return 0; } }"),
+            ("operator",   "public static unsafe C operator +(C a, C b) { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; return a; }"),
+            ("conversion", "public static unsafe implicit operator int(C c) { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; return 0; }"),
+            ("constructor","public unsafe C() { System.Func<System.Threading.Tasks.Task> f = async () => { var x = Foo().Result; }; }"),
+        })
+        {
+            yield return F($"conc002-regression-unsafe-{kind}-nested-lambda",
+                "using System.Threading.Tasks;\npublic class C {\n  static Task<int> Foo() => Task.FromResult(1);\n  " + member + "\n}\n");
+        }
+
+        // ---- CONC-002: other await-ILLEGAL contexts (valid input ⇒ must skip). ----
+        yield return F("conc002-skip-lock-body", """
+            using System.Threading.Tasks;
+            public class C {
+              readonly object _lock = new();
+              static Task<int> Foo() => Task.FromResult(1);
+              public async Task M() { lock (_lock) { var x = Foo().Result; } await Task.Yield(); }
+            }
+            """);
+
+        yield return F("conc002-skip-unsafe-block", """
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> Foo() => Task.FromResult(1);
+              public async Task M() { unsafe { var x = Foo().Result; } await Task.Yield(); }
+            }
+            """);
+
+        yield return F("conc002-skip-catch-filter", """
+            using System;
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> Foo() => Task.FromResult(1);
+              public async Task M() { try { await Task.Yield(); } catch (Exception) when (Foo().Result > 0) { } }
+            }
+            """);
+
+        yield return F("conc002-skip-query-let", """
+            using System.Linq;
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> F() => Task.FromResult(1);
+              public async Task M() {
+                var q = from i in new[] { 1, 2 } let r = F().Result select r;
+                await Task.Yield();
+                _ = q.ToList();
+              }
+            }
+            """);
+
+        yield return F("conc002-skip-non-async-method", """
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> Foo() => Task.FromResult(1);
+              public int M() { return Foo().Result; }
+            }
+            """);
+
+        yield return F("conc002-skip-async-lambda-in-unsafe-block", """
+            using System;
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> Foo() => Task.FromResult(1);
+              public async Task M() { unsafe { Func<Task> f = async () => { var x = Foo().Result; }; } await Task.Yield(); }
+            }
+            """);
+
+        // ---- CONC-002: await-LEGAL contexts (valid input ⇒ should REWRITE; output must still compile). ----
+        yield return F("conc002-rewrite-async-method-body", """
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> Foo() => Task.FromResult(1);
+              public async Task<int> M() { return Foo().Result; }
+            }
+            """);
+
+        yield return F("conc002-rewrite-wait-async-method-body", """
+            using System.Threading.Tasks;
+            public class C {
+              static Task Foo() => Task.CompletedTask;
+              public async Task M() { Foo().Wait(); await Task.Yield(); }
+            }
+            """);
+
+        yield return F("conc002-rewrite-top-level-join-source", """
+            using System.Linq;
+            using System.Collections.Generic;
+            using System.Threading.Tasks;
+            public class C {
+              Task<List<int>> Foo() => Task.FromResult(new List<int>());
+              public async Task M() {
+                var b = new List<int>();
+                var q = from x in b join y in Foo().Result on x equals y select x;
+                await Task.Yield();
+                _ = q.ToList();
+              }
+            }
+            """);
+
+        yield return F("conc002-rewrite-async-lambda-in-lock", """
+            using System;
+            using System.Threading.Tasks;
+            public class C {
+              readonly object _lock = new();
+              static Task<int> Foo() => Task.FromResult(1);
+              public async Task M() { lock (_lock) { Func<Task> f = async () => { var x = Foo().Result; }; } await Task.Yield(); }
+            }
+            """);
+
+        yield return F("conc002-rewrite-catch-body", """
+            using System;
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> Foo() => Task.FromResult(1);
+              public async Task M() { try { await Task.Yield(); } catch (Exception) { var x = Foo().Result; } }
+            }
+            """);
+
+        yield return F("conc002-rewrite-async-finally", """
+            using System.Threading.Tasks;
+            public class C {
+              static Task<int> Foo() => Task.FromResult(1);
+              public async Task M() { try { await Task.Yield(); } finally { var x = Foo().Result; } }
+            }
+            """);
+
+        // ---- ExecutorSealedRewriter (WF-001): output must compile. ----
+        yield return F("wf001-rewrite-plain-executor", """
+            using System.Threading.Tasks;
+            public class Executor { }
+            public sealed class MessageHandlerAttribute : System.Attribute { }
+            public partial class MyExec : Executor {
+              [MessageHandler]
+              public Task<int> Handle(string s) => Task.FromResult(0);
+            }
+            """);
+
+        yield return F("wf001-rewrite-generic-executor", """
+            using System.Threading.Tasks;
+            public class Executor<TIn, TOut> { }
+            public sealed class MessageHandlerAttribute : System.Attribute { }
+            public partial class MyExec : Executor<string, int> {
+              [MessageHandler]
+              public Task<int> Handle(string s) => Task.FromResult(0);
+            }
+            """);
+
+        yield return F("wf001-noop-abstract-executor", """
+            using System.Threading.Tasks;
+            public class Executor { }
+            public sealed class MessageHandlerAttribute : System.Attribute { }
+            public abstract partial class BaseAuditor : Executor {
+              [MessageHandler]
+              public abstract Task<string> Audit(string s);
+            }
+            """);
+
+        // ---- FanInArgOrderRewriter (FAN-IN-001): swap output must compile. ----
+        yield return F("fanin-rewrite-swap-with-overloads", """
+            public class B {
+              public void AddFanInBarrierEdge(object target, object[] sources) { }
+              public void AddFanInBarrierEdge(object[] sources, object target) { }
+            }
+            public class C {
+              void F() {
+                var b = new B();
+                object agg = null;
+                object o1 = null, o2 = null;
+                b.AddFanInBarrierEdge(agg, new[] { o1, o2 }); // swapped to (sources, target)
+              }
+            }
+            """);
+    }
+
+    private static object[] F(string label, string source) => new object[] { label, source };
+}

--- a/src/maf-autopilot.Tests/RewriterIdempotenceTests.cs
+++ b/src/maf-autopilot.Tests/RewriterIdempotenceTests.cs
@@ -76,12 +76,11 @@ public sealed class RewriterIdempotenceTests
     }
 
     [Fact]
-    public void ExecutorSealedRewriter_Idempotent_AbstractClass_SkipPath()
+    public void ExecutorSealedRewriter_AbstractClass_LeftUnchanged_Idempotent()
     {
-        // The abstract-class guard skips the rewrite with a warning comment.
-        // Running it twice should leave the comment exactly once — the second
-        // pass should detect the existing comment via source-text dedup and
-        // not duplicate it.
+        // Parity with the scanner: an abstract Executor is left untouched. Running
+        // the rewriter twice is a no-op — no `sealed`, no advisory comment, output
+        // identical to input on both passes.
         const string src = """
             using Microsoft.Agents.AI.Workflow;
             public abstract class BaseAuditor : Executor
@@ -91,22 +90,15 @@ public sealed class RewriterIdempotenceTests
             }
             """;
         var output = ApplyTwice(new ExecutorSealedRewriter(), src);
-
-        // Phase 4.G fixup (nit #3) — assert the warning appears EXACTLY once.
-        // Without this, a future bug where two abstract Executors in the same
-        // source produce two comments per visit could pass the equality check
-        // (both passes producing identical bad output) while still being buggy.
-        var matches = System.Text.RegularExpressions.Regex.Matches(
-            output, "cannot seal an abstract Executor");
-        Assert.Equal(1, matches.Count);
+        Assert.DoesNotContain("cannot seal", output);
+        Assert.DoesNotContain("sealed", output);
+        Assert.Equal(src, output.TrimEnd());
     }
 
     [Fact]
-    public void ExecutorSealedRewriter_TwoAbstractExecutors_EachGetsOneComment()
+    public void ExecutorSealedRewriter_TwoAbstractExecutors_BothLeftUnchanged()
     {
-        // Adversarial input (suggested by Phase 4.G review): two abstract
-        // Executor-derived classes in one source. Each should get its OWN
-        // comment, totaling two — but each only once, not duplicated.
+        // Two abstract Executor-derived classes in one source — both left untouched.
         const string src = """
             using Microsoft.Agents.AI.Workflow;
             public abstract class FirstAuditor : Executor
@@ -121,9 +113,8 @@ public sealed class RewriterIdempotenceTests
             }
             """;
         var output = ApplyTwice(new ExecutorSealedRewriter(), src);
-        var matches = System.Text.RegularExpressions.Regex.Matches(
-            output, "cannot seal an abstract Executor");
-        Assert.Equal(2, matches.Count);
+        Assert.DoesNotContain("cannot seal", output);
+        Assert.Equal(src, output.TrimEnd());
     }
 
     [Fact]

--- a/src/maf-autopilot.Tests/TourToolTests.cs
+++ b/src/maf-autopilot.Tests/TourToolTests.cs
@@ -121,6 +121,33 @@ public sealed class TourToolTests
     }
 
     [Fact]
+    public void Catalogue_ListsEveryMcpServerPrompt_NoDrift()
+    {
+        // Same drift guard for prompts — every [McpServerPrompt] method must
+        // appear in the prompt catalogue (and vice versa).
+        var assembly = typeof(TourTool).Assembly;
+        var promptNames = assembly.GetTypes()
+            .Where(t => t.GetCustomAttribute<McpServerPromptTypeAttribute>() is not null)
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+            .Select(m => m.GetCustomAttribute<McpServerPromptAttribute>())
+            .Where(a => a is not null)
+            .Select(a => a!.Name!)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var catalogued = TourTool.PromptCatalogue.Select(p => p.Name).ToHashSet(StringComparer.Ordinal);
+
+        var missing = promptNames.Except(catalogued).OrderBy(s => s).ToList();
+        var extra = catalogued.Except(promptNames).OrderBy(s => s).ToList();
+
+        Assert.True(missing.Count == 0,
+            $"MafTour catalogue is missing entries for live MCP prompts: {string.Join(", ", missing)}. " +
+            "Add each one to TourTool.PromptCatalogue.");
+        Assert.True(extra.Count == 0,
+            $"MafTour catalogue lists prompts that don't exist as [McpServerPrompt] methods: {string.Join(", ", extra)}.");
+    }
+
+    [Fact]
     public void BuildFullCatalogue_StaticMethod_RoundTripsThroughMafTour()
     {
         // Arrange / Act — the resource path (maf://help) and the tool path (MafTour)

--- a/src/maf-autopilot/Commands/DoctorCli.cs
+++ b/src/maf-autopilot/Commands/DoctorCli.cs
@@ -1,0 +1,42 @@
+namespace MafDoctor.Commands;
+
+/// <summary>
+/// Argument parsing for the <c>doctor</c> CLI subcommand, extracted from the
+/// Program.cs top-level statements so it can be unit-tested without spawning a
+/// process (the analysis itself lives in <c>DoctorTool</c>).
+///
+/// Grammar: <c>doctor [path] [--exclude &lt;substr&gt;]... [--all|--full] [--json]</c>
+/// <list type="bullet">
+///   <item>The first non-flag token is the path (default: current directory at
+///         the call site — left null here so the caller decides the default).</item>
+///   <item><c>--exclude &lt;substr&gt;</c> is repeatable; each skips files whose
+///         repo-relative path contains the substring (used by the drift detector
+///         to scan product code only).</item>
+///   <item><c>--all</c> / <c>--full</c> lists every finding (grouped) vs the top 3.</item>
+///   <item><c>--json</c> emits machine-readable output instead of markdown.</item>
+/// </list>
+/// </summary>
+internal static class DoctorCli
+{
+    public static (string? Path, string Format, List<string> Excludes, bool Full) Parse(string[] args)
+    {
+        var excludes = new List<string>();
+        string? path = null;
+        var full = false;
+        var format = "markdown";
+
+        // args[0] is "doctor"; options start at index 1.
+        for (int i = 1; i < args.Length; i++)
+        {
+            if (args[i] == "--exclude" && i + 1 < args.Length) { excludes.Add(args[++i]); continue; }
+            if (args[i] is "--all" or "--full") { full = true; continue; }
+            if (args[i] is "--json") { format = "json"; continue; }
+            // First non-flag token is the path. The `--` guard means a flag that
+            // appears before the path (e.g. `doctor --json .`) is never mistaken
+            // for the path.
+            if (path is null && !args[i].StartsWith("--", StringComparison.Ordinal)) path = args[i];
+        }
+
+        return (path, format, excludes, full);
+    }
+}

--- a/src/maf-autopilot/Commands/DoctorCli.cs
+++ b/src/maf-autopilot/Commands/DoctorCli.cs
@@ -5,7 +5,7 @@ namespace MafDoctor.Commands;
 /// Program.cs top-level statements so it can be unit-tested without spawning a
 /// process (the analysis itself lives in <c>DoctorTool</c>).
 ///
-/// Grammar: <c>doctor [path] [--exclude &lt;substr&gt;]... [--all|--full] [--json]</c>
+/// Grammar: <c>doctor [path] [--exclude &lt;substr&gt;]... [--all|--full] [--json|--plan]</c>
 /// <list type="bullet">
 ///   <item>The first non-flag token is the path (default: current directory at
 ///         the call site — left null here so the caller decides the default).</item>
@@ -13,7 +13,8 @@ namespace MafDoctor.Commands;
 ///         repo-relative path contains the substring (used by the drift detector
 ///         to scan product code only).</item>
 ///   <item><c>--all</c> / <c>--full</c> lists every finding (grouped) vs the top 3.</item>
-///   <item><c>--json</c> emits machine-readable output instead of markdown.</item>
+///   <item><c>--json</c> emits machine-readable output; <c>--plan</c> emits an
+///         ordered, checkboxed remediation plan. Last format flag wins.</item>
 /// </list>
 /// </summary>
 internal static class DoctorCli
@@ -31,6 +32,7 @@ internal static class DoctorCli
             if (args[i] == "--exclude" && i + 1 < args.Length) { excludes.Add(args[++i]); continue; }
             if (args[i] is "--all" or "--full") { full = true; continue; }
             if (args[i] is "--json") { format = "json"; continue; }
+            if (args[i] is "--plan") { format = "plan"; continue; }
             // First non-flag token is the path. The `--` guard means a flag that
             // appears before the path (e.g. `doctor --json .`) is never mistaken
             // for the path.

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -42,9 +42,10 @@ if (args.Length > 0 && (args[0] is "--help" or "-h" or "help"))
         Commands:
           init [--with-cursor]              Wire the MCP server + steering into the current repo
                                             (.vscode/mcp.json, .mcp.json, instructions, agents).
-          doctor [path] [--exclude <s>] [--all] [--json]
+          doctor [path] [--exclude <s>] [--all] [--json|--plan]
                                             A/B/C/F health report. --all = every finding (grouped),
-                                            not just the top 3; --json = machine-readable output.
+                                            not just the top 3; --json = machine-readable output;
+                                            --plan = ordered, checkboxed remediation plan.
           autofix-all [path] [--dry-run]    Apply deterministic Roslyn fixes.
           new agent <Name>                  Scaffold a MAF agent + smoke test.
           new executor <Name> [In] [Out]    Scaffold a workflow executor + smoke test.

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -42,7 +42,9 @@ if (args.Length > 0 && (args[0] is "--help" or "-h" or "help"))
         Commands:
           init [--with-cursor]              Wire the MCP server + steering into the current repo
                                             (.vscode/mcp.json, .mcp.json, instructions, agents).
-          doctor [path] [--exclude <s>] [--all]  A/B/C/F health report (--all = every finding, not just top 3).
+          doctor [path] [--exclude <s>] [--all] [--json]
+                                            A/B/C/F health report. --all = every finding (grouped),
+                                            not just the top 3; --json = machine-readable output.
           autofix-all [path] [--dry-run]    Apply deterministic Roslyn fixes.
           new agent <Name>                  Scaffold a MAF agent + smoke test.
           new executor <Name> [In] [Out]    Scaffold a workflow executor + smoke test.
@@ -71,22 +73,14 @@ if (args.Length >= 2 && args[0] == "new")
 }
 if (args.Length >= 1 && args[0] == "doctor")
 {
-    // Usage: maf-doctor doctor [path] [--exclude <substr>]...
-    // Repeatable `--exclude` skips files whose repo-relative path contains the
-    // substring — used by the drift detector to scan product code only (skip
-    // samples/ + test fixtures). The first non-flag arg is the path (default cwd).
-    // `--all` / `--full` lists EVERY finding (one line each) instead of the top 3.
-    var excludes = new List<string>();
-    string? path = null;
-    var full = false;
-    for (int i = 1; i < args.Length; i++)
-    {
-        if (args[i] == "--exclude" && i + 1 < args.Length) { excludes.Add(args[++i]); continue; }
-        if (args[i] is "--all" or "--full") { full = true; continue; }
-        if (path is null && !args[i].StartsWith("--", StringComparison.Ordinal)) path = args[i];
-    }
-    path ??= Directory.GetCurrentDirectory();
-    var report = new MafDoctor.Tools.DoctorTool().Run(path, "markdown", excludes, full);
+    // Usage: maf-doctor doctor [path] [--exclude <substr>]... [--all|--full] [--json]
+    // Parsing lives in DoctorCli.Parse (extracted so it's unit-testable without a
+    // process spawn). `--exclude` skips files by repo-relative substring (drift
+    // detector scopes to product code); `--all`/`--full` lists every finding
+    // (grouped); `--json` emits machine-readable output.
+    var (parsedPath, format, excludes, full) = MafDoctor.Commands.DoctorCli.Parse(args);
+    var path = parsedPath ?? Directory.GetCurrentDirectory();
+    var report = new MafDoctor.Tools.DoctorTool().Run(path, format, excludes, full);
     Console.WriteLine(report);
     Environment.Exit(0);
     return;

--- a/src/maf-autopilot/Prompts/MafPrompts.cs
+++ b/src/maf-autopilot/Prompts/MafPrompts.cs
@@ -283,6 +283,52 @@ public static class MafPrompts
         return [new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = sb.ToString() } }];
     }
 
+    [McpServerPrompt(Name = "maf-explain-finding",
+        Title = "MAF Explain Finding: deep-dive and fix one doctor finding")]
+    [Description(
+        "Deep-dive a single MAF Doctor finding (file + line from the report) and turn it " +
+        "into a precise explanation and proposed fix. Calls MafExplainFinding for the grounded " +
+        "code context + rule rationale, then uses maf://constraints and maf://guide as grounding " +
+        "so the explanation and fix are accurate, not hallucinated.")]
+    public static IList<PromptMessage> ExplainFinding(
+        [Description("Repo-relative file path of the finding, exactly as shown in the doctor report (e.g. 'Executors/Foo.cs').")] string file,
+        [Description("1-based line number of the finding.")] string line,
+        [Description("Path to the repository root. Leave empty to let the assistant infer it.")] string? repoPath = null)
+    {
+        // Phase 5.G fixup — length caps before sanitization. See Audit for rationale.
+        try { BoundedInput.Validate(file,     BoundedInput.PathBytes,      nameof(file)); }
+        catch (ArgumentException) { file = string.Empty; }
+        try { BoundedInput.Validate(line,     BoundedInput.ShortTextBytes, nameof(line)); }
+        catch (ArgumentException) { line = string.Empty; }
+        try { BoundedInput.Validate(repoPath, BoundedInput.PathBytes,      nameof(repoPath)); }
+        catch (ArgumentException) { repoPath = null; }
+
+        // Phase 2.G fixup (Finding 3) — strip HTML comments from echoed values.
+        var safeFile = LlmFencing.StripHtmlComments(file);
+        var safeLine = LlmFencing.StripHtmlComments(line);
+        var safeRepoPath = LlmFencing.StripHtmlComments(repoPath);
+
+        var sb = new StringBuilder();
+        sb.AppendLine("Explain ONE MAF Doctor finding and propose the exact fix in the user's code. Be precise — ground every claim in the served resources, do not guess.");
+        sb.AppendLine();
+        sb.AppendLine($"Finding location: `{(string.IsNullOrEmpty(safeFile) ? "<file>" : safeFile)}:{(string.IsNullOrEmpty(safeLine) ? "<line>" : safeLine)}`");
+        if (!string.IsNullOrEmpty(safeRepoPath))
+            sb.AppendLine($"Repository: {safeRepoPath}");
+        sb.AppendLine();
+        var repoArg = string.IsNullOrEmpty(safeRepoPath) ? "<repo>" : safeRepoPath;
+        sb.AppendLine("STEPS:");
+        sb.AppendLine($"1. Call `MafExplainFinding(repoPath: \"{repoArg}\", file: \"{(string.IsNullOrEmpty(safeFile) ? "<file>" : safeFile)}\", line: {(string.IsNullOrEmpty(safeLine) ? "<line>" : safeLine)})` to get the offending code in context plus the rule's rationale, fix, and auto-fixability.");
+        sb.AppendLine("2. Read `maf://constraints` (the hard rules) and the relevant section of `maf://guide`. For an obsolete / removed-surface finding (e.g. `MAF-AP-EXEC-001`), also call `MafRegistryLookup` for the canonical before/after.");
+        sb.AppendLine("3. Explain to the user, grounded in those sources:");
+        sb.AppendLine("   - **What** the finding is and **why it matters** (the concrete failure mode, not a restatement of the rule name).");
+        sb.AppendLine("   - **The fix.** If the tool reports it is *auto-fixable*, tell the user to run `maf-doctor autofix-all .` (or call `MafAutoFixAll`) — the rewrite is deterministic. If it *needs judgment*, propose the exact change as a minimal diff against the shown code.");
+        sb.AppendLine("4. Before finalizing a hand-written fix, re-check it against `maf://constraints` so the fix doesn't violate a hard rule.");
+        sb.AppendLine();
+        sb.AppendLine("Keep it tight: one finding, one clear fix. If `MafExplainFinding` reports no finding at that line, say so and suggest re-running `MafDoctor` for the current `file:line`.");
+
+        return [new PromptMessage { Role = Role.User, Content = new TextContentBlock { Text = sb.ToString() } }];
+    }
+
     [McpServerPrompt(Name = "maf-scaffold",
         Title = "MAF Scaffold: Generate MAF Boilerplate")]
     [Description(

--- a/src/maf-autopilot/Prompts/MafPrompts.cs
+++ b/src/maf-autopilot/Prompts/MafPrompts.cs
@@ -192,7 +192,7 @@ public static class MafPrompts
         sb.AppendLine("**Suggested tool calls** (most-to-least lightweight):");
         sb.AppendLine();
         sb.AppendLine("- `MafDoctor(repoPath)` — A/B/C/F grade + top 3 fixes. Best triage signal.");
-        sb.AppendLine("- `MafScanAntiPatterns(repoPath)` — 10-rule security/concurrency/observability scan.");
+        sb.AppendLine("- `MafScanAntiPatterns(repoPath)` — 11-rule security/concurrency/observability scan.");
         sb.AppendLine("- `MafValidateFanOut(repoPath)` — silent fan-in starvation detector.");
         sb.AppendLine("- `MafLintAgentPrompt(repoPath)` — agent-prompt safety (empty / bloat / refusal / injection).");
         sb.AppendLine("- `MafEstimateCost(repoPath)` — token-cost auditor (missing `MaxOutputTokens` cap).");

--- a/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
+++ b/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
@@ -196,12 +196,21 @@ public sealed class AntiPatternScannerTool
                         || rhs.RawKind != (int)SyntaxKind.TrueLiteralExpression)
                         continue;
 
+                    // Match ONLY the contexts the rewriter can actually fix, so every
+                    // finding is genuinely auto-fixable (true detector ⇆ rewriter parity):
+                    // initializer entries (VisitInitializerExpression) and statement
+                    // assignments (VisitExpressionStatement). A lambda-body / nested
+                    // assignment the rewriter can't touch is intentionally not flagged.
                     var match = assign.Left switch
                     {
-                        IdentifierNameSyntax id => id.Identifier.ValueText == "EnableSensitiveData",          // EnableSensitiveData = true
-                        MemberAccessExpressionSyntax mae => mae.Name.Identifier.ValueText == "EnableSensitiveData", // x.EnableSensitiveData = true
-                        ImplicitElementAccessSyntax iea => IsEnableSensitiveDataKey(iea.ArgumentList),        // ["EnableSensitiveData"] = true
-                        ElementAccessExpressionSyntax eae => IsEnableSensitiveDataKey(eae.ArgumentList),      // dict["EnableSensitiveData"] = true
+                        IdentifierNameSyntax id => id.Identifier.ValueText == "EnableSensitiveData"
+                            && assign.Parent is InitializerExpressionSyntax,                                   // new O { EnableSensitiveData = true }
+                        ImplicitElementAccessSyntax iea => IsEnableSensitiveDataKey(iea.ArgumentList)
+                            && assign.Parent is InitializerExpressionSyntax,                                   // new D { ["EnableSensitiveData"] = true }
+                        MemberAccessExpressionSyntax mae => mae.Name.Identifier.ValueText == "EnableSensitiveData"
+                            && assign.Parent is ExpressionStatementSyntax,                                     // x.EnableSensitiveData = true;
+                        ElementAccessExpressionSyntax eae => IsEnableSensitiveDataKey(eae.ArgumentList)
+                            && assign.Parent is ExpressionStatementSyntax,                                     // dict["EnableSensitiveData"] = true;
                         _ => false,
                     };
                     if (!match) continue;
@@ -347,6 +356,11 @@ public sealed class AntiPatternScannerTool
                         continue;
 
                     var modifiers = cls.Modifiers.Select(m => m.ValueText).ToHashSet();
+                    // Skip abstract classes: an abstract Executor base can never be
+                    // `sealed partial` (abstract precludes sealed), so flagging it with
+                    // an auto-fixable rule whose fix is impossible would be dishonest.
+                    // The dispatched concrete subclass is what must be `sealed partial`.
+                    if (modifiers.Contains("abstract")) continue;
                     var hasPartial = modifiers.Contains("partial");
                     var hasSealed = modifiers.Contains("sealed");
                     if (hasPartial && hasSealed) continue;
@@ -641,11 +655,16 @@ internal sealed class RegexRule : AntiPatternRule
         var lineStart = 0;
         for (var i = 0; i < lines.Length; i++)
         {
-            var match = _pattern.Match(lines[i]);
-            if (match.Success
-                && !IsInCommentOrSkippedLiteral(root, lineStart + match.Index, _matchesStringContent))
+            // Inspect EVERY match on the line, not just the first: a real code
+            // match can follow a comment/string match on the same physical line.
+            // Emit the first match that isn't in skipped trivia (one per line,
+            // preserving prior behavior); only skip the line if all are filtered.
+            foreach (Match m in _pattern.Matches(lines[i]))
             {
-                findings.Add(new AntiPatternFinding(Id, Name, Severity, file, i + 1, match.Value));
+                if (IsInCommentOrSkippedLiteral(root, lineStart + m.Index, _matchesStringContent))
+                    continue;
+                findings.Add(new AntiPatternFinding(Id, Name, Severity, file, i + 1, m.Value));
+                break;
             }
             lineStart += lines[i].Length + 1; // +1 for the '\n' that Split removed
         }

--- a/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
+++ b/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
@@ -158,12 +158,6 @@ public sealed class AntiPatternScannerTool
     /// </summary>
     internal static bool LooksLikeSecret(string text) => SecretRedactionPattern.IsMatch(text);
 
-    /// <summary>OBS-001's `new ChatClientAgent(` probe — hoisted to a field so it honors
-    /// the same NonBacktracking + MatchTimeout hygiene as every other rule (case-sensitive,
-    /// matching the original static call and real C# type-name casing).</summary>
-    private static readonly Regex ChatClientAgentCtor =
-        new(@"\bnew\s+ChatClientAgent\s*\(", RegexHygiene, RegexBudget);
-
     internal static readonly IReadOnlyList<AntiPatternRule> AllRules = new AntiPatternRule[]
     {
         new RegexRule(
@@ -250,34 +244,51 @@ public sealed class AntiPatternScannerTool
             pattern: new Regex(@"\)\s*\.(?:Result|Wait)\b(\s*\(\s*\))?", RegexHygiene, RegexBudget),
             skipInTestFiles: true),
 
-        new RegexRule(
+        // MAF-AP-OBS-001 — file builds an agent but never chains UseOpenTelemetry.
+        // RoslynRule (not a raw-text scan): detection walks syntax NODES, so an
+        // `AIAgentBuilder` / `new ChatClientAgent(` / `UseOpenTelemetry` that appears
+        // only inside a comment or a string literal no longer false-fires — comments
+        // are trivia (never nodes) and a string body is a literal token, not an
+        // identifier. The reported line is the real builder node, not the first
+        // textual match.
+        new RoslynRule(
             id: "MAF-AP-OBS-001",
             name: "Missing UseOpenTelemetry in file that builds an agent",
             severity: AntiPatternSeverity.Warning,
-            // Two conditions in the same file: builder type AND no UseOpenTelemetry call.
-            pattern: null,
-            skipInTestFiles: true,
-            customScan: (source, _, file) =>
+            scan: (root, file) =>
             {
-                var hasBuilder = source.Contains("AIAgentBuilder")
-                              || ChatClientAgentCtor.IsMatch(source);
-                var hasOTel = source.Contains("UseOpenTelemetry");
-                if (hasBuilder && !hasOTel)
+                // An agent is built in real code via an `AIAgentBuilder` reference or
+                // a `new ChatClientAgent(...)` construction.
+                Microsoft.CodeAnalysis.SyntaxNode? builderNode = null;
+                foreach (var n in root.DescendantNodes())
                 {
-                    var line = FirstLineMatching(source, @"AIAgentBuilder|new\s+ChatClientAgent\s*\(");
-                    return new[]
+                    if (n is IdentifierNameSyntax { Identifier.ValueText: "AIAgentBuilder" }
+                        || (n is BaseObjectCreationExpressionSyntax oce
+                            && ObjectCreationTypeName(oce) == "ChatClientAgent"))
                     {
-                        new AntiPatternFinding(
-                            "MAF-AP-OBS-001",
-                            "Missing UseOpenTelemetry in file that builds an agent",
-                            AntiPatternSeverity.Warning,
-                            file,
-                            line,
-                            "(agent built without telemetry chained)")
-                    };
+                        builderNode = n;
+                        break;
+                    }
                 }
-                return Array.Empty<AntiPatternFinding>();
-            }),
+                if (builderNode is null) return Array.Empty<AntiPatternFinding>();
+
+                var hasOTel = root.DescendantNodes().OfType<IdentifierNameSyntax>()
+                    .Any(id => id.Identifier.ValueText == "UseOpenTelemetry");
+                if (hasOTel) return Array.Empty<AntiPatternFinding>();
+
+                var line = builderNode.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+                return new[]
+                {
+                    new AntiPatternFinding(
+                        "MAF-AP-OBS-001",
+                        "Missing UseOpenTelemetry in file that builds an agent",
+                        AntiPatternSeverity.Warning,
+                        file,
+                        line,
+                        "(agent built without telemetry chained)")
+                };
+            },
+            skipInTestFiles: true),
 
         new RoslynRule(
             id: "MAF-AP-CONC-001",
@@ -328,7 +339,7 @@ public sealed class AntiPatternScannerTool
                 foreach (var oce in root.DescendantNodes().OfType<BaseObjectCreationExpressionSyntax>())
                 {
                     if (oce.Initializer is null) continue;
-                    if (ChatClientAgentOptionsTargetName(oce) != "ChatClientAgentOptions") continue;
+                    if (ObjectCreationTypeName(oce) != "ChatClientAgentOptions") continue;
 
                     foreach (var expr in oce.Initializer.Expressions.OfType<AssignmentExpressionSyntax>())
                     {
@@ -358,9 +369,10 @@ public sealed class AntiPatternScannerTool
                 var findings = new List<AntiPatternFinding>();
                 foreach (var cls in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
                 {
-                    // Only consider classes that inherit from `Executor` and have [MessageHandler] methods.
-                    var baseList = cls.BaseList?.Types.Select(t => t.Type.ToString()) ?? [];
-                    if (!baseList.Any(b => b == "Executor" || b.EndsWith(".Executor", StringComparison.Ordinal)))
+                    // Only consider classes that inherit from `Executor` (plain OR
+                    // generic `Executor<…>`, qualified or not) and have [MessageHandler]
+                    // methods. Shared predicate keeps this in lockstep with the rewriter.
+                    if (!(cls.BaseList?.Types.Any(t => IsExecutorBaseType(t.Type)) ?? false))
                         continue;
                     if (!cls.Members.OfType<MethodDeclarationSyntax>().Any(m =>
                         m.AttributeLists.SelectMany(a => a.Attributes).Any(a =>
@@ -463,16 +475,22 @@ public sealed class AntiPatternScannerTool
                 {
                     if (invocation.Expression is not MemberAccessExpressionSyntax member) continue;
                     if (member.Name.Identifier.ValueText != "Use") continue;
-                    var argText = invocation.ArgumentList.ToString();
 
-                    // Heuristic: if `runFunc` appears but `runStreamingFunc` doesn't, or
-                    // either is explicitly set to `null`, the streaming path bypasses.
-                    var hasRunFunc = argText.Contains("runFunc", StringComparison.Ordinal);
-                    var hasStreaming = argText.Contains("runStreamingFunc", StringComparison.Ordinal);
-                    var streamingIsNull = argText.Contains("runStreamingFunc: null", StringComparison.Ordinal)
-                                       || argText.Contains("runStreamingFunc:null", StringComparison.Ordinal);
-                    if (!hasRunFunc) continue;
-                    if (hasStreaming && !streamingIsNull) continue;
+                    // Match the NAMED-callback middleware form via the AST, not a raw
+                    // substring of the argument text. The old `argText.Contains("runFunc")`
+                    // false-fired on any `.Use(...)` whose text merely CONTAINED the
+                    // substring — a positional local named `runFunc`, or an unrelated
+                    // identifier like `computeMyrunFunc()`. NameColon pins the actual
+                    // `runFunc:` / `runStreamingFunc:` argument labels.
+                    var args = invocation.ArgumentList.Arguments;
+                    ArgumentSyntax? Named(string n) =>
+                        args.FirstOrDefault(a => a.NameColon?.Name.Identifier.ValueText == n);
+
+                    if (Named("runFunc") is null) continue;          // not the named middleware form
+                    var streaming = Named("runStreamingFunc");
+                    var streamingIsNull = streaming is { Expression: LiteralExpressionSyntax sl }
+                        && sl.RawKind == (int)SyntaxKind.NullLiteralExpression;
+                    if (streaming is not null && !streamingIsNull) continue; // both callbacks present
 
                     var loc = invocation.GetLocation().GetLineSpan();
                     var why = streamingIsNull
@@ -510,7 +528,7 @@ public sealed class AntiPatternScannerTool
     /// visible (a <c>T x = new() {…}</c> variable declaration). Pure-source — returns
     /// null when the type can't be determined without a semantic model.
     /// </summary>
-    private static string? ChatClientAgentOptionsTargetName(BaseObjectCreationExpressionSyntax oce)
+    private static string? ObjectCreationTypeName(BaseObjectCreationExpressionSyntax oce)
     {
         static string Simple(string t) => t.Contains('.') ? t[(t.LastIndexOf('.') + 1)..] : t;
 
@@ -524,22 +542,33 @@ public sealed class AntiPatternScannerTool
         return null;
     }
 
+    /// <summary>
+    /// True if a base-type syntax names the MAF workflow <c>Executor</c> base in any
+    /// form: plain <c>Executor</c>, generic <c>Executor&lt;…&gt;</c>, namespace-qualified
+    /// (<c>Microsoft.Agents.AI.Workflows.Executor</c>), or alias-qualified. Shared by
+    /// the WF-001 scanner rule AND <see cref="Rewriters.ExecutorSealedRewriter"/> so
+    /// detector and rewriter agree on which classes derive from Executor — without
+    /// this, the scanner would flag a generic-base Executor as auto-fixable while the
+    /// rewriter silently no-op'd it (a detector⇆rewriter parity break).
+    /// </summary>
+    internal static bool IsExecutorBaseType(TypeSyntax type) => SimpleTypeName(type) == "Executor";
+
+    /// <summary>The rightmost simple identifier of a (possibly generic / qualified) type name.</summary>
+    private static string? SimpleTypeName(TypeSyntax type) => type switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        GenericNameSyntax g => g.Identifier.ValueText,
+        QualifiedNameSyntax q => SimpleTypeName(q.Right),
+        AliasQualifiedNameSyntax a => SimpleTypeName(a.Name),
+        _ => null,
+    };
+
     /// <summary>True if a bracketed indexer argument list is the single string key "EnableSensitiveData".</summary>
     private static bool IsEnableSensitiveDataKey(BracketedArgumentListSyntax args)
         => args.Arguments.Count == 1
            && args.Arguments[0].Expression is LiteralExpressionSyntax keyLit
            && keyLit.RawKind == (int)SyntaxKind.StringLiteralExpression
            && keyLit.Token.ValueText == "EnableSensitiveData";
-
-    private static int FirstLineMatching(string source, string regex)
-    {
-        // Phase 5.9 — hygiene policy applies to scanner-internal regexes too.
-        var rx = new Regex(regex, RegexHygiene, RegexBudget);
-        var lines = source.Split('\n');
-        for (var i = 0; i < lines.Length; i++)
-            if (rx.IsMatch(lines[i])) return i + 1;
-        return 1;
-    }
 
     /// <summary>
     /// Returns the inclusive line ranges that lie inside a <c>#if</c> block whose

--- a/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
+++ b/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
@@ -257,14 +257,16 @@ public sealed class AntiPatternScannerTool
             severity: AntiPatternSeverity.Warning,
             scan: (root, file) =>
             {
-                // An agent is built in real code via an `AIAgentBuilder` reference or
-                // a `new ChatClientAgent(...)` construction.
+                // An agent is BUILT via a `new AIAgentBuilder(...)` or a
+                // `new ChatClientAgent(...)` CONSTRUCTION. Match construction (object
+                // creation), NOT a bare type reference — a parameter type, field type,
+                // `nameof(AIAgentBuilder)` or `typeof(...)` is not building an agent and
+                // must not fire (the earlier identifier-match over-flagged those).
                 Microsoft.CodeAnalysis.SyntaxNode? builderNode = null;
                 foreach (var n in root.DescendantNodes())
                 {
-                    if (n is IdentifierNameSyntax { Identifier.ValueText: "AIAgentBuilder" }
-                        || (n is BaseObjectCreationExpressionSyntax oce
-                            && ObjectCreationTypeName(oce) == "ChatClientAgent"))
+                    if (n is BaseObjectCreationExpressionSyntax oce
+                        && ObjectCreationTypeName(oce) is "AIAgentBuilder" or "ChatClientAgent")
                     {
                         builderNode = n;
                         break;
@@ -384,11 +386,14 @@ public sealed class AntiPatternScannerTool
                         continue;
 
                     var modifiers = cls.Modifiers.Select(m => m.ValueText).ToHashSet();
-                    // Skip abstract classes: an abstract Executor base can never be
-                    // `sealed partial` (abstract precludes sealed), so flagging it with
-                    // an auto-fixable rule whose fix is impossible would be dishonest.
-                    // The dispatched concrete subclass is what must be `sealed partial`.
-                    if (modifiers.Contains("abstract")) continue;
+                    // Skip abstract AND static Executors: an abstract Executor can never
+                    // be `sealed` (abstract precludes sealed), and a static class can't
+                    // derive from Executor at all — neither is fixable, so flagging them
+                    // with an auto-fixable rule would be dishonest. This also keeps the
+                    // scanner in lockstep with ExecutorSealedRewriter, which leaves both
+                    // untouched (detector⇆rewriter parity). The dispatched concrete
+                    // subclass is what must be `sealed partial`.
+                    if (modifiers.Contains("abstract") || modifiers.Contains("static")) continue;
                     var hasPartial = modifiers.Contains("partial");
                     var hasSealed = modifiers.Contains("sealed");
                     if (hasPartial && hasSealed) continue;

--- a/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
+++ b/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
@@ -128,8 +128,31 @@ public sealed class AntiPatternScannerTool
     internal static readonly Regex SecretLiteralPattern =
         new(@"""(?:sk-|api[-_]?key=)[A-Za-z0-9_\-]{16,}""", RegexHygiene | RegexOptions.IgnoreCase, RegexBudget);
 
-    /// <summary>True if the text contains a hard-coded secret literal (MAF-AP-SEC-002).</summary>
-    internal static bool LooksLikeSecret(string text) => SecretLiteralPattern.IsMatch(text);
+    /// <summary>
+    /// Broader, best-effort REDACTION pattern (decoupled from the precise SEC-002
+    /// rule pattern). Used only to decide whether a source line is too risky to
+    /// echo into a report — so it errs toward over-matching (redact-on-doubt is
+    /// safe; it just hides a line). Covers OpenAI/api keys, quoted connection-string
+    /// secrets (AccountKey/Password/Secret/Token=…), GitHub tokens, AWS access-key
+    /// ids, JWTs, and PEM private-key headers. NOT exhaustive — high-entropy secrets
+    /// in unrecognized shapes can still slip through; this is defense-in-depth, not
+    /// the primary control.
+    /// </summary>
+    internal static readonly Regex SecretRedactionPattern = new(
+        @"""(?:sk-|api[-_]?key=)[A-Za-z0-9_\-]{16,}"""
+        + @"|""[^""]*(?:accountkey|sharedaccesskey|password|pwd|secret|token)\s*=\s*[^""]{4,}[^""]*"""
+        + @"|gh[opsru]_[A-Za-z0-9]{20,}"
+        + @"|AKIA[0-9A-Z]{16}"
+        + @"|eyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]+"
+        + @"|-----BEGIN [A-Z ]*PRIVATE KEY-----",
+        RegexHygiene | RegexOptions.IgnoreCase, RegexBudget);
+
+    /// <summary>
+    /// Best-effort: true if the text looks like it contains a secret, for REDACTION
+    /// purposes. Broader than the SEC-002 finding rule (<see cref="SecretLiteralPattern"/>)
+    /// on purpose — see <see cref="SecretRedactionPattern"/>. Not a guarantee.
+    /// </summary>
+    internal static bool LooksLikeSecret(string text) => SecretRedactionPattern.IsMatch(text);
 
     internal static readonly IReadOnlyList<AntiPatternRule> AllRules = new AntiPatternRule[]
     {
@@ -147,14 +170,53 @@ public sealed class AntiPatternScannerTool
             // Matches "sk-XXXXXXXXXXXXXXXX" or "api-key=XXXXXXXXXXXXXXXX" style strings.
             // Shared with DoctorTool's snippet redactor via SecretLiteralPattern.
             pattern: SecretLiteralPattern,
-            skipInTestFiles: false),
+            skipInTestFiles: false,
+            // This rule deliberately matches inside string literals (a hard-coded
+            // key IS a string), so it must NOT be skipped by the string-literal filter.
+            matchesStringContent: true),
 
-        new RegexRule(
+        // Syntax-aware (RoslynRule) so it matches the actual assignment shapes the
+        // EnableSensitiveDataRewriter fixes — object-initializer, dictionary/
+        // collection-initializer (`["EnableSensitiveData"] = true`), member-access,
+        // and element-access — and does NOT false-fire on comments / string
+        // literals that merely mention it. A regex (`EnableSensitiveData\s*=\s*true`)
+        // both missed the dictionary form (the `"]` breaks it) AND matched comments,
+        // so its "auto-fixable" tag was a no-op. This keeps detector ⇆ rewriter in parity.
+        new RoslynRule(
             id: "MAF-AP-SEC-003",
             name: "EnableSensitiveData = true outside development",
             severity: AntiPatternSeverity.Error,
-            pattern: new Regex(@"EnableSensitiveData\s*=\s*true", RegexHygiene, RegexBudget),
-            skipInTestFiles: true),
+            skipInTestFiles: true,
+            scan: (root, file) =>
+            {
+                var findings = new List<AntiPatternFinding>();
+                foreach (var assign in root.DescendantNodes().OfType<AssignmentExpressionSyntax>())
+                {
+                    if (assign.Right is not LiteralExpressionSyntax rhs
+                        || rhs.RawKind != (int)SyntaxKind.TrueLiteralExpression)
+                        continue;
+
+                    var match = assign.Left switch
+                    {
+                        IdentifierNameSyntax id => id.Identifier.ValueText == "EnableSensitiveData",          // EnableSensitiveData = true
+                        MemberAccessExpressionSyntax mae => mae.Name.Identifier.ValueText == "EnableSensitiveData", // x.EnableSensitiveData = true
+                        ImplicitElementAccessSyntax iea => IsEnableSensitiveDataKey(iea.ArgumentList),        // ["EnableSensitiveData"] = true
+                        ElementAccessExpressionSyntax eae => IsEnableSensitiveDataKey(eae.ArgumentList),      // dict["EnableSensitiveData"] = true
+                        _ => false,
+                    };
+                    if (!match) continue;
+
+                    var loc = assign.GetLocation().GetLineSpan();
+                    findings.Add(new AntiPatternFinding(
+                        "MAF-AP-SEC-003",
+                        "EnableSensitiveData = true outside development",
+                        AntiPatternSeverity.Error,
+                        file,
+                        loc.StartLinePosition.Line + 1,
+                        assign.ToString()));
+                }
+                return findings;
+            }),
 
         new RegexRule(
             id: "MAF-AP-CONC-002",
@@ -412,6 +474,13 @@ public sealed class AntiPatternScannerTool
             skipInTestFiles: false),
     };
 
+    /// <summary>True if a bracketed indexer argument list is the single string key "EnableSensitiveData".</summary>
+    private static bool IsEnableSensitiveDataKey(BracketedArgumentListSyntax args)
+        => args.Arguments.Count == 1
+           && args.Arguments[0].Expression is LiteralExpressionSyntax keyLit
+           && keyLit.RawKind == (int)SyntaxKind.StringLiteralExpression
+           && keyLit.Token.ValueText == "EnableSensitiveData";
+
     private static int FirstLineMatching(string source, string regex)
     {
         // Phase 5.9 — hygiene policy applies to scanner-internal regexes too.
@@ -543,11 +612,13 @@ internal sealed class RegexRule : AntiPatternRule
 {
     private readonly Regex? _pattern;
     private readonly Func<string, Microsoft.CodeAnalysis.SyntaxNode, string, IEnumerable<AntiPatternFinding>>? _custom;
+    private readonly bool _matchesStringContent;
 
     public RegexRule(
         string id, string name, AntiPatternSeverity severity,
         Regex? pattern, bool skipInTestFiles = false,
-        Func<string, Microsoft.CodeAnalysis.SyntaxNode, string, IEnumerable<AntiPatternFinding>>? customScan = null)
+        Func<string, Microsoft.CodeAnalysis.SyntaxNode, string, IEnumerable<AntiPatternFinding>>? customScan = null,
+        bool matchesStringContent = false)
     {
         Id = id;
         Name = name;
@@ -555,6 +626,7 @@ internal sealed class RegexRule : AntiPatternRule
         SkipInTestFiles = skipInTestFiles;
         _pattern = pattern;
         _custom = customScan;
+        _matchesStringContent = matchesStringContent;
     }
 
     public override IEnumerable<AntiPatternFinding> Scan(string source, Microsoft.CodeAnalysis.SyntaxNode root, string file)
@@ -566,13 +638,50 @@ internal sealed class RegexRule : AntiPatternRule
 
         var findings = new List<AntiPatternFinding>();
         var lines = source.Split('\n');
+        var lineStart = 0;
         for (var i = 0; i < lines.Length; i++)
         {
             var match = _pattern.Match(lines[i]);
-            if (match.Success)
+            if (match.Success
+                && !IsInCommentOrSkippedLiteral(root, lineStart + match.Index, _matchesStringContent))
+            {
                 findings.Add(new AntiPatternFinding(Id, Name, Severity, file, i + 1, match.Value));
+            }
+            lineStart += lines[i].Length + 1; // +1 for the '\n' that Split removed
         }
         return findings;
+    }
+
+    /// <summary>
+    /// True if the matched span lies in a comment (skip for ALL rules — a
+    /// commented-out / documented pattern is not a real finding) or, for rules
+    /// that don't target string content, inside a string-literal token (a pattern
+    /// inside a string is data, not code). The hard-coded-secret rule sets
+    /// <paramref name="matchesStringContent"/> so it keeps matching string bodies.
+    /// Offset-based (not line-based), so it's robust to CRLF/LF/CR differences.
+    /// </summary>
+    private static bool IsInCommentOrSkippedLiteral(
+        Microsoft.CodeAnalysis.SyntaxNode root, int offset, bool matchesStringContent)
+    {
+        if (offset < 0 || offset >= root.FullSpan.End) return false;
+
+        var triviaKind = (SyntaxKind)root.FindTrivia(offset).RawKind;
+        if (triviaKind is SyntaxKind.SingleLineCommentTrivia
+            or SyntaxKind.MultiLineCommentTrivia
+            or SyntaxKind.SingleLineDocumentationCommentTrivia
+            or SyntaxKind.MultiLineDocumentationCommentTrivia)
+            return true;
+
+        if (matchesStringContent) return false;
+
+        var token = root.FindToken(offset);
+        var tokenKind = (SyntaxKind)token.RawKind;
+        return token.Span.Contains(offset)
+            && tokenKind is SyntaxKind.StringLiteralToken
+                or SyntaxKind.InterpolatedStringTextToken
+                or SyntaxKind.SingleLineRawStringLiteralToken
+                or SyntaxKind.MultiLineRawStringLiteralToken
+                or SyntaxKind.Utf8StringLiteralToken;
     }
 }
 

--- a/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
+++ b/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
@@ -138,14 +138,16 @@ public sealed class AntiPatternScannerTool
     /// in unrecognized shapes can still slip through; this is defense-in-depth, not
     /// the primary control.
     /// </summary>
-    internal static readonly Regex SecretRedactionPattern = new(
+    // Pattern text in a const so the multi-line literal doesn't push the
+    // `new(...)` options outside the ci-invariants regex-hygiene detection window.
+    private const string SecretRedactionRegexText =
         @"""(?:sk-|api[-_]?key=)[A-Za-z0-9_\-]{16,}"""
         + @"|""[^""]*(?:accountkey|sharedaccesskey|password|pwd|secret|token)\s*=\s*[^""]{4,}[^""]*"""
         + @"|gh[opsru]_[A-Za-z0-9]{20,}"
         + @"|AKIA[0-9A-Z]{16}"
         + @"|eyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]+"
-        + @"|-----BEGIN [A-Z ]*PRIVATE KEY-----",
-        RegexHygiene | RegexOptions.IgnoreCase, RegexBudget);
+        + @"|-----BEGIN [A-Z ]*PRIVATE KEY-----";
+    internal static readonly Regex SecretRedactionPattern = new(SecretRedactionRegexText, RegexHygiene | RegexOptions.IgnoreCase, RegexBudget);
 
     /// <summary>
     /// Best-effort: true if the text looks like it contains a secret, for REDACTION

--- a/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
+++ b/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
@@ -141,7 +141,9 @@ public sealed class AntiPatternScannerTool
     // Pattern text in a const so the multi-line literal doesn't push the
     // `new(...)` options outside the ci-invariants regex-hygiene detection window.
     private const string SecretRedactionRegexText =
-        @"""(?:sk-|api[-_]?key=)[A-Za-z0-9_\-]{16,}"""
+        // Leading quote OPTIONAL (`"?`) so bare `sk-…` / `api-key=…` in a comment or
+        // raw-string body is redacted too, not just the quoted finding-style line.
+        @"""?(?:sk-|api[-_]?key\s*=\s*)[A-Za-z0-9_\-]{16,}"
         + @"|""[^""]*(?:accountkey|sharedaccesskey|password|pwd|secret|token)\s*=\s*[^""]{4,}[^""]*"""
         + @"|gh[opsru]_[A-Za-z0-9]{20,}"
         + @"|AKIA[0-9A-Z]{16}"
@@ -155,6 +157,12 @@ public sealed class AntiPatternScannerTool
     /// on purpose — see <see cref="SecretRedactionPattern"/>. Not a guarantee.
     /// </summary>
     internal static bool LooksLikeSecret(string text) => SecretRedactionPattern.IsMatch(text);
+
+    /// <summary>OBS-001's `new ChatClientAgent(` probe — hoisted to a field so it honors
+    /// the same NonBacktracking + MatchTimeout hygiene as every other rule (case-sensitive,
+    /// matching the original static call and real C# type-name casing).</summary>
+    private static readonly Regex ChatClientAgentCtor =
+        new(@"\bnew\s+ChatClientAgent\s*\(", RegexHygiene, RegexBudget);
 
     internal static readonly IReadOnlyList<AntiPatternRule> AllRules = new AntiPatternRule[]
     {
@@ -200,9 +208,11 @@ public sealed class AntiPatternScannerTool
 
                     // Match ONLY the contexts the rewriter can actually fix, so every
                     // finding is genuinely auto-fixable (true detector ⇆ rewriter parity):
-                    // initializer entries (VisitInitializerExpression) and statement
-                    // assignments (VisitExpressionStatement). A lambda-body / nested
-                    // assignment the rewriter can't touch is intentionally not flagged.
+                    // initializer entries (VisitInitializerExpression) and statement-position
+                    // assignments (VisitExpressionStatement — this DOES include a statement
+                    // inside a block-bodied lambda). Expression-bodied lambdas
+                    // (`() => o.X = true`) and nested/parenthesized assignments
+                    // (`b = (o.X = true)`) are intentionally excluded — the rewriter can't reach them.
                     var match = assign.Left switch
                     {
                         IdentifierNameSyntax id => id.Identifier.ValueText == "EnableSensitiveData"
@@ -233,7 +243,11 @@ public sealed class AntiPatternScannerTool
             id: "MAF-AP-CONC-002",
             name: "Sync-over-async (.Result / .Wait())",
             severity: AntiPatternSeverity.Warning,
-            pattern: new Regex(@"\b\)\s*\.(Result|Wait)\s*(\(\))?", RegexHygiene, RegexBudget),
+            // Anchor on the call's close-paren `\)` (NOT a leading `\b`, which
+            // required a word char before `)` and so MISSED the canonical
+            // parameterless `Foo().Result` / `Foo().Wait()`). The trailing `\b`
+            // after the member name avoids `.Results` / `.WaitHandle` false hits.
+            pattern: new Regex(@"\)\s*\.(?:Result|Wait)\b(\s*\(\s*\))?", RegexHygiene, RegexBudget),
             skipInTestFiles: true),
 
         new RegexRule(
@@ -246,7 +260,7 @@ public sealed class AntiPatternScannerTool
             customScan: (source, _, file) =>
             {
                 var hasBuilder = source.Contains("AIAgentBuilder")
-                              || Regex.IsMatch(source, @"\bnew\s+ChatClientAgent\s*\(");
+                              || ChatClientAgentCtor.IsMatch(source);
                 var hasOTel = source.Contains("UseOpenTelemetry");
                 if (hasBuilder && !hasOTel)
                 {
@@ -309,12 +323,12 @@ public sealed class AntiPatternScannerTool
                 var findings = new List<AntiPatternFinding>();
                 // Find object initializers on ChatClientAgentOptions where an Instructions
                 // assignment appears at the OUTER level (not nested inside `ChatOptions = new { ... }`).
-                foreach (var oce in root.DescendantNodes().OfType<ObjectCreationExpressionSyntax>())
+                // Handles both `new ChatClientAgentOptions { … }` AND target-typed
+                // `ChatClientAgentOptions opts = new() { … }` (declared type visible).
+                foreach (var oce in root.DescendantNodes().OfType<BaseObjectCreationExpressionSyntax>())
                 {
-                    var typeName = oce.Type.ToString();
-                    var simpleName = typeName.Contains('.') ? typeName[(typeName.LastIndexOf('.') + 1)..] : typeName;
-                    if (simpleName != "ChatClientAgentOptions") continue;
                     if (oce.Initializer is null) continue;
+                    if (ChatClientAgentOptionsTargetName(oce) != "ChatClientAgentOptions") continue;
 
                     foreach (var expr in oce.Initializer.Expressions.OfType<AssignmentExpressionSyntax>())
                     {
@@ -490,6 +504,26 @@ public sealed class AntiPatternScannerTool
             skipInTestFiles: false),
     };
 
+    /// <summary>
+    /// The constructed type's simple name for an object-creation, resolving the
+    /// target-typed <c>new()</c> form only when the declared type is syntactically
+    /// visible (a <c>T x = new() {…}</c> variable declaration). Pure-source — returns
+    /// null when the type can't be determined without a semantic model.
+    /// </summary>
+    private static string? ChatClientAgentOptionsTargetName(BaseObjectCreationExpressionSyntax oce)
+    {
+        static string Simple(string t) => t.Contains('.') ? t[(t.LastIndexOf('.') + 1)..] : t;
+
+        if (oce is ObjectCreationExpressionSyntax explicitOce)
+            return Simple(explicitOce.Type.ToString());
+
+        // Target-typed `new()` — only resolvable from a visible declared type.
+        if (oce.Parent is EqualsValueClauseSyntax { Parent: VariableDeclaratorSyntax { Parent: VariableDeclarationSyntax vd } })
+            return Simple(vd.Type.ToString());
+
+        return null;
+    }
+
     /// <summary>True if a bracketed indexer argument list is the single string key "EnableSensitiveData".</summary>
     private static bool IsEnableSensitiveDataKey(BracketedArgumentListSyntax args)
         => args.Arguments.Count == 1
@@ -594,7 +628,13 @@ public sealed class AntiPatternScannerTool
         sb.AppendLine("| Rule | File | Line | Match |");
         sb.AppendLine("|---|---|---:|---|");
         foreach (var f in findings)
-            sb.AppendLine($"| `{f.RuleId}` — {f.RuleName} | `{f.File}` | {f.Line} | `{f.Match}` |");
+        {
+            // The Match column echoes the matched source — redact it if it looks
+            // like a secret (e.g. the SEC-002 key literal), and neutralize backticks
+            // so the value can't break the markdown code span / table cell.
+            var match = LooksLikeSecret(f.Match) ? "(redacted)" : f.Match.Replace('`', '\'').Replace('|', '\\');
+            sb.AppendLine($"| `{f.RuleId}` — {f.RuleName} | `{f.File.Replace('`', '\'')}` | {f.Line} | `{match}` |");
+        }
         sb.AppendLine();
     }
 }

--- a/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
+++ b/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
@@ -119,6 +119,18 @@ public sealed class AntiPatternScannerTool
         RegexOptions.Compiled | RegexOptions.NonBacktracking;
     private static readonly TimeSpan RegexBudget = TimeSpan.FromSeconds(2);
 
+    /// <summary>
+    /// The hard-coded-secret literal pattern (rule MAF-AP-SEC-002). Exposed as
+    /// the single source of truth for "what is a secret" so other tools can
+    /// redact any source line containing one — e.g. DoctorTool's snippet
+    /// renderer redacts content-aware, regardless of which rule surfaced the line.
+    /// </summary>
+    internal static readonly Regex SecretLiteralPattern =
+        new(@"""(?:sk-|api[-_]?key=)[A-Za-z0-9_\-]{16,}""", RegexHygiene | RegexOptions.IgnoreCase, RegexBudget);
+
+    /// <summary>True if the text contains a hard-coded secret literal (MAF-AP-SEC-002).</summary>
+    internal static bool LooksLikeSecret(string text) => SecretLiteralPattern.IsMatch(text);
+
     internal static readonly IReadOnlyList<AntiPatternRule> AllRules = new AntiPatternRule[]
     {
         new RegexRule(
@@ -133,7 +145,8 @@ public sealed class AntiPatternScannerTool
             name: "Hard-coded API key literal",
             severity: AntiPatternSeverity.Error,
             // Matches "sk-XXXXXXXXXXXXXXXX" or "api-key=XXXXXXXXXXXXXXXX" style strings.
-            pattern: new Regex(@"""(?:sk-|api[-_]?key=)[A-Za-z0-9_\-]{16,}""", RegexHygiene | RegexOptions.IgnoreCase, RegexBudget),
+            // Shared with DoctorTool's snippet redactor via SecretLiteralPattern.
+            pattern: SecretLiteralPattern,
             skipInTestFiles: false),
 
         new RegexRule(

--- a/src/maf-autopilot/Tools/BeforeAfterTool.cs
+++ b/src/maf-autopilot/Tools/BeforeAfterTool.cs
@@ -147,22 +147,30 @@ public sealed class BeforeAfterTool
         var ctxEndBefore = Math.Min(beforeLines.Length, beforeLines.Length - suffix + contextLines);
         var ctxEndAfter = Math.Min(afterLines.Length, afterLines.Length - suffix + contextLines);
 
+        // Redact a diff line whose content looks like a secret (redact-on-doubt),
+        // so the rendered diff doesn't echo a hard-coded key sitting near a change.
+        static string Safe(string line)
+        {
+            try { return AntiPatternScannerTool.LooksLikeSecret(line) ? "(redacted — may contain a secret)" : line; }
+            catch { return "(redacted — may contain a secret)"; }
+        }
+
         var sb = new StringBuilder();
         sb.AppendLine($"@@ -{ctxStart + 1},{ctxEndBefore - ctxStart} +{ctxStart + 1},{ctxEndAfter - ctxStart} @@");
 
         // Leading context (unchanged lines before the change).
         for (var i = ctxStart; i < prefix; i++)
-            sb.AppendLine($" {beforeLines[i]}");
+            sb.AppendLine($" {Safe(beforeLines[i])}");
 
         // The change region: emit all removed lines, then all added lines.
         for (var i = prefix; i < beforeLines.Length - suffix; i++)
-            sb.AppendLine($"-{beforeLines[i]}");
+            sb.AppendLine($"-{Safe(beforeLines[i])}");
         for (var i = prefix; i < afterLines.Length - suffix; i++)
-            sb.AppendLine($"+{afterLines[i]}");
+            sb.AppendLine($"+{Safe(afterLines[i])}");
 
         // Trailing context (unchanged lines after the change).
         for (var i = beforeLines.Length - suffix; i < ctxEndBefore; i++)
-            sb.AppendLine($" {beforeLines[i]}");
+            sb.AppendLine($" {Safe(beforeLines[i])}");
 
         return sb.ToString();
     }

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -22,7 +22,8 @@ public sealed class DoctorTool
     [McpServerTool(ReadOnly = true, Destructive = false, OpenWorld = false)]
     [Description("""
         Run every MAF anti-pattern scanner and fan-out validator across the repo
-        and produce a single A/B/C/F health letter with the top 3 fixes to address.
+        and produce a single A/B/C/F health letter with the top 3 fixes to address
+        (or every finding, grouped by rule, when full: true).
 
         Grading:
           A — no errors, no silent-starvation risks, < 5 warnings
@@ -35,6 +36,8 @@ public sealed class DoctorTool
           - format: output format — 'markdown' (default, human-readable) or 'json'
             (machine-readable for CI/dashboards). JSON output follows the schema
             documented in docs/output-schemas.md.
+          - full: when true, list EVERY finding (grouped by rule, ordered by
+            impact) instead of only the top 3 — full triage / CI.
 
         Returns a markdown report (default) or JSON. Treat as advisory — fix the
         top items, re-run.
@@ -43,7 +46,7 @@ public sealed class DoctorTool
         [Description("Absolute path to the repository root.")] string repoPath,
         [Description("Output format: 'markdown' (default, human-readable) or 'json' (machine-readable for CI/dashboards).")]
         string format = "markdown",
-        [Description("When true, list EVERY finding (one line each) instead of only the top 3 fixes. Use for full triage / CI.")]
+        [Description("When true, list EVERY finding (grouped by rule, ordered by impact) instead of only the top 3 fixes. Use for full triage / CI.")]
         bool full = false)
         => RunCore(repoPath, format, excludes: null, full: full);
 
@@ -146,7 +149,8 @@ public sealed class DoctorTool
                 Line: h.Line,
                 Issue: $"`{h.MethodName}` returns `{h.ReturnType}` — fan-out handler must return Task<T>",
                 FixDescription: "Change return type to Task<T>, ValueTask<T>, or IAsyncEnumerable<T> so the fan-in barrier receives messages.",
-                AutoFixable: false))
+                AutoFixable: false,
+                Why: "A fan-out handler that doesn't return Task<T>, ValueTask<T>, or IAsyncEnumerable<T> yields no message to the fan-in barrier — aggregation silently runs on partial data with no exception."))
             .Concat(antiPatterns
                 .Where(a => a.Severity == AntiPatternSeverity.Error)
                 .Select(a => new DoctorRecommendation(
@@ -158,7 +162,8 @@ public sealed class DoctorTool
                     Line: a.Line,
                     Issue: a.RuleName,
                     FixDescription: GetAntiPatternFix(a.RuleId),
-                    AutoFixable: IsAutoFixable(a.RuleId))))
+                    AutoFixable: IsAutoFixable(a.RuleId),
+                    Why: GetWhy(a.RuleId))))
             .Concat(promptFindings
                 .Where(p => p.Severity == PromptSeverity.Error)
                 .Select(p => new DoctorRecommendation(
@@ -170,7 +175,8 @@ public sealed class DoctorTool
                     Line: p.Line,
                     Issue: p.Message,
                     FixDescription: GetPromptFix(p.RuleId),
-                    AutoFixable: false)))
+                    AutoFixable: false,
+                    Why: GetWhy(p.RuleId))))
             .Concat(costFindings
                 .Where(c => c.HasCapWarning)
                 .Select(c => new DoctorRecommendation(
@@ -182,7 +188,8 @@ public sealed class DoctorTool
                     Line: c.Line,
                     Issue: $"Unbounded `{c.CallSite}`",
                     FixDescription: "Set `MaxOutputTokens` on the nearest `ChatOptions` to cap the per-call cost.",
-                    AutoFixable: false)))
+                    AutoFixable: false,
+                    Why: "An agent call with no `MaxOutputTokens` cap can emit an unbounded response — one runaway generation can dominate your bill and latency.")))
             .Concat(antiPatterns
                 .Where(a => a.Severity == AntiPatternSeverity.Warning)
                 .Select(a => new DoctorRecommendation(
@@ -194,7 +201,8 @@ public sealed class DoctorTool
                     Line: a.Line,
                     Issue: a.RuleName,
                     FixDescription: GetAntiPatternFix(a.RuleId),
-                    AutoFixable: IsAutoFixable(a.RuleId))))
+                    AutoFixable: IsAutoFixable(a.RuleId),
+                    Why: GetWhy(a.RuleId))))
             .OrderBy(r => r.Priority)
             .ToList();
 
@@ -229,7 +237,8 @@ public sealed class DoctorTool
                 Line: f.Line,
                 Issue: f.Issue,
                 FixDescription: f.FixDescription,
-                AutoFixable: f.AutoFixable))
+                AutoFixable: f.AutoFixable,
+                Why: f.Why))
             .ToList();
 
         return new DoctorJsonResult(
@@ -278,6 +287,37 @@ public sealed class DoctorTool
         "PROMPT-003" => "Add a refusal clause to the Instructions (\"do not...\", \"refuse if...\").",
         "PROMPT-004" => "Stop concatenating untrusted input into Instructions — use ChatOptions or function tool args instead.",
         _ => "See MafRegistryLookup for the canonical fix.",
+    };
+
+    /// <summary>
+    /// One-line consequence per rule ID — the "why it bites you" that turns a
+    /// finding from a label into something a developer can act on with intent.
+    /// Covers anti-pattern + prompt-lint rules; fan-out / cost carry their Why
+    /// inline at construction. Empty string ⇒ no rationale shown.
+    /// </summary>
+    internal static string GetWhy(string ruleId) => ruleId switch
+    {
+        // Anti-pattern rules (AntiPatternScannerTool.AllRules)
+        "MAF-AP-SEC-001" or "MAF002" => "`DefaultAzureCredential` probes many credential sources at runtime — slow, non-deterministic, and in production it can silently pick the wrong identity or fail closed.",
+        "MAF-AP-SEC-002" => "A key committed to source is a leaked secret the moment it's pushed. Rotate it and load from configuration / Key Vault instead.",
+        "MAF-AP-SEC-003" or "MAF003" => "Sensitive-data logging writes prompts and responses (often PII / secrets) to your telemetry sink — acceptable in dev, a data-leak in production.",
+        "MAF-AP-CONC-001" => "`AIContextProvider` instances are shared across sessions; a mutable instance field leaks one user's state into another's. Use `ProviderSessionState<T>`.",
+        "MAF-AP-CONC-002" => "Blocking on async with `.Result` / `.Wait()` can deadlock under a synchronization context and starves the thread pool under load.",
+        "MAF-AP-OBS-001" => "With no `UseOpenTelemetry` on the chat pipeline you get no traces or metrics for agent calls — production failures become invisible.",
+        "MAF-AP-AGENT-001" => "`Instructions` set at the top level of `ChatClientAgentOptions` is silently ignored — the agent runs with no system prompt and no error.",
+        "MAF-AP-WF-001" => "Missing `partial` blocks the workflow source generator from emitting the dispatcher (a generator-time compile error); `sealed` is the canonical form the analyzer expects, though the build still succeeds without it.",
+        "MAF-AP-DEVUI-001" => "DevUI / Hosting have no current-MAF equivalent — an unguarded reference breaks the production build. Guard it with `#if DEVUI_ENABLED`.",
+        "MAF-AP-MID-001" => "Providing only `runFunc` means the streaming path (`RunStreamingAsync`) silently bypasses your middleware — auth / logging / guards don't run when streaming.",
+        "MAF-AP-EXEC-001" => "These executor surfaces (`ReflectingExecutor` / `IMessageHandler` / `[StreamsMessage]` / `[YieldsMessage]`) were removed in 1.3.0 — code using them won't compile against current MAF.",
+        "MAF130-FAN-IN-001" => "The legacy `AddFanInBarrierEdge(target, sources)` overload is obsolete; with the arguments swapped the barrier wires the wrong way and never fires.",
+
+        // Prompt-lint rules (PromptLintTool)
+        "PROMPT-001" => "An empty system prompt leaves the model with no role or guardrails — behavior is undefined and easily steered by user input.",
+        "PROMPT-002" => "An oversized system prompt wastes tokens on every call and buries the directives that matter, degrading instruction-following.",
+        "PROMPT-003" => "Without an explicit refusal clause the agent attempts out-of-scope or unsafe requests instead of declining.",
+        "PROMPT-004" => "Concatenating untrusted input into `Instructions` is prompt injection by construction — the user's text becomes system-level instruction.",
+
+        _ => "",
     };
 
     // -------------------------------------------------------------------------
@@ -341,22 +381,22 @@ public sealed class DoctorTool
         sb.AppendLine();
 
         var fixes = full ? s.AllFixes : s.TopFixes;
+        var lineCache = new Dictionary<string, string[]?>(StringComparer.Ordinal);
+
         if (fixes.Count > 0)
         {
-            sb.AppendLine(full
-                ? $"### All findings ({fixes.Count}, ordered by impact)"
-                : "### Top fixes (ordered by impact)");
-            sb.AppendLine();
-            var i = 1;
-            foreach (var fix in fixes)
+            if (full)
+                AppendGroupedFindings(sb, repoPath, fixes, lineCache);
+            else
+                AppendTopFixes(sb, repoPath, s, lineCache);
+
+            // The single most actionable line: how many of these the tool can fix
+            // for you, deterministically, in one command. Computed over ALL findings
+            // so it's the same headline regardless of --all.
+            var autoCount = s.AllFixes.Count(f => f.AutoFixable);
+            if (autoCount > 0)
             {
-                sb.AppendLine($"{i}. **[{fix.Source}]** {fix.Description}");
-                i++;
-            }
-            sb.AppendLine();
-            if (!full && s.AllFixes.Count > s.TopFixes.Count)
-            {
-                sb.AppendLine($"_…and {s.AllFixes.Count - s.TopFixes.Count} more. Run with `--all` (CLI) or `full: true` (MafDoctor) for every finding._");
+                sb.AppendLine($"💡 **{autoCount} of {s.AllFixes.Count} finding(s) are auto-fixable** — apply the deterministic Roslyn rewriters with `maf-doctor autofix-all .` (CLI) or `MafAutoFixAll(repoPath)` (MCP). The rest need your judgment (or hand them to the `@maf-migration` agent).");
                 sb.AppendLine();
             }
         }
@@ -366,15 +406,153 @@ public sealed class DoctorTool
             sb.AppendLine();
         }
 
-        sb.AppendLine("### Want more detail?");
+        sb.AppendLine("### Want more");
         sb.AppendLine();
-        sb.AppendLine("- Anti-pattern breakdown: `MafScanAntiPatterns(repoPath)`");
-        sb.AppendLine("- Fan-out per-handler verdicts: `MafValidateFanOut(repoPath)`");
-        sb.AppendLine("- Workflow topology + Mermaid diagram: `MafSimulateWorkflow(repoPath)`");
-        sb.AppendLine("- CS0618 compiler-ground-truth: `MafRunCs0618Hunt(projectPath)`");
-        sb.AppendLine("- CI-friendly SARIF output: `MafScanAntiPatterns(repoPath, format: \"sarif\")` or `MafValidateFanOut(path, format: \"sarif\")`");
+        sb.AppendLine("- Every finding (full triage): `--all` (CLI) or `full: true` (MafDoctor MCP).");
+        sb.AppendLine("- Machine-readable JSON (CI / dashboards): `--json` (CLI) or `format: \"json\"` (MafDoctor MCP).");
+        sb.AppendLine("- Deeper per-area analysis in your MCP client (Copilot / Claude / Cursor): `MafScanAntiPatterns`, `MafValidateFanOut`, `MafSimulateWorkflow`, `MafRunCs0618Hunt` — the anti-pattern + fan-out scanners also emit SARIF (`format: \"sarif\"`).");
 
         return sb.ToString();
+    }
+
+    /// <summary>Default view — the top fixes, each enriched with Why / Fix / the offending source line.</summary>
+    private static void AppendTopFixes(
+        StringBuilder sb, string repoPath, DoctorSummary s, Dictionary<string, string[]?> lineCache)
+    {
+        sb.AppendLine("### Top fixes (ordered by impact)");
+        sb.AppendLine();
+        var i = 1;
+        foreach (var fix in s.TopFixes)
+        {
+            var tag = fix.AutoFixable ? "auto-fixable" : "needs your judgment";
+            sb.AppendLine($"{i}. **[{fix.Source}]** {fix.Description} · _{tag}_");
+            if (!string.IsNullOrEmpty(fix.Why)) sb.AppendLine($"   - **Why:** {fix.Why}");
+            if (!string.IsNullOrEmpty(fix.FixDescription)) sb.AppendLine($"   - **Fix:** {fix.FixDescription}");
+            var (src, redacted) = TryReadSourceLine(repoPath, fix.File, fix.Line, lineCache);
+            if (redacted)
+                sb.AppendLine($"   - `{fix.File}:{fix.Line}` → _(source line redacted — contains a secret)_");
+            else if (src is not null)
+                sb.AppendLine($"   - `{fix.File}:{fix.Line}` → `{src}`");
+            i++;
+        }
+        sb.AppendLine();
+        if (s.AllFixes.Count > s.TopFixes.Count)
+        {
+            sb.AppendLine($"_…and {s.AllFixes.Count - s.TopFixes.Count} more. Run with `--all` (CLI) or `full: true` (MafDoctor) for every finding._");
+            sb.AppendLine();
+        }
+    }
+
+    /// <summary>--all view — every finding, grouped by rule (so 8 hits of one rule
+    /// read as one entry ×8), ordered by impact, each occurrence showing its line.</summary>
+    private static void AppendGroupedFindings(
+        StringBuilder sb, string repoPath, IReadOnlyList<DoctorRecommendation> fixes,
+        Dictionary<string, string[]?> lineCache)
+    {
+        var groups = fixes
+            .GroupBy(f => f.RuleId)
+            .Select(g => new
+            {
+                Rep = g.OrderBy(x => x.Priority).First(),
+                Items = g.OrderBy(x => x.File, StringComparer.Ordinal).ThenBy(x => x.Line).ToList(),
+                MinPriority = g.Min(x => x.Priority),
+            })
+            .OrderBy(g => g.MinPriority)
+            .ThenByDescending(g => g.Items.Count)
+            .ThenBy(g => g.Rep.RuleId, StringComparer.Ordinal)
+            .ToList();
+
+        sb.AppendLine($"### All findings ({fixes.Count} across {groups.Count} rule(s), grouped + ordered by impact)");
+        sb.AppendLine();
+
+        foreach (var g in groups)
+        {
+            var rep = g.Rep;
+            var tag = rep.AutoFixable ? "auto-fixable" : "needs your judgment";
+            var count = g.Items.Count > 1 ? $" ×{g.Items.Count}" : "";
+            // Use a rule-generic title (not the representative's per-instance Issue),
+            // so a group of distinct fan-out methods / cost sites isn't mislabeled
+            // with one member's specifics under a ×N count.
+            sb.AppendLine($"#### {PrioritySeverityLabel(rep.Priority)} `{rep.RuleId}` — {GroupHeaderTitle(rep)}{count} · _{tag}_");
+            sb.AppendLine();
+            if (!string.IsNullOrEmpty(rep.Why)) sb.AppendLine($"- **Why:** {rep.Why}");
+            if (!string.IsNullOrEmpty(rep.FixDescription)) sb.AppendLine($"- **Fix:** {rep.FixDescription}");
+            sb.AppendLine();
+            foreach (var it in g.Items)
+            {
+                var (src, redacted) = TryReadSourceLine(repoPath, it.File, it.Line, lineCache);
+                var suffix = redacted ? " → _(redacted — contains a secret)_"
+                    : src is not null ? $" → `{src}`"
+                    : "";
+                sb.AppendLine($"  - `{it.File}:{it.Line}`{suffix}");
+            }
+            sb.AppendLine();
+        }
+    }
+
+    /// <summary>Priority bucket → severity emoji + label for the grouped view.</summary>
+    private static string PrioritySeverityLabel(int priority) => priority switch
+    {
+        1 => "🔴 starvation",
+        2 => "🔴 error",
+        3 => "🟠 cost",
+        _ => "🟡 warning",
+    };
+
+    /// <summary>
+    /// A rule-generic title for a grouped header. Anti-pattern Issues are already
+    /// the rule name (generic), but fan-out / cost Issues embed per-instance
+    /// specifics (a method / call site) that would be misleading under a ×N count.
+    /// </summary>
+    private static string GroupHeaderTitle(DoctorRecommendation rep) => rep.RuleId switch
+    {
+        "MAF001" => "fan-out handler must return `Task<T>`",
+        "COST-001" => "uncapped agent call — no `MaxOutputTokens`",
+        _ => rep.Issue,
+    };
+
+    /// <summary>
+    /// Reads the offending source line for a finding so the report shows the
+    /// actual code, not just a location. Best-effort: returns null (no snippet)
+    /// if the file is missing, the line is out of range, or anything throws.
+    /// Files are cached per report. Defense-in-depth: routes through the audited
+    /// <see cref="PathGuard.ValidateContainment"/> (the same helper the walker
+    /// uses) rather than a hand-rolled prefix check — the path came from our own
+    /// walker, but re-verifying closes the sibling-prefix + reparse-point lanes.
+    /// </summary>
+    /// <returns>
+    /// <c>(Text, Redacted)</c>: <c>Text</c> is the trimmed source line (or null
+    /// when unavailable); <c>Redacted</c> is true when the line contains a secret
+    /// literal and was withheld. The secret text never leaves this method —
+    /// redaction is <b>content-aware</b> (checked on the full untruncated line),
+    /// so a secret co-located on a line surfaced by any rule is suppressed, not
+    /// just findings from the hard-coded-key rule itself.
+    /// </returns>
+    private static (string? Text, bool Redacted) TryReadSourceLine(
+        string repoPath, string relFile, int line, Dictionary<string, string[]?> cache)
+    {
+        if (line <= 0 || string.IsNullOrEmpty(relFile)) return (null, false);
+
+        if (!cache.TryGetValue(relFile, out var lines))
+        {
+            lines = null;
+            try
+            {
+                var full = PathGuard.ValidateContainment(repoPath, relFile, nameof(relFile));
+                if (File.Exists(full))
+                    lines = File.ReadAllLines(full);
+            }
+            catch { lines = null; } // containment violation / IO → no snippet
+            cache[relFile] = lines;
+        }
+
+        if (lines is null || line > lines.Length) return (null, false);
+        var raw = lines[line - 1].Trim();
+        if (raw.Length == 0) return (null, false);
+        // Redact BEFORE truncation so a secret past char 100 can't slip through.
+        if (AntiPatternScannerTool.LooksLikeSecret(raw)) return (null, true);
+        var text = raw.Replace('`', '\'');
+        return (text.Length > 100 ? text[..100] + "…" : text, false);
     }
 }
 
@@ -396,13 +574,14 @@ public sealed record DoctorSummary(
 public sealed record DoctorRecommendation(
     int Priority,
     string Source,
-    string Description,    // for markdown output (keep existing)
-    string RuleId,         // NEW — for JSON
-    string File,           // NEW — for JSON
-    int Line,              // NEW — for JSON
-    string Issue,          // NEW — short title for JSON
-    string FixDescription, // NEW — actionable fix string for JSON
-    bool AutoFixable);     // NEW — whether MafAutoFix can handle this
+    string Description,    // one-line header for markdown output
+    string RuleId,         // for JSON
+    string File,           // for JSON
+    int Line,              // for JSON
+    string Issue,          // short title for JSON
+    string FixDescription, // actionable fix string
+    bool AutoFixable,      // whether MafAutoFix can apply a deterministic rewriter
+    string Why = "");      // Tier 1 — one-line consequence ("why it bites you"); "" = none known
 
 // -------------------------------------------------------------------------
 // JSON output schema types (format: "json")
@@ -428,7 +607,8 @@ public sealed record DoctorJsonFinding(
     [property: JsonPropertyName("line")] int Line,
     [property: JsonPropertyName("issue")] string Issue,
     [property: JsonPropertyName("fix_description")] string FixDescription,
-    [property: JsonPropertyName("auto_fixable")] bool AutoFixable);
+    [property: JsonPropertyName("auto_fixable")] bool AutoFixable,
+    [property: JsonPropertyName("why")] string Why = "");
 
 [JsonSerializable(typeof(DoctorJsonResult))]
 [JsonSerializable(typeof(DoctorJsonFinding))]

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -66,7 +66,18 @@ public sealed class DoctorTool
 
     private string RunCore(string repoPath, string format, IReadOnlyList<string>? excludes, bool full = false)
     {
-        if (PathGuard.ValidateRepoPath(repoPath) is { } err) return err;
+        // Render a validation failure in the REQUESTED format — a machine consumer
+        // asking for --json must get JSON back, not a plain-text string that
+        // breaks their parser.
+        if (PathGuard.ValidateRepoPath(repoPath) is { } err)
+        {
+            if (format.Equals("json", StringComparison.OrdinalIgnoreCase))
+                return JsonSerializer.Serialize(
+                    new DoctorJsonError("1", err), DoctorJsonContext.Default.DoctorJsonError);
+            if (format.Equals("plan", StringComparison.OrdinalIgnoreCase))
+                return $"# 🩺 MAF remediation plan\n\n⚠️ Cannot scan: {err}\n";
+            return err;
+        }
 
         var summary = AnalyzeRepo(repoPath, excludes);
 
@@ -209,6 +220,37 @@ public sealed class DoctorTool
                     FixDescription: GetAntiPatternFix(a.RuleId),
                     AutoFixable: IsAutoFixable(a.RuleId),
                     Why: GetWhy(a.RuleId))))
+            .Concat(promptFindings
+                // Prompt WARNINGS (PROMPT-001/002/003) are counted in the grade +
+                // metrics; they must also be LISTED, or --all/--plan/--json would
+                // contradict the metrics ("grade B, 2 warnings" but "0 findings").
+                .Where(p => p.Severity == PromptSeverity.Warning)
+                .Select(p => new DoctorRecommendation(
+                    Priority: 4,
+                    Source: "MafLintAgentPrompt",
+                    Description: $"{p.RuleId} at {p.File}:{p.Line} — {p.Message}",
+                    RuleId: p.RuleId,
+                    File: p.File,
+                    Line: p.Line,
+                    Issue: p.Message,
+                    FixDescription: GetPromptFix(p.RuleId),
+                    AutoFixable: false,
+                    Why: GetWhy(p.RuleId))))
+            .Concat(antiPatterns
+                // Info-severity anti-patterns are counted in the grade too — list
+                // them for the same reason (no rule emits Info today; kept consistent).
+                .Where(a => a.Severity == AntiPatternSeverity.Info)
+                .Select(a => new DoctorRecommendation(
+                    Priority: 4,
+                    Source: "MafScanAntiPatterns",
+                    Description: $"{a.RuleId} at {a.File}:{a.Line} — {a.RuleName}",
+                    RuleId: a.RuleId,
+                    File: a.File,
+                    Line: a.Line,
+                    Issue: a.RuleName,
+                    FixDescription: GetAntiPatternFix(a.RuleId),
+                    AutoFixable: IsAutoFixable(a.RuleId),
+                    Why: GetWhy(a.RuleId))))
             .OrderBy(r => r.Priority)
             .ToList();
 
@@ -238,7 +280,7 @@ public sealed class DoctorTool
         var findings = (full ? s.AllFixes : s.TopFixes)
             .Select(f => new DoctorJsonFinding(
                 RuleId: f.RuleId,
-                Severity: f.Priority switch { 1 => "starvation_risk", 2 => "error", _ => "warning" },
+                Severity: f.Priority switch { 1 => "starvation_risk", 2 => "error", 3 => "cost", _ => "warning" },
                 File: f.File,
                 Line: f.Line,
                 Issue: f.Issue,
@@ -251,8 +293,9 @@ public sealed class DoctorTool
             SchemaVersion: "1",
             Verdict: s.Grade.ToString(),
             ErrorsCount: s.AntiPatternErrors + s.PromptErrors,
-            WarningsCount: s.AntiPatternWarnings + s.PromptWarnings,
+            WarningsCount: s.AntiPatternWarnings + s.PromptWarnings + s.AntiPatternInfos,
             SilentStarvationRisks: s.SilentStarvationRisks,
+            UnboundedCostSites: s.UnboundedCostSites,
             TopFixes: findings,
             SummaryMd: markdownSummary);
     }
@@ -275,7 +318,7 @@ public sealed class DoctorTool
     {
         "MAF-AP-SEC-001" => "Replace `DefaultAzureCredential` with `ManagedIdentityCredential` in production code.",
         "MAF-AP-SEC-003" => "Remove `EnableSensitiveData = true` from non-dev configurations.",
-        "MAF-AP-WF-001" => "Add `sealed` modifier to the Executor class.",
+        "MAF-AP-WF-001" => "Add the missing `sealed` / `partial` modifier(s) so the Executor class is `sealed partial`.",
         "MAF130-FAN-IN-001" => "Swap `AddFanInBarrierEdge` argument order — sources first, target second.",
         "MAF-AP-CONC-002" => "Replace `.Result` / `.Wait()` with `await`.",
         "MAF-AP-OBS-001" => "Wire `UseOpenTelemetry` on the IChatClient pipeline.",
@@ -371,7 +414,7 @@ public sealed class DoctorTool
         sb.AppendLine();
         sb.AppendLine($"_{s.Reason}_");
         sb.AppendLine();
-        sb.AppendLine($"**Repo:** `{repoPath}`");
+        sb.AppendLine($"**Repo:** `{repoPath.Replace('`', '\'')}`");
         sb.AppendLine();
         sb.AppendLine("| Metric | Count |");
         sb.AppendLine("|---|---:|");
@@ -417,7 +460,7 @@ public sealed class DoctorTool
         sb.AppendLine("- Every finding (full triage): `--all` (CLI) or `full: true` (MafDoctor MCP).");
         sb.AppendLine("- Machine-readable JSON (CI / dashboards): `--json` (CLI) or `format: \"json\"` (MafDoctor MCP).");
         sb.AppendLine("- Ordered, checkboxed remediation plan (drop into a GitHub issue): `--plan` (CLI) or `format: \"plan\"` (MafDoctor MCP).");
-        sb.AppendLine("- Deep-dive ONE finding (offending code in context + why + fix): `MafExplainFinding(repoPath, file, line)` or the `maf-explain-finding` prompt (MCP clients).");
+        sb.AppendLine("- Deep-dive ONE finding (offending code in context + why + fix) — **MCP clients only** (no CLI flag): `MafExplainFinding(repoPath, file, line)` or the `maf-explain-finding` prompt.");
         sb.AppendLine("- Deeper per-area analysis in your MCP client (Copilot / Claude / Cursor): `MafScanAntiPatterns`, `MafValidateFanOut`, `MafSimulateWorkflow`, `MafRunCs0618Hunt` — the anti-pattern + fan-out scanners also emit SARIF (`format: \"sarif\"`).");
 
         return sb.ToString();
@@ -438,7 +481,7 @@ public sealed class DoctorTool
             if (!string.IsNullOrEmpty(fix.FixDescription)) sb.AppendLine($"   - **Fix:** {fix.FixDescription}");
             var (src, redacted) = TryReadSourceLine(repoPath, fix.File, fix.Line, lineCache);
             if (redacted)
-                sb.AppendLine($"   - `{fix.File}:{fix.Line}` → _(source line redacted — contains a secret)_");
+                sb.AppendLine($"   - `{fix.File}:{fix.Line}` → _(source line redacted — may contain a secret)_");
             else if (src is not null)
                 sb.AppendLine($"   - `{fix.File}:{fix.Line}` → `{src}`");
             i++;
@@ -478,7 +521,7 @@ public sealed class DoctorTool
             foreach (var it in g.Items)
             {
                 var (src, redacted) = TryReadSourceLine(repoPath, it.File, it.Line, lineCache);
-                var suffix = redacted ? " → _(redacted — contains a secret)_"
+                var suffix = redacted ? " → _(redacted — may contain a secret)_"
                     : src is not null ? $" → `{src}`"
                     : "";
                 sb.AppendLine($"  - `{it.File}:{it.Line}`{suffix}");
@@ -505,6 +548,7 @@ public sealed class DoctorTool
     {
         "MAF001" => "fan-out handler must return `Task<T>`",
         "COST-001" => "uncapped agent call — no `MaxOutputTokens`",
+        "PROMPT-004" => "untrusted input concatenated into `Instructions` (prompt injection)",
         _ => rep.Issue,
     };
 
@@ -544,7 +588,7 @@ public sealed class DoctorTool
         sb.AppendLine();
         sb.AppendLine($"_{s.Reason}_");
         sb.AppendLine();
-        sb.AppendLine($"**Repo:** `{repoPath}`");
+        sb.AppendLine($"**Repo:** `{repoPath.Replace('`', '\'')}`");
         sb.AppendLine();
 
         var all = s.AllFixes;
@@ -567,7 +611,7 @@ public sealed class DoctorTool
             sb.AppendLine();
             sb.AppendLine("- [ ] Run `maf-doctor autofix-all .` (CLI) or `MafAutoFixAll(repoPath)` (MCP), then rebuild.");
             sb.AppendLine();
-            sb.AppendLine("It applies deterministic Roslyn rewriters for:");
+            sb.AppendLine("It applies deterministic Roslyn rewriters for the rules below (and may also clear build-surfaced fixes like the fan-in arg-order swap that the scan-time grader doesn't see):");
             foreach (var (rep, items) in GroupByRule(auto))
                 sb.AppendLine($"  - `{rep.RuleId}` — {GroupHeaderTitle(rep)}{(items.Count > 1 ? $" ×{items.Count}" : "")}");
             sb.AppendLine();
@@ -593,7 +637,7 @@ public sealed class DoctorTool
 
         sb.AppendLine("## After");
         sb.AppendLine();
-        sb.AppendLine("Re-run `maf-doctor doctor .` to confirm the grade improved. For any single finding, `MafExplainFinding(repoPath, file, line)` gives the grounded deep-dive + fix.");
+        sb.AppendLine("Re-run `maf-doctor doctor .` to confirm the grade improved. In an MCP client (Copilot / Claude / Cursor), `MafExplainFinding(repoPath, file, line)` gives a grounded per-finding deep-dive + fix.");
         return sb.ToString();
     }
 
@@ -636,7 +680,12 @@ public sealed class DoctorTool
         var raw = lines[line - 1].Trim();
         if (raw.Length == 0) return (null, false);
         // Redact BEFORE truncation so a secret past char 100 can't slip through.
-        if (AntiPatternScannerTool.LooksLikeSecret(raw)) return (null, true);
+        // Guard the regex: a RegexMatchTimeout (cold-start DFA build under load)
+        // must degrade to redact-on-doubt, never abort the whole report.
+        bool looksSecret;
+        try { looksSecret = AntiPatternScannerTool.LooksLikeSecret(raw); }
+        catch { return (null, true); }
+        if (looksSecret) return (null, true);
         var text = raw.Replace('`', '\'');
         return (text.Length > 100 ? text[..100] + "…" : text, false);
     }
@@ -683,8 +732,14 @@ public sealed record DoctorJsonResult(
     [property: JsonPropertyName("errors_count")] int ErrorsCount,
     [property: JsonPropertyName("warnings_count")] int WarningsCount,
     [property: JsonPropertyName("silent_starvation_risks")] int SilentStarvationRisks,
+    [property: JsonPropertyName("unbounded_cost_sites")] int UnboundedCostSites,
     [property: JsonPropertyName("top_fixes")] IReadOnlyList<DoctorJsonFinding> TopFixes,
     [property: JsonPropertyName("summary_md")] string SummaryMd);
+
+/// <summary>Error shape for format:"json" when the request fails validation (e.g. bad path).</summary>
+public sealed record DoctorJsonError(
+    [property: JsonPropertyName("schema_version")] string SchemaVersion,
+    [property: JsonPropertyName("error")] string Error);
 
 public sealed record DoctorJsonFinding(
     [property: JsonPropertyName("rule_id")] string RuleId,
@@ -698,5 +753,6 @@ public sealed record DoctorJsonFinding(
 
 [JsonSerializable(typeof(DoctorJsonResult))]
 [JsonSerializable(typeof(DoctorJsonFinding))]
+[JsonSerializable(typeof(DoctorJsonError))]
 [JsonSourceGenerationOptions(WriteIndented = true)]
 internal sealed partial class DoctorJsonContext : JsonSerializerContext { }

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -251,7 +251,12 @@ public sealed class DoctorTool
                     FixDescription: GetAntiPatternFix(a.RuleId),
                     AutoFixable: IsAutoFixable(a.RuleId),
                     Why: GetWhy(a.RuleId))))
+            // Deterministic within a priority bucket (matches GroupByRule's order),
+            // so the top-3 markdown headline + JSON top_fixes don't depend on
+            // filesystem enumeration order.
             .OrderBy(r => r.Priority)
+            .ThenBy(r => r.File, StringComparer.Ordinal)
+            .ThenBy(r => r.Line)
             .ToList();
 
         return new DoctorSummary(
@@ -280,7 +285,7 @@ public sealed class DoctorTool
         var findings = (full ? s.AllFixes : s.TopFixes)
             .Select(f => new DoctorJsonFinding(
                 RuleId: f.RuleId,
-                Severity: f.Priority switch { 1 => "starvation_risk", 2 => "error", 3 => "cost", _ => "warning" },
+                Severity: SeverityFor(f.Priority).Json,
                 File: f.File,
                 Line: f.Line,
                 Issue: f.Issue,
@@ -300,16 +305,24 @@ public sealed class DoctorTool
             SummaryMd: markdownSummary);
     }
 
-    /// <summary>True if MafAutoFix knows how to apply a deterministic rewriter for this rule.</summary>
+    /// <summary>
+    /// True if MafAutoFix applies a deterministic, context-safe rewriter for this
+    /// rule. The MAF002/MAF003 (analyzer aliases) and MAF130-FAN-IN-001 (autofix-only)
+    /// arms are kept for 1:1 parity with AutoFixTool's factory map even though the
+    /// doctor scan emits only canonical AntiPatternScannerTool.AllRules IDs.
+    /// </summary>
     private static bool IsAutoFixable(string ruleId) => ruleId switch
     {
         "MAF-AP-SEC-001" => true,    // DefaultAzureCredential → ManagedIdentityCredential
         "MAF002" => true,            // analyzer-aligned alias
         "MAF-AP-SEC-003" => true,    // EnableSensitiveData = true → removed
         "MAF003" => true,            // analyzer-aligned alias
-        "MAF-AP-WF-001" => true,     // sealed modifier on Executor
+        "MAF-AP-WF-001" => true,     // sealed/partial modifiers on Executor
         "MAF130-FAN-IN-001" => true, // fan-in argument order swap
-        "MAF-AP-CONC-002" => true,   // .Result / .Wait() → await
+        // NOT MAF-AP-CONC-002: a safe `.Result`/`.Wait()` → `await` fix requires the
+        // caller to be async (signature/caller changes), so it's a judgment call, not
+        // a blanket auto-fix — the rewriter only rewrites already-async contexts and
+        // declines the rest. The doctor lists CONC-002 as "needs your judgment".
         _ => false,
     };
 
@@ -317,14 +330,17 @@ public sealed class DoctorTool
     private static string GetAntiPatternFix(string ruleId) => ruleId switch
     {
         "MAF-AP-SEC-001" => "Replace `DefaultAzureCredential` with `ManagedIdentityCredential` in production code.",
+        "MAF-AP-SEC-002" => "Remove the hard-coded key; load it from configuration / Key Vault and rotate the leaked value.",
         "MAF-AP-SEC-003" => "Remove `EnableSensitiveData = true` from non-dev configurations.",
         "MAF-AP-WF-001" => "Add the missing `sealed` / `partial` modifier(s) so the Executor class is `sealed partial`.",
         "MAF130-FAN-IN-001" => "Swap `AddFanInBarrierEdge` argument order — sources first, target second.",
-        "MAF-AP-CONC-002" => "Replace `.Result` / `.Wait()` with `await`.",
+        "MAF-AP-CONC-002" => "Make the enclosing method `async` and `await` the call (or use a synchronous API) — `.Result` / `.Wait()` can deadlock.",
         "MAF-AP-OBS-001" => "Wire `UseOpenTelemetry` on the IChatClient pipeline.",
-        "MAF-AP-IDN-001" => "Use `ManagedIdentityCredential` instead of secret-based auth.",
         "MAF-AP-CONC-001" => "Move session state out of `AIContextProvider` instance fields into `ProviderSessionState<T>`.",
         "MAF-AP-AGENT-001" => "Move `Instructions` inside `ChatClientAgentOptions.ChatOptions` (top-level placement is silently ignored).",
+        "MAF-AP-EXEC-001" => "Migrate the legacy executor surface (`ReflectingExecutor` / `IMessageHandler` / `[StreamsMessage]` / `[YieldsMessage]`) per the MAF130 registry.",
+        "MAF-AP-DEVUI-001" => "Guard the DevUI / Hosting reference with `#if DEVUI_ENABLED`.",
+        "MAF-AP-MID-001" => "Provide BOTH `runFunc` and `runStreamingFunc` so the streaming path runs the middleware too.",
         _ => "See MafRegistryLookup for the canonical fix for this rule.",
     };
 
@@ -382,8 +398,23 @@ public sealed class DoctorTool
 
         foreach (var path in EnumerateScannableFiles(repoPath, excludes))
         {
-            var source = File.ReadAllText(path);
-            var rel = MakeRelative(repoPath, path);
+            string source, rel;
+            try
+            {
+                // Guard ONLY the read + relative-path resolve: a file can be
+                // deleted/locked/raced between enumeration and read. Narrow catch
+                // so analyzer/parse bugs still propagate (the grade must never be
+                // silently degraded by swallowing a logic error).
+                source = File.ReadAllText(path);
+                rel = MakeRelative(repoPath, path);
+            }
+            catch (Exception ex) when (ex is IOException
+                                        or UnauthorizedAccessException
+                                        or System.Security.SecurityException
+                                        or InvalidOperationException)
+            {
+                continue; // skip the unreadable/out-of-root file, don't crash the run
+            }
             antiPatterns.AddRange(AntiPatternScannerTool.ScanFile(source, rel));
             handlers.AddRange(FanOutValidatorTool.AnalyzeSource(source, rel));
             promptFindings.AddRange(PromptLintTool.LintSource(source, rel));
@@ -402,13 +433,7 @@ public sealed class DoctorTool
     private static string FormatReport(string repoPath, DoctorSummary s, bool full = false)
     {
         var sb = new StringBuilder();
-        var emoji = s.Grade switch
-        {
-            'A' => "🟢",
-            'B' => "🟡",
-            'C' => "🟠",
-            _ => "🔴",
-        };
+        var emoji = GradeEmoji(s.Grade);
 
         sb.AppendLine($"## {emoji} MAF health grade: **{s.Grade}**");
         sb.AppendLine();
@@ -530,14 +555,30 @@ public sealed class DoctorTool
         }
     }
 
-    /// <summary>Priority bucket → severity emoji + label for the grouped view.</summary>
-    private static string PrioritySeverityLabel(int priority) => priority switch
+    /// <summary>
+    /// Single source of truth for severity presentation, keyed by the doctor's
+    /// priority bucket, so the JSON string, markdown label, and emoji can never
+    /// drift across the report / --all / --plan / JSON / MafExplainFinding surfaces.
+    /// The JSON strings are part of the schema_version "1" contract — keep byte-identical.
+    /// </summary>
+    internal static (string Json, string Label, string Emoji) SeverityFor(int priority) => priority switch
     {
-        1 => "🔴 starvation",
-        2 => "🔴 error",
-        3 => "🟠 cost",
-        _ => "🟡 warning",
+        1 => ("starvation_risk", "🔴 starvation", "🔴"),
+        2 => ("error", "🔴 error", "🔴"),
+        3 => ("cost", "🟠 cost", "🟠"),
+        _ => ("warning", "🟡 warning", "🟡"),
     };
+
+    /// <summary>Grade letter → status emoji (single source of truth).</summary>
+    internal static string GradeEmoji(char grade) => grade switch
+    {
+        'A' => "🟢",
+        'B' => "🟡",
+        'C' => "🟠",
+        _ => "🔴",
+    };
+
+    private static string PrioritySeverityLabel(int priority) => SeverityFor(priority).Label;
 
     /// <summary>
     /// A rule-generic title for a grouped header. Anti-pattern Issues are already
@@ -548,6 +589,7 @@ public sealed class DoctorTool
     {
         "MAF001" => "fan-out handler must return `Task<T>`",
         "COST-001" => "uncapped agent call — no `MaxOutputTokens`",
+        "PROMPT-002" => "oversized Instructions (token bloat)",
         "PROMPT-004" => "untrusted input concatenated into `Instructions` (prompt injection)",
         _ => rep.Issue,
     };
@@ -583,7 +625,7 @@ public sealed class DoctorTool
     private static string FormatPlan(string repoPath, DoctorSummary s)
     {
         var sb = new StringBuilder();
-        var emoji = s.Grade switch { 'A' => "🟢", 'B' => "🟡", 'C' => "🟠", _ => "🔴" };
+        var emoji = GradeEmoji(s.Grade);
         sb.AppendLine($"# {emoji} MAF remediation plan — grade {s.Grade}");
         sb.AppendLine();
         sb.AppendLine($"_{s.Reason}_");
@@ -687,7 +729,10 @@ public sealed class DoctorTool
         catch { return (null, true); }
         if (looksSecret) return (null, true);
         var text = raw.Replace('`', '\'');
-        return (text.Length > 100 ? text[..100] + "…" : text, false);
+        if (text.Length <= 100) return (text, false);
+        // Don't slice through a surrogate pair (would emit U+FFFD mojibake).
+        var cut = char.IsHighSurrogate(text[99]) ? 99 : 100;
+        return (text[..cut] + "…", false);
     }
 }
 

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -33,18 +33,21 @@ public sealed class DoctorTool
 
         Input:
           - repoPath: absolute path to the repository root.
-          - format: output format — 'markdown' (default, human-readable) or 'json'
-            (machine-readable for CI/dashboards). JSON output follows the schema
-            documented in docs/output-schemas.md.
+          - format: output format — 'markdown' (default, human-readable), 'json'
+            (machine-readable for CI/dashboards; schema in docs/output-schemas.md),
+            or 'plan' (an ordered, checkboxed remediation plan covering every
+            finding — Phase 1 batches the auto-fixable ones into one autofix-all
+            command, Phase 2 lists the semantic fixes as impact-ordered tasks).
           - full: when true, list EVERY finding (grouped by rule, ordered by
-            impact) instead of only the top 3 — full triage / CI.
+            impact) instead of only the top 3 — full triage / CI. (Ignored for
+            format 'plan', which always covers everything.)
 
         Returns a markdown report (default) or JSON. Treat as advisory — fix the
         top items, re-run.
         """)]
     public string MafDoctor(
         [Description("Absolute path to the repository root.")] string repoPath,
-        [Description("Output format: 'markdown' (default, human-readable) or 'json' (machine-readable for CI/dashboards).")]
+        [Description("Output format: 'markdown' (default, human-readable), 'json' (machine-readable for CI/dashboards), or 'plan' (an ordered, checkboxed remediation plan to drop into a GitHub issue).")]
         string format = "markdown",
         [Description("When true, list EVERY finding (grouped by rule, ordered by impact) instead of only the top 3 fixes. Use for full triage / CI.")]
         bool full = false)
@@ -72,6 +75,9 @@ public sealed class DoctorTool
             var result = BuildJsonResult(repoPath, summary, full);
             return JsonSerializer.Serialize(result, DoctorJsonContext.Default.DoctorJsonResult);
         }
+
+        if (format.Equals("plan", StringComparison.OrdinalIgnoreCase))
+            return FormatPlan(repoPath, summary); // always covers every finding
 
         return FormatReport(repoPath, summary, full);
     }
@@ -410,6 +416,7 @@ public sealed class DoctorTool
         sb.AppendLine();
         sb.AppendLine("- Every finding (full triage): `--all` (CLI) or `full: true` (MafDoctor MCP).");
         sb.AppendLine("- Machine-readable JSON (CI / dashboards): `--json` (CLI) or `format: \"json\"` (MafDoctor MCP).");
+        sb.AppendLine("- Ordered, checkboxed remediation plan (drop into a GitHub issue): `--plan` (CLI) or `format: \"plan\"` (MafDoctor MCP).");
         sb.AppendLine("- Deep-dive ONE finding (offending code in context + why + fix): `MafExplainFinding(repoPath, file, line)` or the `maf-explain-finding` prompt (MCP clients).");
         sb.AppendLine("- Deeper per-area analysis in your MCP client (Copilot / Claude / Cursor): `MafScanAntiPatterns`, `MafValidateFanOut`, `MafSimulateWorkflow`, `MafRunCs0618Hunt` — the anti-pattern + fan-out scanners also emit SARIF (`format: \"sarif\"`).");
 
@@ -450,18 +457,7 @@ public sealed class DoctorTool
         StringBuilder sb, string repoPath, IReadOnlyList<DoctorRecommendation> fixes,
         Dictionary<string, string[]?> lineCache)
     {
-        var groups = fixes
-            .GroupBy(f => f.RuleId)
-            .Select(g => new
-            {
-                Rep = g.OrderBy(x => x.Priority).First(),
-                Items = g.OrderBy(x => x.File, StringComparer.Ordinal).ThenBy(x => x.Line).ToList(),
-                MinPriority = g.Min(x => x.Priority),
-            })
-            .OrderBy(g => g.MinPriority)
-            .ThenByDescending(g => g.Items.Count)
-            .ThenBy(g => g.Rep.RuleId, StringComparer.Ordinal)
-            .ToList();
+        var groups = GroupByRule(fixes);
 
         sb.AppendLine($"### All findings ({fixes.Count} across {groups.Count} rule(s), grouped + ordered by impact)");
         sb.AppendLine();
@@ -511,6 +507,95 @@ public sealed class DoctorTool
         "COST-001" => "uncapped agent call — no `MaxOutputTokens`",
         _ => rep.Issue,
     };
+
+    /// <summary>
+    /// Groups recommendations by rule, ordered by impact (min priority), then by
+    /// occurrence count, then rule id. Each group carries a representative (the
+    /// highest-priority member) + every occurrence sorted by file:line. Shared by
+    /// the grouped <c>--all</c> view and the <c>--plan</c> formatter.
+    /// </summary>
+    private static IReadOnlyList<(DoctorRecommendation Rep, List<DoctorRecommendation> Items)> GroupByRule(
+        IEnumerable<DoctorRecommendation> fixes)
+        => fixes
+            .GroupBy(f => f.RuleId)
+            .Select(g => (
+                Rep: g.OrderBy(x => x.Priority).First(),
+                Items: g.OrderBy(x => x.File, StringComparer.Ordinal).ThenBy(x => x.Line).ToList(),
+                MinPriority: g.Min(x => x.Priority)))
+            .OrderBy(t => t.MinPriority)
+            .ThenByDescending(t => t.Items.Count)
+            .ThenBy(t => t.Rep.RuleId, StringComparer.Ordinal)
+            .Select(t => (t.Rep, t.Items))
+            .ToList();
+
+    /// <summary>
+    /// Tier 3 — the <c>--plan</c> / <c>format: "plan"</c> output: an ordered,
+    /// checkboxed remediation plan you can drop straight into a GitHub issue.
+    /// Phase 1 batches every auto-fixable finding into a single deterministic
+    /// command; Phase 2 lists the semantic fixes as impact-ordered tasks. Always
+    /// covers every finding (a partial plan would be misleading). No source
+    /// snippets — file:line + why + fix only — so it never echoes a secret.
+    /// </summary>
+    private static string FormatPlan(string repoPath, DoctorSummary s)
+    {
+        var sb = new StringBuilder();
+        var emoji = s.Grade switch { 'A' => "🟢", 'B' => "🟡", 'C' => "🟠", _ => "🔴" };
+        sb.AppendLine($"# {emoji} MAF remediation plan — grade {s.Grade}");
+        sb.AppendLine();
+        sb.AppendLine($"_{s.Reason}_");
+        sb.AppendLine();
+        sb.AppendLine($"**Repo:** `{repoPath}`");
+        sb.AppendLine();
+
+        var all = s.AllFixes;
+        if (all.Count == 0)
+        {
+            sb.AppendLine("✅ Nothing to do — the repo is clean against all configured rules.");
+            return sb.ToString();
+        }
+
+        var auto = all.Where(f => f.AutoFixable).ToList();
+        var manual = all.Where(f => !f.AutoFixable).ToList();
+        sb.AppendLine($"{all.Count} finding(s): **{auto.Count} auto-fixable**, **{manual.Count} need your judgment**.");
+        sb.AppendLine();
+
+        if (auto.Count > 0)
+        {
+            sb.AppendLine("## Phase 1 — Quick wins (deterministic, no LLM)");
+            sb.AppendLine();
+            sb.AppendLine($"One command clears {auto.Count} mechanical finding(s):");
+            sb.AppendLine();
+            sb.AppendLine("- [ ] Run `maf-doctor autofix-all .` (CLI) or `MafAutoFixAll(repoPath)` (MCP), then rebuild.");
+            sb.AppendLine();
+            sb.AppendLine("It applies deterministic Roslyn rewriters for:");
+            foreach (var (rep, items) in GroupByRule(auto))
+                sb.AppendLine($"  - `{rep.RuleId}` — {GroupHeaderTitle(rep)}{(items.Count > 1 ? $" ×{items.Count}" : "")}");
+            sb.AppendLine();
+        }
+
+        if (manual.Count > 0)
+        {
+            sb.AppendLine("## Phase 2 — Semantic fixes (need your judgment)");
+            sb.AppendLine();
+            sb.AppendLine("Ordered by impact — each is a separate, build-verified change (hand to `@maf-migration` for the agent loop):");
+            sb.AppendLine();
+            foreach (var (rep, items) in GroupByRule(manual))
+            {
+                var count = items.Count > 1 ? $" ×{items.Count}" : "";
+                sb.AppendLine($"- [ ] **{PrioritySeverityLabel(rep.Priority)} `{rep.RuleId}` — {GroupHeaderTitle(rep)}**{count}");
+                if (!string.IsNullOrEmpty(rep.Why)) sb.AppendLine($"  - **Why:** {rep.Why}");
+                if (!string.IsNullOrEmpty(rep.FixDescription)) sb.AppendLine($"  - **Fix:** {rep.FixDescription}");
+                foreach (var it in items)
+                    sb.AppendLine($"  - `{it.File}:{it.Line}`");
+                sb.AppendLine();
+            }
+        }
+
+        sb.AppendLine("## After");
+        sb.AppendLine();
+        sb.AppendLine("Re-run `maf-doctor doctor .` to confirm the grade improved. For any single finding, `MafExplainFinding(repoPath, file, line)` gives the grounded deep-dive + fix.");
+        return sb.ToString();
+    }
 
     /// <summary>
     /// Reads the offending source line for a finding so the report shows the

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -410,6 +410,7 @@ public sealed class DoctorTool
         sb.AppendLine();
         sb.AppendLine("- Every finding (full triage): `--all` (CLI) or `full: true` (MafDoctor MCP).");
         sb.AppendLine("- Machine-readable JSON (CI / dashboards): `--json` (CLI) or `format: \"json\"` (MafDoctor MCP).");
+        sb.AppendLine("- Deep-dive ONE finding (offending code in context + why + fix): `MafExplainFinding(repoPath, file, line)` or the `maf-explain-finding` prompt (MCP clients).");
         sb.AppendLine("- Deeper per-area analysis in your MCP client (Copilot / Claude / Cursor): `MafScanAntiPatterns`, `MafValidateFanOut`, `MafSimulateWorkflow`, `MafRunCs0618Hunt` — the anti-pattern + fan-out scanners also emit SARIF (`format: \"sarif\"`).");
 
         return sb.ToString();

--- a/src/maf-autopilot/Tools/ExplainFindingTool.cs
+++ b/src/maf-autopilot/Tools/ExplainFindingTool.cs
@@ -181,9 +181,12 @@ public sealed class ExplainFindingTool
             var raw = lines[n - 1];
             var marker = marked.Contains(n) ? ">" : " ";
             var num = n.ToString().PadLeft(width);
-            var body = AntiPatternScannerTool.LooksLikeSecret(raw)
-                ? "(line redacted — may contain a secret)"
-                : raw.TrimEnd();
+            // Guard the regex: a RegexMatchTimeout must redact-on-doubt, not fault
+            // the whole tool (mirrors DoctorTool.TryReadSourceLine).
+            bool secret;
+            try { secret = AntiPatternScannerTool.LooksLikeSecret(raw); }
+            catch { secret = true; }
+            var body = secret ? "(line redacted — may contain a secret)" : raw.TrimEnd();
             sb.AppendLine($"{marker} {num} | {body}");
         }
         sb.AppendLine("```");

--- a/src/maf-autopilot/Tools/ExplainFindingTool.cs
+++ b/src/maf-autopilot/Tools/ExplainFindingTool.cs
@@ -67,6 +67,12 @@ public sealed class ExplainFindingTool
         try { full = PathGuard.ValidateContainment(repoPath, file, nameof(file)); }
         catch (ArgumentException ex) { return $"Error: {ex.Message}"; }
 
+        // C#-source only: doctor findings come from .cs files, and this guards
+        // against rendering a secret-bearing config (.env / appsettings / .pem)
+        // through the best-effort (not exhaustive) redactor.
+        if (!full.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            return $"Error: MafExplainFinding only inspects C# source (.cs) files; got `{file}`.";
+
         if (!File.Exists(full)) return $"Error: file not found under the repository: `{file}`.";
 
         var source = File.ReadAllText(full);
@@ -193,11 +199,6 @@ public sealed class ExplainFindingTool
         sb.AppendLine();
     }
 
-    private static string SeverityEmoji(int priority) => priority switch
-    {
-        1 => "🔴",
-        2 => "🔴",
-        3 => "🟠",
-        _ => "🟡",
-    };
+    // Single source of truth in DoctorTool.SeverityFor (keeps emoji/label/JSON aligned).
+    private static string SeverityEmoji(int priority) => DoctorTool.SeverityFor(priority).Emoji;
 }

--- a/src/maf-autopilot/Tools/ExplainFindingTool.cs
+++ b/src/maf-autopilot/Tools/ExplainFindingTool.cs
@@ -45,9 +45,9 @@ public sealed class ExplainFindingTool
           - line: 1-based line number of the finding.
           - context: lines of surrounding code on each side (default 8, max 30).
 
-        Returns a markdown report. Lines matching the hard-coded-API-key pattern
-        are redacted, not echoed; other secret shapes (connection strings, JWTs,
-        PEM blocks) are not detected.
+        Returns a markdown report. Lines that look like they contain a secret
+        (API keys, connection-string secrets, tokens, JWTs, PEM private keys) are
+        redacted, not echoed — best-effort, not exhaustive.
         """)]
     public string MafExplainFinding(
         [Description("Absolute path to the repository root.")] string repoPath,
@@ -154,17 +154,22 @@ public sealed class ExplainFindingTool
     /// <summary>
     /// Renders a numbered code window centred on <paramref name="centerLine"/>,
     /// marking every line in <paramref name="marked"/> with <c>&gt;</c>. Lines
-    /// matching the hard-coded-API-key pattern (the shared SEC-002
+    /// that look like they contain a secret (the shared
     /// <see cref="AntiPatternScannerTool.LooksLikeSecret"/>, single source of
-    /// truth with DoctorTool's redactor) are withheld — this is best-effort,
-    /// API-key-shaped redaction, NOT full secret-shape coverage. The
+    /// truth with DoctorTool's redactor) are withheld — best-effort, not
+    /// exhaustive (high-entropy secrets in unrecognized shapes can slip through). The
     /// <c>"{marker} {num} | "</c> prefix also means no source line can ever form
     /// a valid CommonMark closing fence, so a line of backticks can't break out.
     /// </summary>
     private static void AppendCodeWindow(StringBuilder sb, string[] lines, int centerLine, HashSet<int> marked, int context)
     {
-        var start = Math.Max(1, centerLine - context);
-        var end = Math.Min(lines.Length, centerLine + context);
+        // Cover the context window AND every marked finding line, so a widened
+        // multi-finding window (or a small `context`) never claims "marked above"
+        // for a line that falls outside the rendered range.
+        var lo = marked.Count > 0 ? Math.Min(centerLine - context, marked.Min()) : centerLine - context;
+        var hi = marked.Count > 0 ? Math.Max(centerLine + context, marked.Max()) : centerLine + context;
+        var start = Math.Max(1, lo);
+        var end = Math.Min(lines.Length, hi);
         if (start > lines.Length) return; // line past EOF — nothing to show
 
         sb.AppendLine("### Code in context");
@@ -177,7 +182,7 @@ public sealed class ExplainFindingTool
             var marker = marked.Contains(n) ? ">" : " ";
             var num = n.ToString().PadLeft(width);
             var body = AntiPatternScannerTool.LooksLikeSecret(raw)
-                ? "(line redacted — contains a secret)"
+                ? "(line redacted — may contain a secret)"
                 : raw.TrimEnd();
             sb.AppendLine($"{marker} {num} | {body}");
         }

--- a/src/maf-autopilot/Tools/ExplainFindingTool.cs
+++ b/src/maf-autopilot/Tools/ExplainFindingTool.cs
@@ -1,0 +1,195 @@
+using System.ComponentModel;
+using System.Text;
+using ModelContextProtocol.Server;
+
+namespace MafDoctor.Tools;
+
+/// <summary>
+/// MCP tool: MafExplainFinding
+///
+/// Tier 2 of the doctor-suggestions work. Where <see cref="DoctorTool"/> lists
+/// findings, this tool deep-dives ONE: given a finding's location (file + line,
+/// as printed in the doctor report), it returns the <b>grounded substrate</b> an
+/// assistant needs to explain it and propose a precise fix WITHOUT hallucinating
+/// — the offending code in context, plus the rule's rationale, fix, and
+/// auto-fixability (reused verbatim from <see cref="DoctorTool.Grade"/>).
+///
+/// The design leverage: maf-doctor runs as an MCP server inside a host that
+/// already has a model (Copilot / Claude / Cursor). We don't spend our own LLM
+/// budget — we hand the host model exact, deterministic material and let it
+/// narrate. The companion <c>maf-explain-finding</c> prompt orchestrates that.
+/// </summary>
+[McpServerToolType]
+public sealed class ExplainFindingTool
+{
+    private const int DefaultContext = 8;
+    private const int MaxContext = 30;
+
+    [McpServerTool(ReadOnly = true, Destructive = false, OpenWorld = false)]
+    [Description("""
+        Deep-dive a SINGLE MAF Doctor finding into grounded context for explaining
+        or fixing it. Given the finding's location (file + line, as printed in the
+        MafDoctor report), returns: the offending source line in context, and the
+        rule's rationale ("why it bites you"), the actionable fix, and whether it
+        is auto-fixable.
+
+        Use this after MafDoctor surfaces a finding you want to understand or
+        resolve. Pair it with the `maf-explain-finding` prompt, which reads
+        maf://constraints + maf://guide and turns this substrate into a precise
+        explanation and proposed fix.
+
+        Input:
+          - repoPath: absolute path to the repository root.
+          - file: repo-relative path of the finding (exactly as shown in the
+            report, e.g. 'Executors/Foo.cs').
+          - line: 1-based line number of the finding.
+          - context: lines of surrounding code on each side (default 8, max 30).
+
+        Returns a markdown report. Lines matching the hard-coded-API-key pattern
+        are redacted, not echoed; other secret shapes (connection strings, JWTs,
+        PEM blocks) are not detected.
+        """)]
+    public string MafExplainFinding(
+        [Description("Absolute path to the repository root.")] string repoPath,
+        [Description("Repo-relative path of the finding, as shown in the report (e.g. 'Executors/Foo.cs').")] string file,
+        [Description("1-based line number of the finding.")] int line,
+        [Description("Lines of surrounding context on each side (default 8, max 30).")] int context = DefaultContext)
+    {
+        if (PathGuard.ValidateRepoPath(repoPath) is { } err) return err;
+
+        try { BoundedInput.Validate(file, BoundedInput.PathBytes, nameof(file)); }
+        catch (ArgumentException ex) { return $"Error: {ex.Message}"; }
+
+        if (line <= 0) return "Error: line must be a positive 1-based line number.";
+        context = Math.Clamp(context, 0, MaxContext);
+
+        string full;
+        try { full = PathGuard.ValidateContainment(repoPath, file, nameof(file)); }
+        catch (ArgumentException ex) { return $"Error: {ex.Message}"; }
+
+        if (!File.Exists(full)) return $"Error: file not found under the repository: `{file}`.";
+
+        var source = File.ReadAllText(full);
+        var rel = file.Replace('\\', '/');
+
+        // Reuse the doctor's analysis on just this file so the rule rationale +
+        // fix + auto-fixability are identical to what MafDoctor reports.
+        var summary = DoctorTool.Grade(
+            AntiPatternScannerTool.ScanFile(source, rel),
+            FanOutValidatorTool.AnalyzeSource(source, rel),
+            PromptLintTool.LintSource(source, rel),
+            EstimateCostTool.AnalyzeSource(source, rel));
+
+        // Findings exactly on the line, else widen to ±2 (line numbers in a
+        // report can drift by an attribute line etc.).
+        var atLine = summary.AllFixes.Where(f => f.Line == line).ToList();
+        var widened = false;
+        if (atLine.Count == 0)
+        {
+            atLine = summary.AllFixes.Where(f => Math.Abs(f.Line - line) <= 2)
+                .OrderBy(f => Math.Abs(f.Line - line)).ThenBy(f => f.Priority).ToList();
+            widened = atLine.Count > 0;
+        }
+
+        var lines = source.Replace("\r\n", "\n").Split('\n');
+        var sb = new StringBuilder();
+        sb.AppendLine($"## 🔬 Finding deep-dive — `{rel}:{line}`");
+        sb.AppendLine();
+
+        // Mark the ACTUAL finding line(s) (which, when widened, differ from the
+        // user-supplied line), and centre the window on the nearest finding so it
+        // stays visible even at context: 0.
+        var centerLine = atLine.Count > 0 ? atLine[0].Line : line;
+        var marked = atLine.Count > 0
+            ? atLine.Select(f => f.Line).ToHashSet()
+            : new HashSet<int> { line };
+        AppendCodeWindow(sb, lines, centerLine, marked, context);
+
+        if (atLine.Count == 0)
+        {
+            sb.AppendLine("> ℹ️ No active finding detected at or near this line. It may already be");
+            sb.AppendLine("> fixed, or the line number may be stale — re-run `MafDoctor` and use the");
+            sb.AppendLine("> exact `file:line` it prints.");
+            sb.AppendLine();
+            return sb.ToString();
+        }
+
+        if (widened)
+        {
+            sb.AppendLine($"_(No finding exactly on line {line}; showing the nearest within ±2 lines — marked above.)_");
+            sb.AppendLine();
+        }
+
+        var nearOrAt = widened ? "near this line" : "at this line";
+        sb.AppendLine(atLine.Count == 1
+            ? (widened ? "### The finding (near your line)" : "### The finding")
+            : $"### {atLine.Count} findings {nearOrAt}");
+        sb.AppendLine();
+        foreach (var f in atLine)
+        {
+            var tag = f.AutoFixable ? "auto-fixable" : "needs your judgment";
+            sb.AppendLine($"**{SeverityEmoji(f.Priority)} `{f.RuleId}` — {f.Issue}** · _{tag}_");
+            if (!string.IsNullOrEmpty(f.Why)) sb.AppendLine($"- **Why:** {f.Why}");
+            if (!string.IsNullOrEmpty(f.FixDescription)) sb.AppendLine($"- **Fix:** {f.FixDescription}");
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("### How to resolve");
+        sb.AppendLine();
+        if (atLine.Any(f => f.AutoFixable))
+            sb.AppendLine("- **Mechanical** (auto-fixable above): apply deterministically with `maf-doctor autofix-all .` (CLI) or `MafAutoFixAll(repoPath)` (MCP), then re-run the doctor.");
+        if (atLine.Any(f => !f.AutoFixable))
+            sb.AppendLine("- **Semantic** (needs your judgment): apply the **Fix** above by hand or via the `@maf-migration` agent. Verify the change against the hard rules before committing.");
+        sb.AppendLine();
+
+        sb.AppendLine("### Grounding (read before fixing)");
+        sb.AppendLine();
+        sb.AppendLine("- Hard rules that must never be violated: `maf://constraints`");
+        sb.AppendLine("- Per-version migration guide: `maf://guide`");
+        sb.AppendLine("- Obsolete / removed-surface fix lookup (e.g. `MAF-AP-EXEC-001`; CS0618-class registry entries): `MafRegistryLookup(<id>)` / `MafApiSafety(<api>)`");
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Renders a numbered code window centred on <paramref name="centerLine"/>,
+    /// marking every line in <paramref name="marked"/> with <c>&gt;</c>. Lines
+    /// matching the hard-coded-API-key pattern (the shared SEC-002
+    /// <see cref="AntiPatternScannerTool.LooksLikeSecret"/>, single source of
+    /// truth with DoctorTool's redactor) are withheld — this is best-effort,
+    /// API-key-shaped redaction, NOT full secret-shape coverage. The
+    /// <c>"{marker} {num} | "</c> prefix also means no source line can ever form
+    /// a valid CommonMark closing fence, so a line of backticks can't break out.
+    /// </summary>
+    private static void AppendCodeWindow(StringBuilder sb, string[] lines, int centerLine, HashSet<int> marked, int context)
+    {
+        var start = Math.Max(1, centerLine - context);
+        var end = Math.Min(lines.Length, centerLine + context);
+        if (start > lines.Length) return; // line past EOF — nothing to show
+
+        sb.AppendLine("### Code in context");
+        sb.AppendLine();
+        sb.AppendLine("```text");
+        var width = end.ToString().Length;
+        for (var n = start; n <= end; n++)
+        {
+            var raw = lines[n - 1];
+            var marker = marked.Contains(n) ? ">" : " ";
+            var num = n.ToString().PadLeft(width);
+            var body = AntiPatternScannerTool.LooksLikeSecret(raw)
+                ? "(line redacted — contains a secret)"
+                : raw.TrimEnd();
+            sb.AppendLine($"{marker} {num} | {body}");
+        }
+        sb.AppendLine("```");
+        sb.AppendLine();
+    }
+
+    private static string SeverityEmoji(int priority) => priority switch
+    {
+        1 => "🔴",
+        2 => "🔴",
+        3 => "🟠",
+        _ => "🟡",
+    };
+}

--- a/src/maf-autopilot/Tools/FanOutValidatorTool.cs
+++ b/src/maf-autopilot/Tools/FanOutValidatorTool.cs
@@ -88,7 +88,11 @@ public sealed class FanOutValidatorTool
 
             var returnType = method.ReturnType.ToString();
             var verdict = ClassifyReturnType(returnType);
-            var location = method.GetLocation().GetLineSpan();
+            // Report the SIGNATURE line (the return type), not method.GetLocation()
+            // — the latter starts at the [MessageHandler] attribute (attributes are
+            // part of the method's span), so the offending return type wouldn't be
+            // on the reported line. The return-type token is exactly what's wrong.
+            var location = method.ReturnType.GetLocation().GetLineSpan();
 
             findings.Add(new MessageHandlerFinding(
                 File: fileName,

--- a/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
@@ -25,6 +25,17 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
             return base.VisitClassDeclaration(node);
 
         var modifiers = node.Modifiers.Select(m => m.ValueText).ToHashSet();
+
+        // Parity with the WF-001 scanner, which SKIPS abstract Executors entirely:
+        // an abstract class can't be `sealed` (the two modifiers are mutually
+        // exclusive), and a static class can't derive from Executor at all. Leave
+        // both UNTOUCHED — returning the node unchanged means MafAutoFix /
+        // MafBeforeAfter honestly report "no change" for a file the scanner also
+        // considers clean, instead of dirtying it with an advisory comment. (The
+        // concrete subclass is what must be `sealed partial`; the scanner flags THAT.)
+        if (modifiers.Contains("abstract") || modifiers.Contains("static"))
+            return base.VisitClassDeclaration(node);
+
         var needsSealed = !modifiers.Contains("sealed");
         var needsPartial = !modifiers.Contains("partial");
         if (!needsSealed && !needsPartial)
@@ -34,25 +45,6 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
         // missing, and `partial` is the load-bearing one (without it the workflow
         // source generator can't emit the dispatcher → generator-time compile
         // error). So add WHICHEVER is missing — not just `sealed`.
-
-        // Corruption guard: `sealed abstract` / `sealed static` are C# compile
-        // errors, so `sealed` can't be added to those. An abstract Executor can
-        // never be `sealed partial` at all (abstract precludes sealed) — the
-        // scanner skips abstract classes for that reason, so a real WF-001 finding
-        // won't reach here — but if autofix-all visits one directly, leave a
-        // comment pointing at the real fix (make the concrete subclass
-        // `sealed partial`, or don't derive the abstract base from Executor)
-        // rather than emit uncompilable code.
-        if (needsSealed && modifiers.Contains("abstract"))
-        {
-            return AddSkipWarning(node,
-                "// MAF-AP-WF-001: cannot seal an abstract Executor — refactor to a non-abstract class first.");
-        }
-        if (needsSealed && modifiers.Contains("static"))
-        {
-            return AddSkipWarning(node,
-                "// MAF-AP-WF-001: cannot seal a static class — static classes cannot derive from Executor anyway; this rule shouldn't be reachable.");
-        }
 
         // Build canonical `[access] sealed … partial class`: insert `sealed` right
         // after the first (access) modifier; append `partial` last (immediately
@@ -74,33 +66,6 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
         }
 
         return node.WithModifiers(SyntaxFactory.TokenList(list));
-    }
-
-    /// <summary>
-    /// Prepend a leading-trivia comment to the class declaration explaining why the
-    /// rewriter cannot apply the fix — the safe alternative to emitting uncompilable
-    /// <c>sealed abstract</c>. This DOES change the node, so the caller's
-    /// <c>MafAutoFix</c>/<c>MafBeforeAfter</c> flow counts the file as changed and
-    /// writes the breadcrumb to disk. That is a deliberate trade-off (surface the
-    /// manual-fix guidance) rather than a silent no-op: the scanner skips abstract
-    /// Executors, so this path is only reached when autofix visits one directly.
-    /// Behaviour is pinned by tests.
-    ///
-    /// Idempotent — dedup by scanning the class's source text for the same
-    /// comment. Roslyn re-parses can shift trivia between adjacent tokens,
-    /// so source-text inspection is more reliable than checking just the
-    /// node's immediate leading-trivia list.
-    /// </summary>
-    private static SyntaxNode AddSkipWarning(ClassDeclarationSyntax node, string comment)
-    {
-        if (node.ToFullString().Contains(comment, StringComparison.Ordinal))
-        {
-            return node;
-        }
-        return node.WithLeadingTrivia(
-            node.GetLeadingTrivia()
-                .Add(SyntaxFactory.Comment(comment))
-                .Add(SyntaxFactory.EndOfLine("\n")));
     }
 
     private static bool IsExecutorWithMessageHandler(ClassDeclarationSyntax cls)

--- a/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
@@ -25,50 +25,52 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
             return base.VisitClassDeclaration(node);
 
         var modifiers = node.Modifiers.Select(m => m.ValueText).ToHashSet();
-        if (modifiers.Contains("sealed"))
-            return base.VisitClassDeclaration(node); // already sealed
+        var needsSealed = !modifiers.Contains("sealed");
+        var needsPartial = !modifiers.Contains("partial");
+        if (!needsSealed && !needsPartial)
+            return base.VisitClassDeclaration(node); // already `sealed partial`
 
-        // Phase 4.1a — corruption guard: `sealed abstract class` is a C#
-        // compile error (the two modifiers are mutually exclusive). Same for
-        // `sealed static class` (static implies sealed AND abstract; combining
-        // with explicit `sealed` is also rejected). Pre-fix, the rewriter
-        // happily inserted `sealed` regardless and produced uncompilable user
-        // code. Now: skip the rewrite and leave a comment-warning so the
-        // developer sees why the rule wasn't auto-applied.
-        if (modifiers.Contains("abstract"))
+        // The scanner (MAF-AP-WF-001) fires when EITHER `sealed` or `partial` is
+        // missing, and `partial` is the load-bearing one (without it the workflow
+        // source generator can't emit the dispatcher → generator-time compile
+        // error). So add WHICHEVER is missing — not just `sealed`.
+
+        // Phase 4.1a — corruption guard: `sealed abstract` / `sealed static` are
+        // C# compile errors. We can't add `sealed` to those, so skip with a
+        // comment-warning rather than emit uncompilable code. (Adding `sealed`
+        // is what's blocked; an abstract class missing `partial` is a refactor
+        // the developer must do anyway.)
+        if (needsSealed && modifiers.Contains("abstract"))
         {
             return AddSkipWarning(node,
                 "// MAF-AP-WF-001: cannot seal an abstract Executor — refactor to a non-abstract class first.");
         }
-        if (modifiers.Contains("static"))
+        if (needsSealed && modifiers.Contains("static"))
         {
             return AddSkipWarning(node,
                 "// MAF-AP-WF-001: cannot seal a static class — static classes cannot derive from Executor anyway; this rule shouldn't be reachable.");
         }
 
-        // Insert `sealed` immediately after `public` (or any first access modifier);
-        // fall back to the start of the modifier list. Preserve trivia by borrowing
-        // the trailing trivia of the preceding token.
-        var sealedToken = SyntaxFactory.Token(SyntaxKind.SealedKeyword)
-            .WithTrailingTrivia(SyntaxFactory.Space);
-
-        SyntaxTokenList newModifiers;
-        if (node.Modifiers.Count == 0)
+        // Build canonical `[access] sealed … partial class`: insert `sealed` right
+        // after the first (access) modifier; append `partial` last (immediately
+        // before the `class` keyword). Each inserted token carries a trailing
+        // space so the rendered text stays well-formed.
+        var list = node.Modifiers.ToList();
+        if (needsSealed)
         {
-            newModifiers = SyntaxFactory.TokenList(sealedToken);
+            var sealedToken = SyntaxFactory.Token(SyntaxKind.SealedKeyword)
+                .WithTrailingTrivia(SyntaxFactory.Space);
+            // Insert after the first modifier; if there are none, prepend.
+            list.Insert(list.Count == 0 ? 0 : 1, sealedToken);
         }
-        else
+        if (needsPartial)
         {
-            // Insert after the first modifier (preserves "public sealed partial class X").
-            // Note: when `node.Modifiers.Count == 1` (e.g. just `public`), index 1
-            // equals the list's Count, and List<T>.Insert(Count, x) appends — which
-            // is exactly what we want: `public` → `public sealed`.
-            var list = node.Modifiers.ToList();
-            list.Insert(1, sealedToken);
-            newModifiers = SyntaxFactory.TokenList(list);
+            var partialToken = SyntaxFactory.Token(SyntaxKind.PartialKeyword)
+                .WithTrailingTrivia(SyntaxFactory.Space);
+            list.Add(partialToken); // last modifier, right before `class`
         }
 
-        return node.WithModifiers(newModifiers);
+        return node.WithModifiers(SyntaxFactory.TokenList(list));
     }
 
     /// <summary>

--- a/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
@@ -35,11 +35,14 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
         // source generator can't emit the dispatcher → generator-time compile
         // error). So add WHICHEVER is missing — not just `sealed`.
 
-        // Phase 4.1a — corruption guard: `sealed abstract` / `sealed static` are
-        // C# compile errors. We can't add `sealed` to those, so skip with a
-        // comment-warning rather than emit uncompilable code. (Adding `sealed`
-        // is what's blocked; an abstract class missing `partial` is a refactor
-        // the developer must do anyway.)
+        // Corruption guard: `sealed abstract` / `sealed static` are C# compile
+        // errors, so `sealed` can't be added to those. An abstract Executor can
+        // never be `sealed partial` at all (abstract precludes sealed) — the
+        // scanner skips abstract classes for that reason, so a real WF-001 finding
+        // won't reach here — but if autofix-all visits one directly, leave a
+        // comment pointing at the real fix (make the concrete subclass
+        // `sealed partial`, or don't derive the abstract base from Executor)
+        // rather than emit uncompilable code.
         if (needsSealed && modifiers.Contains("abstract"))
         {
             return AddSkipWarning(node,

--- a/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
@@ -77,10 +77,14 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
     }
 
     /// <summary>
-    /// Attach a leading-trivia comment to the class declaration explaining why
-    /// the rewriter skipped it. Returns the node unchanged otherwise — the
-    /// caller's `MafAutoFix` flow will record "no change" for this file, which
-    /// is the right answer: we'd rather emit nothing than emit garbage.
+    /// Prepend a leading-trivia comment to the class declaration explaining why the
+    /// rewriter cannot apply the fix — the safe alternative to emitting uncompilable
+    /// <c>sealed abstract</c>. This DOES change the node, so the caller's
+    /// <c>MafAutoFix</c>/<c>MafBeforeAfter</c> flow counts the file as changed and
+    /// writes the breadcrumb to disk. That is a deliberate trade-off (surface the
+    /// manual-fix guidance) rather than a silent no-op: the scanner skips abstract
+    /// Executors, so this path is only reached when autofix visits one directly.
+    /// Behaviour is pinned by tests.
     ///
     /// Idempotent — dedup by scanning the class's source text for the same
     /// comment. Roslyn re-parses can shift trivia between adjacent tokens,
@@ -101,9 +105,11 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
 
     private static bool IsExecutorWithMessageHandler(ClassDeclarationSyntax cls)
     {
+        // Shared predicate with the WF-001 scanner rule — matches plain `Executor`,
+        // generic `Executor<…>`, and qualified forms — so detector and rewriter stay
+        // in lockstep (no "flagged as fixable but silently not rewritten" parity gap).
         var derivesFromExecutor = cls.BaseList?.Types
-            .Select(t => t.Type.ToString())
-            .Any(b => b == "Executor" || b.EndsWith(".Executor", StringComparison.Ordinal)) ?? false;
+            .Any(t => AntiPatternScannerTool.IsExecutorBaseType(t.Type)) ?? false;
         if (!derivesFromExecutor) return false;
 
         return cls.Members.OfType<MethodDeclarationSyntax>().Any(m =>

--- a/src/maf-autopilot/Tools/Rewriters/FanInArgOrderRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/FanInArgOrderRewriter.cs
@@ -32,12 +32,26 @@ internal sealed class FanInArgOrderRewriter : CSharpSyntaxRewriter, IRuleRewrite
         if (!LooksLikeWrongOrder(args[0], args[1]))
             return base.VisitInvocationExpression(node);
 
-        // Swap and strip the named-argument labels (they no longer match
-        // the new overload's parameter positions).
-        var newFirst = StripNamedLabel(args[1]).WithTriviaFrom(args[0]);
-        var newSecond = StripNamedLabel(args[0]).WithTriviaFrom(args[1]);
+        // Swap the two argument VALUES and strip the named-argument labels (they no
+        // longer match the new overload's parameter positions), preserving trivia per
+        // the IRuleRewriter contract. The old `WithTriviaFrom(peer)` copied the OTHER
+        // slot's trivia onto each moved value, which dropped a comment carried by the
+        // separator and misattributed each value's own trailing comment. Instead:
+        //   * keep each slot's LEADING trivia (indentation stays at its position),
+        //   * carry each value's OWN TRAILING trivia (its trailing comment travels
+        //     with the value), and
+        //   * reuse the ORIGINAL separator token so an inter-argument comment that
+        //     lived on the comma is not lost.
+        var newFirst = StripNamedLabel(args[1])
+            .WithLeadingTrivia(args[0].GetLeadingTrivia())
+            .WithTrailingTrivia(args[1].GetTrailingTrivia());
+        var newSecond = StripNamedLabel(args[0])
+            .WithLeadingTrivia(args[1].GetLeadingTrivia())
+            .WithTrailingTrivia(args[0].GetTrailingTrivia());
 
-        var newArgs = SyntaxFactory.SeparatedList(new[] { newFirst, newSecond });
+        var newArgs = SyntaxFactory.SeparatedList(
+            new[] { newFirst, newSecond },
+            new[] { args.GetSeparator(0) });
         return node.WithArgumentList(node.ArgumentList.WithArguments(newArgs));
     }
 

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -96,10 +96,17 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
         // across ALL ancestors here, before the bounded walk.
         foreach (var ancestor in node.Ancestors())
         {
+            // `MemberDeclarationSyntax` is the common base for method / property /
+            // indexer / operator / conversion / constructor / event / field / type
+            // declarations — every member kind that can carry the `unsafe` modifier.
+            // (Local functions are statements, not members, so they need their own
+            // check.) The modifier establishes an unsafe context that propagates
+            // lexically into nested async lambdas, so one uniform check here closes
+            // the whole class — enumerating only method/localfn/type previously missed
+            // `unsafe` properties / indexers / operators / conversions / constructors.
             if (ancestor is UnsafeStatementSyntax or FixedStatementSyntax
-                || (ancestor is MethodDeclarationSyntax um && um.Modifiers.Any(mod => mod.IsKind(SyntaxKind.UnsafeKeyword)))
-                || (ancestor is LocalFunctionStatementSyntax ulf && ulf.Modifiers.Any(mod => mod.IsKind(SyntaxKind.UnsafeKeyword)))
-                || (ancestor is BaseTypeDeclarationSyntax ut && ut.Modifiers.Any(mod => mod.IsKind(SyntaxKind.UnsafeKeyword))))
+                || (ancestor is MemberDeclarationSyntax umd && umd.Modifiers.Any(mod => mod.IsKind(SyntaxKind.UnsafeKeyword)))
+                || (ancestor is LocalFunctionStatementSyntax ulf && ulf.Modifiers.Any(mod => mod.IsKind(SyntaxKind.UnsafeKeyword))))
             {
                 reason = "// MAF-AP-CONC-002: cannot await in an unsafe context — move the awaited call out of the `unsafe`/`fixed` scope or drop the `unsafe` modifier.";
                 return true;

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -89,64 +89,46 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
             }
         }
 
-        // (b) Enclosing function must be async. Walk to the nearest "function"-y
-        // ancestor and check its modifiers / async lambda token. If we hit the
-        // top-level program or a property accessor (rare), treat as non-async.
+        // (b) WHITELIST, not blacklist. Walk outward and rewrite ONLY when we
+        // positively land in an async-capable scope: an `async` method / local
+        // function / lambda, or a top-level statement (the generated entry point is
+        // async). If we instead reach a type-declaration body or the compilation-unit
+        // root WITHOUT finding one, the `.Result` sits in a context that can never be
+        // `async` (property / field / operator / conversion / primary-ctor base /
+        // attribute / …), so we SKIP. Defaulting to skip closes the entire
+        // await-into-non-async corruption class in one place, instead of trying to
+        // enumerate every non-async member kind (we kept missing some — operators,
+        // then C# 12 primary-constructor base initializers).
         foreach (var ancestor in node.Ancestors())
         {
             switch (ancestor)
             {
                 case MethodDeclarationSyntax m:
-                    if (!m.Modifiers.Any(mod => mod.IsKind(SyntaxKind.AsyncKeyword)))
-                    {
-                        reason = "// MAF-AP-CONC-002: enclosing method is not async — mark `async` (and adjust return type) or refactor before applying this rule.";
-                        return true;
-                    }
-                    reason = string.Empty;
-                    return false; // method is async — OK to rewrite
-                case LocalFunctionStatementSyntax lf:
-                    if (!lf.Modifiers.Any(mod => mod.IsKind(SyntaxKind.AsyncKeyword)))
-                    {
-                        reason = "// MAF-AP-CONC-002: enclosing local function is not async — mark `async` or refactor.";
-                        return true;
-                    }
-                    reason = string.Empty;
-                    return false;
-                case AnonymousFunctionExpressionSyntax af:
-                    if (af.AsyncKeyword == default)
-                    {
-                        reason = "// MAF-AP-CONC-002: enclosing lambda is not async — add `async` or refactor.";
-                        return true;
-                    }
-                    reason = string.Empty;
-                    return false;
-                case AccessorDeclarationSyntax: // property/event accessors — never async-able in our targets
-                    reason = "// MAF-AP-CONC-002: cannot await inside a property/event accessor — refactor.";
+                    if (m.Modifiers.Any(mod => mod.IsKind(SyntaxKind.AsyncKeyword))) { reason = string.Empty; return false; }
+                    reason = "// MAF-AP-CONC-002: enclosing method is not async — mark `async` (and adjust return type) or refactor before applying this rule.";
                     return true;
-                // Expression-bodied / initializer member boundaries that have NO
-                // accessor node and can NEVER be `async`. Without these, a `.Result`
-                // in `string P => Foo().Result;`, `this[int i] => …`, a field
-                // initializer, or a ctor/dtor fell through to the async-allowed
-                // default and got `await` injected → uncompilable (CS4032). These
-                // are members (never nested), so they don't shadow the method /
-                // local-function / lambda cases for ordinary bodies.
-                case PropertyDeclarationSyntax:
-                case IndexerDeclarationSyntax:
-                case EventDeclarationSyntax:
-                case FieldDeclarationSyntax:
-                case ConstructorDeclarationSyntax:
-                case DestructorDeclarationSyntax:
-                case OperatorDeclarationSyntax:           // operators can never be async
-                case ConversionOperatorDeclarationSyntax: // user-defined conversions can never be async
-                    reason = "// MAF-AP-CONC-002: cannot await here — this member cannot be `async`; refactor the call site (e.g. make it a method).";
+                case LocalFunctionStatementSyntax lf:
+                    if (lf.Modifiers.Any(mod => mod.IsKind(SyntaxKind.AsyncKeyword))) { reason = string.Empty; return false; }
+                    reason = "// MAF-AP-CONC-002: enclosing local function is not async — mark `async` or refactor.";
+                    return true;
+                case AnonymousFunctionExpressionSyntax af:
+                    if (af.AsyncKeyword != default) { reason = string.Empty; return false; }
+                    reason = "// MAF-AP-CONC-002: enclosing lambda is not async — add `async` or refactor.";
+                    return true;
+                case GlobalStatementSyntax:
+                    // Top-level statement — the generated Main is async-capable.
+                    reason = string.Empty;
+                    return false;
+                case BaseTypeDeclarationSyntax: // class/struct/record/interface/enum body reached without an async fn
+                case CompilationUnitSyntax:     // reached the root without an async fn
+                    reason = "// MAF-AP-CONC-002: this position cannot `await` (not inside an async method/function) — refactor the call site, e.g. make it an async method.";
                     return true;
             }
         }
 
-        // No enclosing function found (top-level statement context). Top-level
-        // is implicitly async-allowed in modern C#; leave the rewrite alone.
-        reason = string.Empty;
-        return false;
+        // Defensive default: never inject `await` into an unrecognized context.
+        reason = "// MAF-AP-CONC-002: cannot await here — no enclosing async context.";
+        return true;
     }
 
     /// <summary>

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -189,13 +189,23 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
     /// list. Scanning by source-text of the enclosing scope is stable
     /// across parse round-trips.
     /// </summary>
-    /// <summary>True only when the node sits in an await-legal query position: the
-    /// query's initial <c>from</c> source, or a <c>join … in</c> source expression.</summary>
+    /// <summary>True only when the node sits in an await-legal source of THIS query:
+    /// its OWN initial <c>from</c> source, or a <c>join … in</c> source it directly
+    /// owns. Clauses inside a NESTED query (e.g. an inner query embedded in this
+    /// query's await-illegal <c>let</c>/<c>where</c>/<c>select</c>) belong to that
+    /// inner query, not this one — so we exclude them. Without the ownership check,
+    /// <c>DescendantNodes()</c> reached an inner-query join source and wrongly marked
+    /// an await-illegal outer-query position as legal, injecting an <c>await</c> that
+    /// the compiler rejects with CS1995.</summary>
     private static bool IsInAwaitableQuerySource(SyntaxNode node, QueryExpressionSyntax query)
     {
-        if (query.FromClause.Expression.Span.Contains(node.Span)) return true;
+        if (query.FromClause.Expression.Span.Contains(node.Span)
+            && node.FirstAncestorOrSelf<QueryExpressionSyntax>() == query)
+            return true;
         foreach (var join in query.DescendantNodes().OfType<JoinClauseSyntax>())
-            if (join.InExpression.Span.Contains(node.Span)) return true;
+            if (join.FirstAncestorOrSelf<QueryExpressionSyntax>() == query
+                && join.InExpression.Span.Contains(node.Span))
+                return true;
         return false;
     }
 

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -89,6 +89,16 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
             }
         }
 
+        // (a2) LINQ query clause (CS1995): `await` is legal ONLY in the initial
+        // `from` source and a `join … in` source — never in let/where/select/
+        // orderby/group/secondary-from. Skip those (default-safe direction).
+        var query = node.FirstAncestorOrSelf<QueryExpressionSyntax>();
+        if (query is not null && !IsInAwaitableQuerySource(node, query))
+        {
+            reason = "// MAF-AP-CONC-002: cannot await inside this query clause — materialize the awaited value before the query.";
+            return true;
+        }
+
         // (b) WHITELIST, not blacklist. Walk outward and rewrite ONLY when we
         // positively land in an async-capable scope: an `async` method / local
         // function / lambda, or a top-level statement (the generated entry point is
@@ -141,11 +151,26 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
     /// list. Scanning by source-text of the enclosing scope is stable
     /// across parse round-trips.
     /// </summary>
+    /// <summary>True only when the node sits in an await-legal query position: the
+    /// query's initial <c>from</c> source, or a <c>join … in</c> source expression.</summary>
+    private static bool IsInAwaitableQuerySource(SyntaxNode node, QueryExpressionSyntax query)
+    {
+        if (query.FromClause.Expression.Span.Contains(node.Span)) return true;
+        foreach (var join in query.DescendantNodes().OfType<JoinClauseSyntax>())
+            if (join.InExpression.Span.Contains(node.Span)) return true;
+        return false;
+    }
+
     private static SyntaxNode WithTodoTrivia(SyntaxNode node, string commentText)
     {
+        // Dedup scope: the enclosing function, else the enclosing TYPE declaration
+        // (covers contexts with no method ancestor — primary-ctor base initializers,
+        // field / collection-expression initializers — which otherwise re-stacked a
+        // duplicate comment on a second pass), else the parent.
         var enclosingMethod = (SyntaxNode?)node.FirstAncestorOrSelf<MethodDeclarationSyntax>()
             ?? node.FirstAncestorOrSelf<LocalFunctionStatementSyntax>()
             ?? node.FirstAncestorOrSelf<AnonymousFunctionExpressionSyntax>()
+            ?? node.FirstAncestorOrSelf<BaseTypeDeclarationSyntax>()
             ?? node.Parent;
         if (enclosingMethod is not null
             && enclosingMethod.ToFullString().Contains(commentText, StringComparison.Ordinal))

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -136,6 +136,8 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
                 case FieldDeclarationSyntax:
                 case ConstructorDeclarationSyntax:
                 case DestructorDeclarationSyntax:
+                case OperatorDeclarationSyntax:           // operators can never be async
+                case ConversionOperatorDeclarationSyntax: // user-defined conversions can never be async
                     reason = "// MAF-AP-CONC-002: cannot await here — this member cannot be `async`; refactor the call site (e.g. make it a method).";
                     return true;
             }

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -123,6 +123,21 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
                 case AccessorDeclarationSyntax: // property/event accessors — never async-able in our targets
                     reason = "// MAF-AP-CONC-002: cannot await inside a property/event accessor — refactor.";
                     return true;
+                // Expression-bodied / initializer member boundaries that have NO
+                // accessor node and can NEVER be `async`. Without these, a `.Result`
+                // in `string P => Foo().Result;`, `this[int i] => …`, a field
+                // initializer, or a ctor/dtor fell through to the async-allowed
+                // default and got `await` injected → uncompilable (CS4032). These
+                // are members (never nested), so they don't shadow the method /
+                // local-function / lambda cases for ordinary bodies.
+                case PropertyDeclarationSyntax:
+                case IndexerDeclarationSyntax:
+                case EventDeclarationSyntax:
+                case FieldDeclarationSyntax:
+                case ConstructorDeclarationSyntax:
+                case DestructorDeclarationSyntax:
+                    reason = "// MAF-AP-CONC-002: cannot await here — this member cannot be `async`; refactor the call site (e.g. make it a method).";
+                    return true;
             }
         }
 

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -88,41 +88,12 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
     /// </summary>
     private static bool ShouldSkipForContext(SyntaxNode node, out string reason)
     {
-        // (a) Any ancestor lock-statement makes `await` here a CS1996.
-        foreach (var ancestor in node.Ancestors())
-        {
-            if (ancestor is LockStatementSyntax)
-            {
-                reason = "// MAF-AP-CONC-002: cannot await inside a lock block — refactor to SemaphoreSlim.WaitAsync or restructure.";
-                return true;
-            }
-        }
-
-        // (a2) LINQ query clause (CS1995): `await` is legal ONLY in the initial
-        // `from` source and a `join … in` source — never in let/where/select/
-        // orderby/group/secondary-from. Skip those (default-safe direction).
-        var query = node.FirstAncestorOrSelf<QueryExpressionSyntax>();
-        if (query is not null && !IsInAwaitableQuerySource(node, query))
-        {
-            reason = "// MAF-AP-CONC-002: cannot await inside this query clause — materialize the awaited value before the query.";
-            return true;
-        }
-
-        // (a3) Catch filter (CS7094): `await` is illegal in a `catch when (...)`
-        // filter expression. The catch BODY is still awaitable, so we guard the
-        // filter clause specifically (FirstAncestorOrSelf<CatchFilterClauseSyntax>
-        // matches only the `when (...)` expression, never the handler block).
-        if (node.FirstAncestorOrSelf<CatchFilterClauseSyntax>() is not null)
-        {
-            reason = "// MAF-AP-CONC-002: cannot await inside a catch filter (`when (...)`) — hoist the awaited value into a variable before the try/catch.";
-            return true;
-        }
-
-        // (a4) Unsafe context (CS4004): `await` is illegal wherever an unsafe
-        // context is in effect — inside an `unsafe { }` or `fixed ( )` block, OR
-        // under the `unsafe` modifier on the enclosing method / local function /
-        // any enclosing type (the modifier makes the whole declaration unsafe,
-        // including nested types and members).
+        // (UNBOUNDED) Unsafe context (CS4004): `await` is illegal wherever an
+        // unsafe context is in effect — inside an `unsafe { }` or `fixed ( )` block,
+        // OR under the `unsafe` modifier on the enclosing method / local function /
+        // any enclosing type. Unlike lock/query/catch-filter below, an unsafe
+        // context PROPAGATES lexically into nested async lambdas, so it is checked
+        // across ALL ancestors here, before the bounded walk.
         foreach (var ancestor in node.Ancestors())
         {
             if (ancestor is UnsafeStatementSyntax or FixedStatementSyntax
@@ -135,20 +106,51 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
             }
         }
 
-        // (b) WHITELIST, not blacklist. Walk outward and rewrite ONLY when we
-        // positively land in an async-capable scope: an `async` method / local
-        // function / lambda, or a top-level statement (the generated entry point is
-        // async). If we instead reach a type-declaration body or the compilation-unit
-        // root WITHOUT finding one, the `.Result` sits in a context that can never be
-        // `async` (property / field / operator / conversion / primary-ctor base /
-        // attribute / …), so we SKIP. Defaulting to skip closes the entire
-        // await-into-non-async corruption class in one place, instead of trying to
-        // enumerate every non-async member kind (we kept missing some — operators,
-        // then C# 12 primary-constructor base initializers).
+        // SINGLE BOUNDED WALK — walk outward, FIRST match wins. This unifies two
+        // concerns and makes their interaction correct:
+        //
+        //   * lock (CS1996) / LINQ non-source query clause (CS1995) / catch filter
+        //     (CS7094) make awaiting illegal — but ONLY when they sit between the
+        //     node and its nearest enclosing async function. An async lambda /
+        //     local function is its OWN await context, so an OUTER lock / query /
+        //     catch-filter does not reach across it. Because these cases share this
+        //     walk with the async-boundary cases below, hitting an async lambda
+        //     FIRST correctly returns "rewrite" before an outer lock is ever seen
+        //     (pre-fix the unconditional pre-passes over-skipped that legal code and
+        //     injected a factually wrong "cannot await inside a lock" comment).
+        //
+        //   * The async WHITELIST: rewrite ONLY when we positively reach an `async`
+        //     method / local function / lambda, or a top-level statement. Reaching a
+        //     type body or the compilation-unit root first means the `.Result` sits
+        //     in a context that can never be `async` (property / field / operator /
+        //     conversion / primary-ctor base / …), so we SKIP — closing the entire
+        //     await-into-non-async corruption class in one place rather than
+        //     enumerating every non-async member kind.
+        //
+        //   * Parameter defaults and attribute arguments are await-illegal even
+        //     inside an async function (they require a compile-time constant), so
+        //     they SKIP before the walk reaches the async boundary.
         foreach (var ancestor in node.Ancestors())
         {
             switch (ancestor)
             {
+                // Await-illegal sub-contexts — only reached while still inside the
+                // nearest enclosing async scope (see note above).
+                case LockStatementSyntax:
+                    reason = "// MAF-AP-CONC-002: cannot await inside a lock block — refactor to SemaphoreSlim.WaitAsync or restructure.";
+                    return true;
+                case QueryExpressionSyntax q when !IsInAwaitableQuerySource(node, q):
+                    reason = "// MAF-AP-CONC-002: cannot await inside this query clause — materialize the awaited value before the query.";
+                    return true;
+                case CatchFilterClauseSyntax:
+                    reason = "// MAF-AP-CONC-002: cannot await inside a catch filter (`when (...)`) — hoist the awaited value into a variable before the try/catch.";
+                    return true;
+                case ParameterSyntax:
+                case AttributeSyntax:
+                    reason = "// MAF-AP-CONC-002: cannot await in a parameter default / attribute argument — these require a compile-time constant.";
+                    return true;
+
+                // Async-scope boundaries — these END the bounded walk.
                 case MethodDeclarationSyntax m:
                     if (m.Modifiers.Any(mod => mod.IsKind(SyntaxKind.AsyncKeyword))) { reason = string.Empty; return false; }
                     reason = "// MAF-AP-CONC-002: enclosing method is not async — mark `async` (and adjust return type) or refactor before applying this rule.";

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -11,15 +11,24 @@ namespace MafDoctor.Tools.Rewriters;
 /// Also handles <c>SomeAsync().Wait()</c> → <c>await SomeAsync()</c>.
 ///
 /// <para><b>Corruption guard (Phase 4.1b).</b> Before rewriting, the visitor
-/// walks ancestors. Skip with a TODO comment if:</para>
+/// walks ancestors and skips with a TODO comment in every position where the
+/// C# spec makes <c>await</c> illegal (otherwise the rewrite emits uncompilable
+/// source). These are the finite await-illegal contexts:</para>
 /// <list type="bullet">
-///   <item>Any ancestor is a <c>lock</c> block — <c>await</c> inside <c>lock</c>
-///         is a C# compile error.</item>
-///   <item>The enclosing function (method / local function / lambda) is not
-///         marked <c>async</c> — <c>await</c> in a synchronous body is also
-///         a compile error.</item>
+///   <item>Inside a <c>lock</c> block (CS1996).</item>
+///   <item>Inside a LINQ query clause other than the initial <c>from</c> /
+///         <c>join … in</c> source (CS1995).</item>
+///   <item>Inside a <c>catch when (...)</c> filter expression (CS7094) — the
+///         catch body itself remains rewritable.</item>
+///   <item>Inside an unsafe context (CS4004): an <c>unsafe</c>/<c>fixed</c>
+///         block, or under the <c>unsafe</c> modifier on the enclosing
+///         method / local function / type.</item>
+///   <item>Outside any <c>async</c> function — the enclosing method / local
+///         function / lambda must be <c>async</c> (whitelist walk), else the
+///         <c>.Result</c> sits in a context that can never be async
+///         (property / field / operator / primary-ctor base / …) (CS4032/CS4033).</item>
 /// </list>
-/// Pre-fix the rewriter happily inserted <c>await</c> in either case and
+/// Pre-fix the rewriter happily inserted <c>await</c> in these cases and
 /// produced uncompilable user code. Now we surface a comment and leave the
 /// expression unchanged so the developer can refactor manually.
 /// </summary>
@@ -97,6 +106,33 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
         {
             reason = "// MAF-AP-CONC-002: cannot await inside this query clause — materialize the awaited value before the query.";
             return true;
+        }
+
+        // (a3) Catch filter (CS7094): `await` is illegal in a `catch when (...)`
+        // filter expression. The catch BODY is still awaitable, so we guard the
+        // filter clause specifically (FirstAncestorOrSelf<CatchFilterClauseSyntax>
+        // matches only the `when (...)` expression, never the handler block).
+        if (node.FirstAncestorOrSelf<CatchFilterClauseSyntax>() is not null)
+        {
+            reason = "// MAF-AP-CONC-002: cannot await inside a catch filter (`when (...)`) — hoist the awaited value into a variable before the try/catch.";
+            return true;
+        }
+
+        // (a4) Unsafe context (CS4004): `await` is illegal wherever an unsafe
+        // context is in effect — inside an `unsafe { }` or `fixed ( )` block, OR
+        // under the `unsafe` modifier on the enclosing method / local function /
+        // any enclosing type (the modifier makes the whole declaration unsafe,
+        // including nested types and members).
+        foreach (var ancestor in node.Ancestors())
+        {
+            if (ancestor is UnsafeStatementSyntax or FixedStatementSyntax
+                || (ancestor is MethodDeclarationSyntax um && um.Modifiers.Any(mod => mod.IsKind(SyntaxKind.UnsafeKeyword)))
+                || (ancestor is LocalFunctionStatementSyntax ulf && ulf.Modifiers.Any(mod => mod.IsKind(SyntaxKind.UnsafeKeyword)))
+                || (ancestor is BaseTypeDeclarationSyntax ut && ut.Modifiers.Any(mod => mod.IsKind(SyntaxKind.UnsafeKeyword))))
+            {
+                reason = "// MAF-AP-CONC-002: cannot await in an unsafe context — move the awaited call out of the `unsafe`/`fixed` scope or drop the `unsafe` modifier.";
+                return true;
+            }
         }
 
         // (b) WHITELIST, not blacklist. Walk outward and rewrite ONLY when we

--- a/src/maf-autopilot/Tools/SarifExportTool.cs
+++ b/src/maf-autopilot/Tools/SarifExportTool.cs
@@ -21,7 +21,9 @@ internal static class SarifExportTool
         var sarifFindings = findings.Select(f => new SarifFinding(
             RuleId: f.RuleId,
             Severity: MapSeverity(f.Severity),
-            Message: f.RuleName + " — " + f.Match,
+            // Redact a secret-bearing Match (e.g. the SEC-002 key literal) so the
+            // SARIF surface matches the markdown surface's no-secret-leak posture.
+            Message: f.RuleName + " — " + (AntiPatternScannerTool.LooksLikeSecret(f.Match) ? "(redacted)" : f.Match),
             File: f.File,
             Line: f.Line));
 

--- a/src/maf-autopilot/Tools/TourTool.cs
+++ b/src/maf-autopilot/Tools/TourTool.cs
@@ -115,7 +115,8 @@ public sealed class TourTool
         new("MafMigrationPath", "Upgrade", "Multi-step migration planner — walks version-keyed guide metadata, returns ordered intermediate-step sections."),
 
         // — Health —
-        new("MafDoctor", "Health", "Single-command A/B/C/F grade. Aggregates 4 scanners + reports the top 3 fixes. Best triage signal in the toolkit."),
+        new("MafDoctor", "Health", "Single-command A/B/C/F grade. Aggregates 4 scanners + reports the top 3 fixes (or every finding with `full: true`). Best triage signal in the toolkit."),
+        new("MafExplainFinding", "Health", "Deep-dive ONE doctor finding (file + line): the offending code in context plus the rule's why / fix / auto-fixability. Grounded substrate for explaining or fixing it — pair with the `maf-explain-finding` prompt."),
 
         // — Discovery (this very tool) —
         new("MafTour", "Discovery", "This catalogue. Returns every capability with one-line descriptions. Use as the first stop for new users."),
@@ -155,6 +156,7 @@ public sealed class TourTool
         ("maf-cs0618-hunt", "Starter prompt for finding + fixing CS0618 obsolete-API warnings."),
         ("maf-review", "Best-practices code review starter — day-to-day development, PR review, post-migration validation. Routes to MafDoctor / MafScanAntiPatterns / MafValidateFanOut."),
         ("maf-debug", "Reactive-debugging starter — paste an error or symptom, the prompt routes to the right diagnostic tool by symptom class."),
+        ("maf-explain-finding", "Deep-dive + fix ONE doctor finding (file + line). Calls MafExplainFinding for grounded context, then explains + proposes the fix using maf://constraints + maf://guide."),
         ("maf-scaffold", "Boilerplate generation starter — routes to MafNewAgent or MafNewExecutor depending on what you want to build."),
         ("maf-help", "3-question interactive flow for new users. Routes to the right tool / agent based on intent."),
     };

--- a/src/maf-autopilot/Tools/TourTool.cs
+++ b/src/maf-autopilot/Tools/TourTool.cs
@@ -83,7 +83,7 @@ public sealed class TourTool
         new("MafRegistryList", "Registry lookup", "Enumerate every registry entry ID. Useful for discovery and CI auditing."),
 
         // — Scanners —
-        new("MafScanAntiPatterns", "Scanner", "Walk a repo for known anti-patterns (security / concurrency / observability / identity / topology). 10 rules. Supports `format: \"sarif\"` for CI."),
+        new("MafScanAntiPatterns", "Scanner", "Walk a repo for known anti-patterns (security / concurrency / observability / identity / topology). 11 rules. Supports `format: \"sarif\"` for CI."),
         new("MafValidateFanOut", "Scanner", "Find handlers that return `void` / non-generic `Task` (silent fan-in starvation risk). Supports `format: \"sarif\"`."),
         new("MafLintAgentPrompt", "Scanner", "Lint every agent `Instructions` literal. 4 rules: empty / token bloat / missing refusal / untrusted-input concat (prompt injection)."),
         new("MafEstimateCost", "Scanner", "Find every `RunAsync` / `RunStreamingAsync` site missing a `MaxOutputTokens` cap. Production cost governance."),

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -17,7 +17,7 @@
          release.yml overrides this from the pushed tag and keeps the analyzer
          package in lockstep, so the canonical version is the git tag (`vX.Y.Z`).
          This value is the local/dev default. -->
-    <Version>1.2.12</Version>
+    <Version>1.3.0</Version>
     <Authors>joslat</Authors>
     <Description>MAF Doctor — a .NET global tool and MCP server for Microsoft Agent Framework (MAF). Diagnoses, explains, and auto-fixes MAF agents and workflows: A-F health grades, deterministic Roslyn rewriters, anti-pattern and fan-out scanning, and a self-updating obsolete-API registry. Use it from Copilot / Claude / Cursor via MCP, or standalone as a CLI.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -17,13 +17,13 @@
          release.yml overrides this from the pushed tag and keeps the analyzer
          package in lockstep, so the canonical version is the git tag (`vX.Y.Z`).
          This value is the local/dev default. -->
-    <Version>1.2.11</Version>
+    <Version>1.2.12</Version>
     <Authors>joslat</Authors>
     <Description>MAF Doctor — a .NET global tool and MCP server for Microsoft Agent Framework (MAF). Diagnoses, explains, and auto-fixes MAF agents and workflows: A-F health grades, deterministic Roslyn rewriters, anti-pattern and fan-out scanning, and a self-updating obsolete-API registry. Use it from Copilot / Claude / Cursor via MCP, or standalone as a CLI.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/joslat/maf-doctor</RepositoryUrl>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile>NUGET_README.md</PackageReadmeFile>
     <PackageIcon>MAFDoctorIcon.png</PackageIcon>
 
     <!-- Ensure logs go to stderr so stdout stays clean for MCP protocol -->
@@ -59,8 +59,9 @@
       Bundle registry.yaml as an embedded resource so the tool works as a standalone NuGet global tool.
       At runtime, RegistryService first checks MAF_REGISTRY_PATH env var (for local dev override),
       then falls back to this embedded resource.
-    -->    <!-- README for NuGet package page -->
-    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
+    -->    <!-- NuGet-specific README (pure markdown — the GitHub README's centered
+         HTML hero renders as raw text on nuget.org). -->
+    <None Include="..\..\NUGET_README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\assets\MAFDoctorIcon.png" Pack="true" PackagePath="\" Visible="false" />
 
     <!-- Steering snippets — dropped by `maf-autopilot init` into user repos -->


### PR DESCRIPTION
Single consolidated PR (held — do not merge until approved). Builds on the NuGet README hotfix and adds the three-tier doctor-suggestions overhaul. Bumps both packages to **1.3.0**.

Each tier shipped after **two adversarial multi-agent review passes**; all confirmed issues fixed. **785 tests green across net8/9/10** (+~35 new).

## NuGet README hotfix
- Dedicated pure-markdown `NUGET_README.md` (the GitHub README's centered `<p align=center>` hero rendered as raw HTML on nuget.org). Explains `init` is **non-destructive** (attaches/updates only).

## Tier 1 — richer, actionable suggestions
- Per-finding **Why** + **Fix** + auto-fixable tag + "N of M auto-fixable" hint surfaced in the **markdown** report (was JSON-only).
- Shows the **offending source line** (content-aware secret redaction — never echoes a key).
- `--all` **groups findings by rule** (×N, severity emoji, impact-ordered). New CLI `--json` flag. Additive JSON `why` field (schema_version stays "1").

## Tier 2 — grounded host-model explanation
- **`MafExplainFinding`** tool: returns the offending code in context + the rule's why/fix/auto-fixability — grounded substrate so the host model (Copilot/Claude/Cursor) explains + fixes without our own LLM budget.
- **`maf-explain-finding`** prompt drives that flow via `maf://constraints` + `maf://guide`.

## Tier 3 — `doctor --plan`
- Ordered, checkboxed **remediation plan** for a GitHub issue: Phase 1 batches the auto-fixable findings into one `autofix-all`; Phase 2 lists semantic fixes as impact-ordered `- [ ]` tasks. Never echoes a secret.

> **Version note:** csproj set to 1.3.0 as the local default; the canonical version is the `vX.Y.Z` tag pushed after merge (release.yml overrides from the tag). The held 1.2.12 README fix is folded into 1.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)