### PR TITLE
release: 1.4.0 prep — version bump + doc-readiness fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-06-24
+
+Diagnose → triage → fix, end to end: human-readable `autofix-all`, a first-class finding **confidence** signal, the **`maf-remediate`** fix-it-all conductor (+ playbook skill), the **`doctor --plan --json`** manifest, and a false-positive hardening sweep across the detectors. Hardened by two multi-agent review passes (every finding verified) that also caught and fixed 3 real bugs. 922 tests green across net8/9/10.
+
 ### Added
 - **`doctor --plan --json` — structured remediation manifest.** The machine-readable sibling of `--plan`: a phased plan (Phase 1 = one `autofix-all` command + the rules it clears; Phase 2 = semantic findings grouped by rule) where every finding carries `confidence` + a `verify_first` flag and all its `occurrences`. Built so the `maf-remediate` loop can iterate deterministically and triage false positives without parsing markdown. `--plan` alone stays the human checklist; `--json` alone stays the flat findings array. (Schema v1; see docs/output-schemas.md.)
 - **Finding `confidence` for false-positive triage.** Every `doctor` finding now carries a `confidence` — `certain` (compiler ground-truth) / `high` (structural AST, low FP) / `heuristic` (name-only / text / scope-limited — verify before fixing), derived from the detector audit. Surfaced in the markdown report (heuristic non-auto findings tagged **"⚠ heuristic — verify it's real first"**), in `--plan` (a heuristic count + per-item marker), and in `--json` (additive `confidence` field, schema stays v1). Unknown rules default to `heuristic` (verify-first).
@@ -567,8 +571,10 @@ Internal alpha; superseded by `1.3.0-alpha-3`. Not announced.
 
 Initial MCP server prototype. Three tools (`MafApiSafety`, `MafRegistryLookup`, `MafRegistryList`), 11 skills, 2 agents, 10 registry entries. Validated against one real migration (`maf-claims-fraud-guardian` 1.2.0 → 1.3.0). Internal alpha; not announced.
 
-[Unreleased]: https://github.com/joslat/maf-autopilot/compare/v1.0.0...HEAD
-[1.0.0]: https://github.com/joslat/maf-autopilot/releases/tag/v1.0.0
+[Unreleased]: https://github.com/joslat/maf-doctor/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/joslat/maf-doctor/releases/tag/v1.4.0
+[1.3.0]: https://github.com/joslat/maf-doctor/releases/tag/v1.3.0
+[1.0.0]: https://github.com/joslat/maf-doctor/releases/tag/v1.0.0
 [1.3.0-alpha-3]: https://www.nuget.org/packages/maf-autopilot/1.3.0-alpha-3
 [1.3.0-alpha-2]: https://www.nuget.org/packages/maf-autopilot/1.3.0-alpha-2
 [1.3.0-alpha-1]: https://www.nuget.org/packages/maf-autopilot/1.3.0-alpha-1

--- a/NUGET_README.md
+++ b/NUGET_README.md
@@ -42,8 +42,10 @@ Uninstall is just as clean: `dotnet tool uninstall --global maf-doctor`, then de
 
 - 🔍 **Catches bugs that compile clean** — fan-out/fan-in silent failures where a workflow exits successfully but produces no output. Zero build signal.
 - 🩺 **Compiler ground-truth for CS0618** — obsolete-API usage mapped to its exact replacement pattern. Deterministic fixes, not hallucinated ones.
+- 🆕 **Confidence triage (1.4.0)** — every finding carries a `confidence` (`certain`/`high`/`heuristic`); the *heuristic* ones (likely false positives) are flagged "⚠ verify it's real first", in `doctor`, `--plan`, and `--json`.
+- 🆕 **`maf-remediate` — fix it all (1.4.0)** — an MCP prompt that grades, plans, runs `autofix-all`, then works each semantic finding *confirming heuristic ones before editing*, building + re-grading. Backed by the `maf-remediation-playbook` skill. `doctor --plan --json` gives an automatable manifest.
 - 🆕 **`doctor --all`** — list *every* finding (not just the top 3), grouped by rule and ordered by impact, each with a one-line *why* and the offending source line. Full triage in one pass.
-- 🆕 **`doctor --plan`** — turn the findings into an ordered, checkboxed **remediation plan** (Phase 1: one `autofix-all` for the mechanical fixes; Phase 2: the semantic fixes as impact-ordered tasks) you can drop straight into a GitHub issue.
+- 🆕 **`autofix-all` is human-readable** — a per-rule breakdown + changed files + next step by default (`--json` for the machine shape); the deterministic fixes turn the findings into an ordered, checkboxed **remediation plan** via `doctor --plan`.
 - 📖 **It updates itself** — a weekly GitHub Actions watcher refreshes the migration guide, compatibility matrix, and obsolete-API registry as new MAF versions ship, so you don't pin to a MAF version or wait on a maintainer release.
 - 🔐 **Security-hardened** — closes the named MCP attack lattice (path-escape, annotation drift, scaffold code-injection, prompt-injection, workflow-dispatch input injection). Cisco mcp-scanner: all tools SAFE, 0 findings.
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Plus a separate **maf-doctor.Analyzers** NuGet package with 3 Roslyn analyzers (
   <em>Install, then run maf-doctor doctor on any MAF codebase — an A–F health letter + the top fixes, in seconds.</em>
 </p>
 
-### 🆕 New in 1.3.0 — findings you can act on in one read
+### 🆕 New in 1.4.0 — diagnose → triage → fix, end to end
 
-Every finding now tells you **Why** it matters, the **Fix**, and whether it's auto-fixable:
+Findings you can act on, with the false positives flagged before you touch code:
 
-- **`doctor`** surfaces each finding's Why + Fix + the offending source line — `--all` groups every finding by rule, `--json` is machine-readable for CI.
-- **`doctor --plan`** emits an ordered, checkboxed remediation plan, ready to paste into a GitHub issue.
-- **`MafExplainFinding`** (in an MCP client) deep-dives any single finding by `file:line` — grounded explanation + fix using your host model (Copilot / Claude / Cursor), at no extra LLM cost.
-- The deterministic **auto-fixer is now compile-verified** — a CI guard compiles every rewriter's output, so a fix can never emit uncompilable code. ([full notes →](CHANGELOG.md#130---2026-06-18))
+- **`autofix-all` is human-readable by default** — a per-rule breakdown + the changed files + the next step (add `--json` for the machine-readable shape). The `0 files changed` case explains *why* and *what to do next*.
+- **Every finding carries a `confidence`** — `certain` / `high` / `heuristic`. The `heuristic` ones (name/text-based) are flagged **"⚠ verify it's real first"** — your false-positive triage signal, surfaced in `doctor`, `--plan`, and `--json`.
+- **`maf-remediate` — the fix-it-all conductor** (MCP prompt): grade → plan → `autofix-all` → work each semantic finding, **confirming heuristic ones before editing** → build → re-grade. Backed by the new **`maf-remediation-playbook`** skill. Just ask *"fix all the issues maf-doctor finds."*
+- **`doctor --plan --json`** — a structured, phased remediation manifest (per-finding `confidence` + `verify_first`) an automated loop can iterate.
+- **Fewer false positives** — a hardening sweep across the detectors (supported `Hosting.A2A` packages, MediatR `IMessageHandler<T>`, `app.RunAsync()` host calls, `AgentResponse<T>.Result`, `#if DEBUG` guards, … no longer mis-flagged). ([full notes →](CHANGELOG.md#140---2026-06-24))
 
 ### What makes it worth trying
 
@@ -91,10 +92,10 @@ maf-doctor --version                      # confirm
 cd your-maf-project && maf-doctor init    # re-run init to refresh the steering sidecars
 ```
 
-> ⚠️ **"The file is locked by another process" on update?** Your editor keeps the MCP server (`maf-doctor`) **running**, which locks the tool binary — so `dotnet tool update` can't replace it. Stop the running server first, then update:
+> ⚠️ **"The file is locked by another process" on update?** Your editor keeps the MCP server (`maf-doctor`) **running**, which locks the tool binary — so `dotnet tool update` can't replace it. Stop every running instance first, then update:
 >
 > ```powershell
-> # Windows: kill the running MCP server, then update
+> # Windows: kill all running instances, then update
 > Get-Process maf-doctor -ErrorAction SilentlyContinue | Stop-Process -Force
 > dotnet tool update --global maf-doctor
 > ```
@@ -102,7 +103,9 @@ cd your-maf-project && maf-doctor init    # re-run init to refresh the steering 
 > # macOS / Linux
 > pkill -f maf-doctor; dotnet tool update --global maf-doctor
 > ```
-> Or just **close the editor (or disable the maf-doctor MCP server) → update → reopen.** The editor relaunches the server automatically.
+> If you have **both** VS Code and Claude Code open, each holds its **own** lock — the commands above kill every instance (more reliable than closing editors one by one). Alternatively, close **all** editors running the server (or disable it in each) → update → reopen.
+>
+> **After updating:** re-run `maf-doctor init` to refresh the steering, **and reload the editor / MCP server** so it loads the new binary — VS Code: `Developer: Reload Window`; Claude Code: reload the project. (A bare restart isn't enough — the MCP host caches tool/resource descriptors, so without a full reload you'll keep talking to the old version.)
 
 > 📖 **Going deeper:** [what `init` installs (and why)](docs/init-reference.md) · [using MAF Doctor — prompts, tools, agents & natural-language steering](docs/usage.md) · [hands-on workshop](samples/workshop.md).
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,20 +1,20 @@
-# Troubleshooting maf-autopilot
+# Troubleshooting maf-doctor
 
 If you hit something that isn't here, please open an issue with the failing command and its output — the troubleshooting catalog grows from real reports.
 
 ## Installation
 
-### `dotnet tool install --global maf-autopilot` fails with "no compatible packages"
+### `dotnet tool install --global maf-doctor` fails with "no compatible packages"
 
-All published versions are currently prereleases (`1.3.0-alpha-1` … `1.3.0-alpha-3`). NuGet's tool installer ignores prereleases by default. Use:
+`maf-doctor` ships **stable** on NuGet, so the plain command works (no `--prerelease` flag needed):
 
 ```bash
-dotnet tool install --global maf-autopilot --prerelease
+dotnet tool install --global maf-doctor
 ```
 
-Once a stable `1.3.0` ships (plan row #50), the plain command will work.
+If you still hit "no compatible packages," your feed config is probably filtering nuget.org — confirm `dotnet nuget list source` includes `https://api.nuget.org/v3/index.json`. (The old `maf-autopilot` package is deprecated — install `maf-doctor`.)
 
-### `dotnet tool install` succeeds but `maf-autopilot` is not on PATH
+### `dotnet tool install` succeeds but `maf-doctor` is not on PATH
 
 `dotnet` installs global tools to `~/.dotnet/tools` (Linux/macOS) or `%USERPROFILE%\.dotnet\tools` (Windows). Add that directory to `PATH`:
 
@@ -26,18 +26,34 @@ export PATH="$PATH:$HOME/.dotnet/tools"
 [Environment]::SetEnvironmentVariable("Path", $env:Path + ";$env:USERPROFILE\.dotnet\tools", "User")
 ```
 
-### Update or downgrade
+### Update / upgrade (and the "file is locked" error)
 
 ```bash
-dotnet tool update --global maf-autopilot --prerelease
-dotnet tool uninstall --global maf-autopilot
+dotnet tool update --global maf-doctor
+dotnet tool uninstall --global maf-doctor   # if you need to remove it
 ```
 
-## `maf-autopilot init`
+> ⚠️ **Update fails with "The file is locked by another process"?** Your editor keeps the `maf-doctor` MCP server **running**, which holds the tool binary, so `dotnet tool update` can't replace it. Stop every running instance first, then update:
+>
+> ```powershell
+> # Windows — kills all running instances, then update
+> Get-Process maf-doctor -ErrorAction SilentlyContinue | Stop-Process -Force
+> dotnet tool update --global maf-doctor
+> ```
+> ```bash
+> # macOS / Linux
+> pkill -f maf-doctor; dotnet tool update --global maf-doctor
+> ```
+>
+> If you have **both** VS Code and Claude Code open, each holds its **own** lock — the `Stop-Process`/`pkill` commands above kill every instance (more reliable than closing editors one at a time). The alternative is to close **all** editors running the server (or disable it in each), update, then reopen.
+>
+> **After updating:** re-run `maf-doctor init` to refresh the steering sidecars, **and reload the editor / MCP server** so it loads the new binary — VS Code: `Developer: Reload Window`; Claude Code: reload the project. A bare process restart isn't enough: the MCP host caches tool/resource descriptors, so without a full reload you'll keep talking to the old version ("I upgraded but nothing changed").
+
+## `maf-doctor init`
 
 ### "⚠ .vscode/mcp.json exists but could not be parsed as JSON"
 
-Your existing `.vscode/mcp.json` has a syntax error (or trailing comments, which are not valid JSON). `init` has backed it up to `.vscode/mcp.json.bak.<UTC-timestamp>`. Inspect the backup, fix the JSON manually, then re-run `maf-autopilot init`.
+Your existing `.vscode/mcp.json` has a syntax error (or trailing comments, which are not valid JSON). `init` has backed it up to `.vscode/mcp.json.bak.<UTC-timestamp>`. Inspect the backup, fix the JSON manually, then re-run `maf-doctor init`.
 
 ### "ℹ .github/copilot-instructions.md already exists — not overwriting"
 
@@ -49,15 +65,15 @@ Currently `init` does not clean its own backups. Safe to delete them yourself on
 
 ### `mcp.json` had JSON-with-comments — was it backed up?
 
-VS Code officially treats `mcp.json` as JSONC: `//` line comments, `/* */` block comments, and trailing commas are valid. As of the post-2026-05-11 build, `maf-autopilot init` uses lenient JSONC parsing — your comment-bearing file is preserved untouched, no `.bak` is created, and the `maf-autopilot` server entry is merged in. If you see a `.bak.*` despite using only valid JSONC, you're on an older alpha. Update with `dotnet tool update --global maf-autopilot --prerelease`.
+VS Code officially treats `mcp.json` as JSONC: `//` line comments, `/* */` block comments, and trailing commas are valid. `maf-doctor init` uses lenient JSONC parsing — your comment-bearing file is preserved untouched, no `.bak` is created, and the `maf-doctor` server entry is merged in. If you see a `.bak.*` despite using only valid JSONC, you're on an older build — update with `dotnet tool update --global maf-doctor`.
 
 ## MCP server not visible in Copilot Chat
 
-### "Server: maf-autopilot is not connected"
+### "Server: maf-doctor is not connected"
 
 1. Open the **Output** panel → channel **MCP**. If startup failed, the stack trace is there.
-2. Confirm `.vscode/mcp.json` lists `maf-autopilot` under `servers`. Run `maf-autopilot init` if not.
-3. Confirm the command resolves: in a terminal, run `maf-autopilot --version` (or just `maf-autopilot` and Ctrl-C). If "command not found," go back to the PATH section above.
+2. Confirm `.vscode/mcp.json` lists `maf-doctor` under `servers`. Run `maf-doctor init` if not.
+3. Confirm the command resolves: in a terminal, run `maf-doctor --version` (or just `maf-doctor` and Ctrl-C). If "command not found," go back to the PATH section above.
 4. Reload VS Code (`Developer: Reload Window`). MCP servers are started on workspace load.
 
 ### Tools appear but resources don't (or vice versa)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -23,7 +23,7 @@ dotnet tool update --global maf-doctor
 
 > 🎙️ *"One global tool. It's an MCP server for Copilot/Claude/Cursor **and** a standalone CLI — we'll use the CLI."*
 >
-> ⚠️ **Upgrade says "file is locked by another process"?** Your editor keeps the MCP server (`maf-doctor`) running, which locks the binary. Kill it first, then update — `Get-Process maf-doctor | Stop-Process -Force` (Windows) / `pkill -f maf-doctor` (macOS/Linux), or just close the editor → update → reopen. After upgrading, re-run `maf-doctor init` to refresh the steering.
+> ⚠️ **Upgrade says "file is locked by another process"?** Your editor keeps the MCP server (`maf-doctor`) running, which locks the binary. Kill **every** instance first (both VS Code and Claude Code if open) — `Get-Process maf-doctor | Stop-Process -Force` (Windows) / `pkill -f maf-doctor` (macOS/Linux) — then update. **After upgrading**, re-run `maf-doctor init` and **reload the editor** (VS Code: `Developer: Reload Window`) so it loads the new binary; a bare restart keeps the cached old descriptors. (Full guide: [TROUBLESHOOTING.md](../TROUBLESHOOTING.md).)
 
 ## Beat 2 — Drop it into a repo (20s)
 
@@ -48,7 +48,7 @@ You'll see a **🔴 grade F** — with the top fixes. These include **silent fan
 >
 > *Tip:* in a monorepo, scope the scan with `maf-doctor doctor . --exclude samples/ --exclude '**/*.Tests/**'`.
 
-> 💡 **New in 1.3.0:** every finding now shows a one-line **Why** + **Fix**. Add `--all` to list them all (grouped by rule), or `--plan` to get a checkboxed remediation plan you can paste straight into a GitHub issue. And in an MCP client (Copilot / Claude / Cursor), ask *"explain the finding at `Executors/OsintInvestigator.cs:25`"* — it calls **`MafExplainFinding`** to return that code in context + why + the fix, using your host model (no extra LLM cost).
+> 💡 **Act on it:** every finding shows a one-line **Why** + **Fix** and a **`confidence`** (`certain`/`high`/`heuristic` — *heuristic* ones are flagged "⚠ verify it's real first", your false-positive signal). Add `--all` to list them grouped by rule, `--plan` for a checkboxed remediation plan (`--plan --json` for a structured manifest). In an MCP client (Copilot / Claude / Cursor), ask *"explain the finding at `Executors/OsintInvestigator.cs:25`"* — it calls **`MafExplainFinding`** to return that code in context + why + fix, using your host model (no extra LLM cost).
 
 ## Beat 4 — Fix the mechanical issues, deterministically (30s)
 

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -14,7 +14,7 @@
 
     <!-- NuGet packaging -->
     <PackageId>maf-doctor.Analyzers</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Authors>joslat</Authors>
     <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) — write-time enforcement of fan-out safety, secure credentials, and observability defaults (MAF001-MAF003). Companion to the maf-doctor .NET global tool / MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -17,7 +17,7 @@
          release.yml overrides this from the pushed tag and keeps the analyzer
          package in lockstep, so the canonical version is the git tag (`vX.Y.Z`).
          This value is the local/dev default. -->
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Authors>joslat</Authors>
     <Description>MAF Doctor — a .NET global tool and MCP server for Microsoft Agent Framework (MAF). Diagnoses, explains, and auto-fixes MAF agents and workflows: A-F health grades, deterministic Roslyn rewriters, anti-pattern and fan-out scanning, and a self-updating obsolete-API registry. Use it from Copilot / Claude / Cursor via MCP, or standalone as a CLI.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>


### PR DESCRIPTION
Prep for the **1.4.0** release (follows #114). A multi-agent doc-readiness review (every finding verified) ahead of the irreversible NuGet publish.

## Changes
- **Version → 1.4.0** in both csprojs; **CHANGELOG** `[Unreleased]` → `[1.4.0] - 2026-06-24` + link refs to `joslat/maf-doctor`.
- **TROUBLESHOOTING.md** — was entirely pre-rename (the page upgraders land on). Rewrote install/update/init/server sections to `maf-doctor`, removed the false "only alphas published / use `--prerelease`" story, added the file-lock-on-update fix + editor-reload + multi-editor guidance. *(2 × high findings.)*
- **README** — "New in 1.3.0" → **"New in 1.4.0"** (confidence triage, `maf-remediate` + playbook, `--plan --json`, human `autofix-all`, FP hardening), changelog deep-link fixed to the 1.4.0 anchor; upgrade block adds the reload-after-update step (cached descriptors) + multi-editor note.
- **quickstart** — same upgrade/reload guidance; the "act on it" callout adds the confidence signal.
- **NUGET_README** (baked into the package) — Highlights now lead with the 1.4.0 story.

## After merge
Tag `v1.4.0` → `release.yml` runs the full suite across net8/9/10, packs both nupkgs, publishes to NuGet + GHCR, and creates the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
