### PR TITLE
docs: 'New in 1.3.0' README highlight + quickstart polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+- README now leads with a **"New in 1.3.0"** highlight (Tiers 1–3 + the compile-verified auto-fixer).
+- Quickstart: added an **"explain a finding"** (`MafExplainFinding`) snippet for discoverability, and corrected the numbers — the sample reports **7** anti-pattern errors (was "ten"), and deterministic `autofix-all` takes it **F (7 → 4 errors)**, not "F → A" (Grade A is the `@maf-migration` agent phase, not the deterministic fixer).
+
 ## [1.3.0] - 2026-06-18
 
 Doctor-suggestions overhaul — three tiers that turn each finding from a terse label into something a developer can act on in one read. Each tier shipped after two adversarial multi-agent review passes.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ Plus a separate **maf-doctor.Analyzers** NuGet package with 3 Roslyn analyzers (
   <em>Install, then run maf-doctor doctor on any MAF codebase — an A–F health letter + the top fixes, in seconds.</em>
 </p>
 
+### 🆕 New in 1.3.0 — findings you can act on in one read
+
+Every finding now tells you **Why** it matters, the **Fix**, and whether it's auto-fixable:
+
+- **`doctor`** surfaces each finding's Why + Fix + the offending source line — `--all` groups every finding by rule, `--json` is machine-readable for CI.
+- **`doctor --plan`** emits an ordered, checkboxed remediation plan, ready to paste into a GitHub issue.
+- **`MafExplainFinding`** (in an MCP client) deep-dives any single finding by `file:line` — grounded explanation + fix using your host model (Copilot / Claude / Cursor), at no extra LLM cost.
+- The deterministic **auto-fixer is now compile-verified** — a CI guard compiles every rewriter's output, so a fix can never emit uncompilable code. ([full notes →](CHANGELOG.md#130---2026-06-18))
+
 ### What makes it worth trying
 
 - 🔍 **Catches the bugs that compile clean** — detects fan-out/fan-in silent failures where a workflow exits successfully but produces no output. Runtime-only, zero build signal, invisible without this tool.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,9 +39,11 @@ maf-doctor doctor .
 
 You'll see a **🔴 grade F** — with the top fixes. These include **silent fan-out/fan-in starvation** bugs: code that compiles clean and exits "successfully" but produces no output. No build warning, no exception — invisible without this tool.
 
-> 🎙️ *"Grade F. Ten anti-pattern errors, three of them silent-starvation risks — they compile clean and break at runtime."*
+> 🎙️ *"Grade F. Seven anti-pattern errors, plus three silent-starvation risks — they compile clean and break at runtime."*
 >
 > *Tip:* in a monorepo, scope the scan with `maf-doctor doctor . --exclude samples/ --exclude '**/*.Tests/**'`.
+
+> 💡 **New in 1.3.0:** every finding now shows a one-line **Why** + **Fix**. Add `--all` to list them all (grouped by rule), or `--plan` to get a checkboxed remediation plan you can paste straight into a GitHub issue. And in an MCP client (Copilot / Claude / Cursor), ask *"explain the finding at `Executors/OsintInvestigator.cs:25`"* — it calls **`MafExplainFinding`** to return that code in context + why + the fix, using your host model (no extra LLM cost).
 
 ## Beat 4 — Fix the mechanical issues, deterministically (30s)
 
@@ -56,9 +58,9 @@ maf-doctor autofix-all .
 maf-doctor doctor .
 ```
 
-Grade climbs to **🟢 A** (or close). The fixes are deterministic Roslyn rewriters — the same machinery you'd trust in a Microsoft refactor extension, not guesses.
+The grade stays **🔴 F** — but **three mechanical errors are gone (7 → 4)**, deterministically, in under 30 seconds, no LLM in the loop. The rest are *semantic* (a hard-coded key, shared provider state, the fan-out starvation bugs) and need judgment — that's the hand-off to the `@maf-migration` agent, which is what drives the grade to A. The fixes are deterministic Roslyn rewriters — the same machinery you'd trust in a Microsoft refactor extension, not guesses.
 
-> 🎙️ *"Apply for real. Roslyn rewriters. Re-grade — F to A in under 30 seconds, deterministically."*
+> 🎙️ *"Apply for real. Roslyn rewriters — three mechanical errors gone, 7 down to 4, deterministically, no LLM. The rest are semantic; the agent takes those the rest of the way to A."*
 
 ## Beat 5 — Upgrade to the latest MAF (60s)
 


### PR DESCRIPTION
Two doc "nice-to-haves" after the v1.3.0 release, plus a couple of honesty/count fixes found along the way.

## Changes
- **README** — adds a **"New in 1.3.0"** highlight up top: the Tier 1–3 actionable-findings features (`Why`/`Fix`, `--all`/`--json`, `doctor --plan`, `MafExplainFinding`) and the compile-verified auto-fixer.
- **Quickstart** — adds an **"explain a finding"** (`MafExplainFinding`) snippet so the MCP-only Tier 2 flow is discoverable.
- **Quickstart honesty/count fixes** (verified against real tool output on a temp copy of the sample):
  - Beat 3: "**Ten** anti-pattern errors" → "**Seven**" — the doctor reports 7 errors + 3 starvation.
  - Beat 4: "**Grade climbs to A** / F to A, deterministically" → the truth: deterministic `autofix-all` takes it **F (7 → 4 errors)**; Grade A is the `@maf-migration` agent phase, not the deterministic fixer. (Same honesty fix already shipped in `workshop.md` for 1.3.0.)
- **CHANGELOG [Unreleased]** — notes the doc corrections.

Docs-only; no code change.
