### PR TITLE
fix(docker): include docs/migration/ so the GHCR image build finds the SK→MAF resource

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,10 @@
 docs
 !docs/steering
 !docs/steering/**
+# docs/migration/ is embedded as a csproj resource (SK→MAF guide, added 1.5.0);
+# it must be in the build context or in-Docker `dotnet publish` fails (CS1566).
+!docs/migration
+!docs/migration/**
 guides
 !guides
 src/maf-autopilot.Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,10 @@ COPY src/maf-autopilot/ src/maf-autopilot/
 COPY .github/ .github/
 COPY guides/ guides/
 COPY docs/steering/ docs/steering/
+# docs/migration/ holds the SK→MAF migration guide embedded as a resource in the
+# csproj (LogicalName migrate-from/semantic-kernel.md, added in 1.5.0). Without
+# this the in-Docker `dotnet publish` fails with CS1566 (missing resource file).
+COPY docs/migration/ docs/migration/
 COPY README.md ./
 
 # Publish a single TFM (net10.0 — matches the runtime image below). Required


### PR DESCRIPTION
**Fixes the "Publish Docker image to GHCR" failure that's been red since v1.5.0** (v1.5.0/1.6.0/1.7.0 all failed; v1.4.0 and earlier passed). The NuGet release is unaffected — release.yml builds on a full checkout, so `maf-doctor` kept publishing.

**Root cause:** the csproj embeds `docs/migration/from-semantic-kernel-to-maf.md` (added with the SK→MAF migration feature in 1.5.0), but `.dockerignore` excludes `docs/` (only `docs/steering` was re-included) and the Dockerfile never COPYd `docs/migration/`. So the in-Docker `dotnet publish` failed with `CS1566: Error reading resource ... Could not find ... docs/migration/from-semantic-kernel-to-maf.md`.

**Fix:** un-exclude `docs/migration` in `.dockerignore` + `COPY docs/migration/` in the Dockerfile.

**Validated locally:** `docker build --target build .` now completes the `dotnet publish` step (exit 0). After merge I'll re-dispatch docker-publish for v1.7.0 to publish the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)