### PR TITLE
deps(nuget): Test.Sdk 18.6.0 + xunit.runner.visualstudio 3.1.5 (supersedes #63, #65)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,9 +33,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
 
     <!-- Test stack. Pinned to specific versions to keep CI deterministic. -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
 
     <!-- SourceLink (W.14 / AgentEval parity) — embedded source maps so


### PR DESCRIPTION
Bundles the two remaining Dependabot test-dependency bumps that couldn't auto-merge (their `Directory.Packages.props` lines were adjacent to already-merged bumps → conflict; Dependabot wouldn't rebase a manually-touched branch).

- **Microsoft.NET.Test.Sdk** 17.12.0 → 18.6.0 (was #65)
- **xunit.runner.visualstudio** 2.8.2 → 3.1.5 (was #63)

Verified locally: **864 tests green across net8/9/10**. Closes/supersedes #63 and #65.