### PR TITLE
Add MCP update and init freshness checks

### DIFF
--- a/NUGET_README.md
+++ b/NUGET_README.md
@@ -33,7 +33,7 @@ Uninstall is just as clean: `dotnet tool uninstall --global maf-doctor`, then de
 
 ## What you get
 
-- **MCP server** — 27 tools, 7 resources, and 10 prompts for GitHub Copilot / Claude Code / Cursor.
+- **MCP server** — 28 tools, 7 resources, and 10 prompts for GitHub Copilot / Claude Code / Cursor.
 - **CLI** — `doctor`, `autofix-all`, `new agent`, `migrate-scan`, `init`, and more.
 - **Plugin** — 14 bundled skills + 8 specialist agents wired into Copilot's and Claude's agentic loops.
 - A companion **[maf-doctor.Analyzers](https://www.nuget.org/packages/maf-doctor.Analyzers)** package — 3 Roslyn analyzers (MAF001 / MAF002 / MAF003) for IDE write-time enforcement.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The practical upshot: you don't pin to a MAF version in these docs, and you don'
 
 MAF Doctor is a **[Model Context Protocol (MCP)](https://modelcontextprotocol.io) server** packaged as a .NET global tool. With no subcommand it runs in MCP mode and exposes:
 
-- **27 executable tools**, each annotated with MCP behavior hints (read-only / destructive / idempotent / open-world) so clients can auto-classify them — registry lookup, code scanning, build-verified CS0618 hunts, NuGet diffing, workflow simulation, scaffolding, cross-framework (Semantic Kernel → MAF) migration scanning, PR-scoped audits, version planning, and a single-command health letter. The anti-pattern and fan-out scanners emit SARIF for GitHub Advanced Security; the two destructive tools (auto-fix and auto-fix-all) support a dry-run.
+- **28 executable tools**, each annotated with MCP behavior hints (read-only / destructive / idempotent / open-world) so clients can auto-classify them — registry lookup, code scanning, build-verified CS0618 hunts, NuGet diffing, workflow simulation, scaffolding, cross-framework (Semantic Kernel → MAF) migration scanning, PR-scoped audits, version planning, MCP/update status, and a single-command health letter. The anti-pattern and fan-out scanners emit SARIF for GitHub Advanced Security; the two destructive tools (auto-fix and auto-fix-all) support a dry-run.
 - **7 resources** — the migration guide, constraints, registry, rules, help, the Semantic Kernel → MAF mapping, and per-name skills — readable on demand.
 - **10 prompts** — audit, migrate, remediate, migrate-from, cs0618-hunt, review, debug, explain-finding, scaffold, and help.
 - **3 Roslyn analyzers** (in the separate maf-doctor.Analyzers package) — MAF001 (fan-out), MAF002 (DefaultAzureCredential), MAF003 (EnableSensitiveData). Write-time enforcement.
@@ -94,6 +94,8 @@ maf-doctor init
 `init` is **non-destructive — it attaches and updates only, never overwriting your files.** It adds its own MCP server entry to both **VS Code** (.vscode/mcp.json) and **Claude Code** (.mcp.json), and drops auto-loaded steering as self-contained sidecars in each tool's convention dir — .github/instructions/ for Copilot, .claude/ plus a one-line CLAUDE.md import for Claude Code, and an AGENTS.md managed block. These sidecars are refreshed on every re-run and never merged into your hand-authored files, so re-running `init` after an upgrade is always safe. Your assistant picks the server up automatically and gains live tool calls, resource reads, and structured prompts.
 
 #### Keeping it up to date
+
+When the MCP server starts, it checks NuGet for a newer `maf-doctor` package using a short, cached, non-blocking advisory check. It also detects the separate case where the installed tool is current but this workspace's MCP config or steering sidecars were initialized by an older `maf-doctor`. You can ask for the same report any time with the `MafDoctorStatus` MCP tool.
 
 ```powershell
 dotnet tool update --global maf-doctor   # upgrade to the latest release

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -85,7 +85,7 @@ The MCP server, the analyzer NuGet, and the skill bundle are independently shipp
 
 **What it does:**
 - Speaks MCP over stdio (when run as a tool) or stdio-in-container (when run via Docker).
-- Exposes **27 tools** (`[McpServerTool]`-decorated methods under `Tools/*.cs`) — see the README for the live catalogue.
+- Exposes **28 tools** (`[McpServerTool]`-decorated methods under `Tools/*.cs`) — see the README for the live catalogue.
 - Exposes **7 resources** (`maf://guide`, `maf://constraints`, `maf://registry`, `maf://rules`, `maf://help`, `maf://migrate-from?source=...`, `maf://skills?name=...`).
 - Exposes **10 prompts** (`maf-audit`, `maf-migrate`, `maf-remediate`, `maf-migrate-from`, `maf-cs0618-hunt`, `maf-review`, `maf-debug`, `maf-explain-finding`, `maf-scaffold`, `maf-help`).
 - Provides **CLI subcommands**: `init` (wires `.vscode/mcp.json`), `doctor` (health grade), `autofix-all`, `new agent` / `new executor` (scaffolders), `migrate-scan` (SK→MAF inventory), `badge`, `verify-registry` / `registry-extract` (CI helpers).

--- a/docs/init-reference.md
+++ b/docs/init-reference.md
@@ -35,8 +35,20 @@ maf-doctor init --with-cursor   # also the Cursor rule
 ## Safety / idempotency
 
 - **MCP config is merge-not-overwrite:** init parses your existing `mcp.json` / `.mcp.json` (JSONC-tolerant — `//` comments + trailing commas allowed), adds only the `maf-doctor` entry, and preserves every other server and top-level key. It also recognizes a legacy `maf-autopilot` server key so a repo configured by a pre-rename build isn't double-entered.
+- **Managed entry is repaired:** if the `maf-doctor` entry already exists but points at an old command, has stale args, or was written by an older `maf-doctor`, init rewrites only that managed entry and preserves unrelated servers. The entry carries `MAF_DOCTOR_INIT_VERSION` so the MCP startup/status check can distinguish "tool package is current" from "this workspace only needs init refreshed."
 - **Corruption-safe:** if an existing config can't be parsed, init backs it up to `*.bak.<timestamp>` before writing (and caps the read at 1 MB so a malformed file can't OOM the host).
 - **Re-runnable:** run `init` again any time to refresh the steering to the installed version — sidecars are rewritten, the `CLAUDE.md` import and `AGENTS.md` block are upserted, never duplicated.
+
+## Update / init freshness checks
+
+On MCP startup, `maf-doctor` performs a short advisory check against NuGet. If a newer global tool package exists, the MCP server logs the exact update flow:
+
+```bash
+dotnet tool update --global maf-doctor
+maf-doctor init
+```
+
+If the package is already current but this workspace was initialized by an older tool, the notice only asks you to run `maf-doctor init`. The same information is available on demand through the `MafDoctorStatus` MCP tool.
 
 ## After `init`
 

--- a/src/maf-autopilot.Tests/InitCommandTests.cs
+++ b/src/maf-autopilot.Tests/InitCommandTests.cs
@@ -384,4 +384,16 @@ public sealed class InitCommandTests : IDisposable
         Assert.Contains("Project-specific notes.", content);
         Assert.Contains("<!-- BEGIN maf-doctor", content);
     }
+
+      [Fact]
+      public void GetWorkspaceInitStatus_LargeMarkerFile_DoesNotReadWholeFile()
+      {
+        var claudeMd = Path.Combine(_tempDir, "CLAUDE.md");
+        File.WriteAllText(claudeMd, new string('x', 1024 * 1024 + 1));
+
+        var status = InitCommand.GetWorkspaceInitStatus(_tempDir);
+
+        Assert.Contains(status.Findings,
+          finding => finding.Contains("CLAUDE.md exceeds the 1 MB marker-scan safety cap", StringComparison.Ordinal));
+      }
 }

--- a/src/maf-autopilot.Tests/InitCommandTests.cs
+++ b/src/maf-autopilot.Tests/InitCommandTests.cs
@@ -397,9 +397,9 @@ public sealed class InitCommandTests : IDisposable
             finding => finding.Contains("CLAUDE.md exceeds the 1 MB marker-scan safety cap", StringComparison.Ordinal));
     }
 
-      [Fact]
-      public async Task FindInitializedWorkspaceRoot_WalksUpFromSubdirectory()
-      {
+    [Fact]
+    public async Task FindInitializedWorkspaceRoot_WalksUpFromSubdirectory()
+    {
         await InitCommand.WriteMcpJsonAsync(_tempDir);
         var nested = Path.Combine(_tempDir, "src", "app");
         Directory.CreateDirectory(nested);
@@ -407,5 +407,5 @@ public sealed class InitCommandTests : IDisposable
         var root = InitCommand.FindInitializedWorkspaceRoot(nested);
 
         Assert.Equal(Path.GetFullPath(_tempDir), root);
-      }
+    }
 }

--- a/src/maf-autopilot.Tests/InitCommandTests.cs
+++ b/src/maf-autopilot.Tests/InitCommandTests.cs
@@ -385,15 +385,15 @@ public sealed class InitCommandTests : IDisposable
         Assert.Contains("<!-- BEGIN maf-doctor", content);
     }
 
-      [Fact]
-      public void GetWorkspaceInitStatus_LargeMarkerFile_DoesNotReadWholeFile()
-      {
+    [Fact]
+    public void GetWorkspaceInitStatus_LargeMarkerFile_DoesNotReadWholeFile()
+    {
         var claudeMd = Path.Combine(_tempDir, "CLAUDE.md");
         File.WriteAllText(claudeMd, new string('x', 1024 * 1024 + 1));
 
         var status = InitCommand.GetWorkspaceInitStatus(_tempDir);
 
         Assert.Contains(status.Findings,
-          finding => finding.Contains("CLAUDE.md exceeds the 1 MB marker-scan safety cap", StringComparison.Ordinal));
-      }
+            finding => finding.Contains("CLAUDE.md exceeds the 1 MB marker-scan safety cap", StringComparison.Ordinal));
+    }
 }

--- a/src/maf-autopilot.Tests/InitCommandTests.cs
+++ b/src/maf-autopilot.Tests/InitCommandTests.cs
@@ -396,4 +396,16 @@ public sealed class InitCommandTests : IDisposable
         Assert.Contains(status.Findings,
             finding => finding.Contains("CLAUDE.md exceeds the 1 MB marker-scan safety cap", StringComparison.Ordinal));
     }
+
+      [Fact]
+      public async Task FindInitializedWorkspaceRoot_WalksUpFromSubdirectory()
+      {
+        await InitCommand.WriteMcpJsonAsync(_tempDir);
+        var nested = Path.Combine(_tempDir, "src", "app");
+        Directory.CreateDirectory(nested);
+
+        var root = InitCommand.FindInitializedWorkspaceRoot(nested);
+
+        Assert.Equal(Path.GetFullPath(_tempDir), root);
+      }
 }

--- a/src/maf-autopilot.Tests/InitCommandTests.cs
+++ b/src/maf-autopilot.Tests/InitCommandTests.cs
@@ -46,6 +46,8 @@ public sealed class InitCommandTests : IDisposable
         Assert.Equal("stdio", servers["maf-doctor"]!["type"]!.GetValue<string>());
         // Brand key is maf-doctor; the command stays the frozen binary maf-doctor.
         Assert.Equal("maf-doctor", servers["maf-doctor"]!["command"]!.GetValue<string>());
+        Assert.Equal(InitCommand.CurrentVersion,
+          servers["maf-doctor"]!["env"]![InitCommand.InitVersionEnvName]!.GetValue<string>());
     }
 
     [Fact]
@@ -251,9 +253,45 @@ public sealed class InitCommandTests : IDisposable
 
         var root = JsonNode.Parse(await File.ReadAllTextAsync(path))!.AsObject();
         var servers = root["mcpServers"]!.AsObject();
-        Assert.True(servers.ContainsKey("maf-autopilot"));
-        Assert.False(servers.ContainsKey("maf-doctor"),
-            "Legacy maf-autopilot key must be recognized so no duplicate maf-doctor entry is added.");
+        Assert.False(servers.ContainsKey("maf-autopilot"));
+        Assert.True(servers.ContainsKey("maf-doctor"));
+        Assert.Equal("maf-doctor", servers["maf-doctor"]!["command"]!.GetValue<string>());
+        Assert.False(servers["maf-doctor"]!.AsObject().ContainsKey("type"));
+        Assert.Equal(InitCommand.CurrentVersion,
+            servers["maf-doctor"]!["env"]![InitCommand.InitVersionEnvName]!.GetValue<string>());
+    }
+
+    [Fact]
+    public async Task WriteMcpJsonAsync_StaleManagedEntry_IsRepaired()
+    {
+        var vscodeDir = Path.Combine(_tempDir, ".vscode");
+        Directory.CreateDirectory(vscodeDir);
+        var mcpJsonPath = Path.Combine(vscodeDir, "mcp.json");
+        await File.WriteAllTextAsync(mcpJsonPath, """
+            {
+              "servers": {
+                "maf-doctor": {
+                  "type": "stdio",
+                  "command": "maf-autopilot",
+                  "args": ["--old"],
+                  "env": { "KEEP_ME": "yes" }
+                },
+                "other": { "type": "stdio", "command": "node" }
+              }
+            }
+            """);
+
+        await InitCommand.WriteMcpJsonAsync(_tempDir);
+
+        var root = JsonNode.Parse(await File.ReadAllTextAsync(mcpJsonPath))!.AsObject();
+        var servers = root["servers"]!.AsObject();
+        Assert.True(servers.ContainsKey("other"));
+        var entry = servers["maf-doctor"]!.AsObject();
+        Assert.Equal("maf-doctor", entry["command"]!.GetValue<string>());
+        Assert.Empty(entry["args"]!.AsArray());
+        Assert.Equal("yes", entry["env"]!["KEEP_ME"]!.GetValue<string>());
+        Assert.Equal(InitCommand.CurrentVersion,
+            entry["env"]![InitCommand.InitVersionEnvName]!.GetValue<string>());
     }
 
     // -------------------------------------------------------------------------

--- a/src/maf-autopilot.Tests/UpdateAdvisorTests.cs
+++ b/src/maf-autopilot.Tests/UpdateAdvisorTests.cs
@@ -24,6 +24,8 @@ public sealed class UpdateAdvisorTests
     [InlineData("v1.8.0+abc123", "1.8.0", 0)]
     [InlineData("1.8", "1.8.0", 0)]
     [InlineData("1.7.9", "1.8.0", -1)]
+    [InlineData("1.8.0-beta.1", "1.8.0", -1)]
+    [InlineData("1.8.0", "1.8.0-beta.1", 1)]
     public void CompareSemanticVersions_HandlesCommonNuGetShapes(string left, string right, int expectedSign)
     {
         var comparison = UpdateAdvisor.CompareSemanticVersions(left, right);

--- a/src/maf-autopilot.Tests/UpdateAdvisorTests.cs
+++ b/src/maf-autopilot.Tests/UpdateAdvisorTests.cs
@@ -1,0 +1,33 @@
+using MafDoctor;
+using Xunit;
+
+namespace MafDoctor.Tests;
+
+public sealed class UpdateAdvisorTests
+{
+    [Fact]
+    public void ParseLatestStableVersion_IgnoresPrereleaseAndPicksHighestStable()
+    {
+        const string json = """
+            {
+              "versions": ["1.8.0", "1.9.0-beta.1", "1.10.0", "1.9.1"]
+            }
+            """;
+
+        var latest = UpdateAdvisor.ParseLatestStableVersion(json);
+
+        Assert.Equal("1.10.0", latest);
+    }
+
+    [Theory]
+    [InlineData("1.10.0", "1.9.9", 1)]
+    [InlineData("v1.8.0+abc123", "1.8.0", 0)]
+    [InlineData("1.8", "1.8.0", 0)]
+    [InlineData("1.7.9", "1.8.0", -1)]
+    public void CompareSemanticVersions_HandlesCommonNuGetShapes(string left, string right, int expectedSign)
+    {
+        var comparison = UpdateAdvisor.CompareSemanticVersions(left, right);
+
+        Assert.Equal(expectedSign, Math.Sign(comparison));
+    }
+}

--- a/src/maf-autopilot/InitCommand.cs
+++ b/src/maf-autopilot/InitCommand.cs
@@ -37,6 +37,7 @@ internal static class InitCommand
     };
 
     private const long McpJsonMaxBytes = 1 * 1024 * 1024;
+    private const long MarkerFileMaxBytes = 1 * 1024 * 1024;
 
     /// <summary>
     /// Copies the file to a backup path with a unique suffix, retrying on collision.
@@ -404,6 +405,13 @@ internal static class InitCommand
         if (!File.Exists(path))
         {
             findings.Add($"{relativePath} is missing");
+            return;
+        }
+
+        var info = new FileInfo(path);
+        if (info.Length > MarkerFileMaxBytes)
+        {
+            findings.Add($"{relativePath} exceeds the 1 MB marker-scan safety cap; run init to refresh the managed marker manually");
             return;
         }
 

--- a/src/maf-autopilot/InitCommand.cs
+++ b/src/maf-autopilot/InitCommand.cs
@@ -330,6 +330,23 @@ internal static class InitCommand
         return new InitStatus(findings.Count == 0, findings);
     }
 
+    internal static string FindInitializedWorkspaceRoot(string startDir)
+    {
+        var current = new DirectoryInfo(Path.GetFullPath(startDir));
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, ".mcp.json")) ||
+                File.Exists(Path.Combine(current.FullName, ".vscode", "mcp.json")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        return Path.GetFullPath(startDir);
+    }
+
     private static void InspectMcpConfig(
         string path,
         string serversKey,

--- a/src/maf-autopilot/InitCommand.cs
+++ b/src/maf-autopilot/InitCommand.cs
@@ -24,6 +24,8 @@ namespace MafDoctor;
 /// </summary>
 internal static class InitCommand
 {
+    internal const string InitVersionEnvName = "MAF_DOCTOR_INIT_VERSION";
+
     /// <summary>
     /// VS Code's mcp.json is JSONC — supports // line comments, /* block */ comments,
     /// and trailing commas. Use these options instead of strict JSON parsing.
@@ -33,6 +35,8 @@ internal static class InitCommand
         CommentHandling = JsonCommentHandling.Skip,
         AllowTrailingCommas = true,
     };
+
+    private const long McpJsonMaxBytes = 1 * 1024 * 1024;
 
     /// <summary>
     /// Copies the file to a backup path with a unique suffix, retrying on collision.
@@ -56,6 +60,19 @@ internal static class InitCommand
         throw new IOException(
             $"Could not create a unique backup for '{originalPath}' after 5 attempts. " +
             $"Check that the directory is writable.");
+    }
+
+    internal static string CurrentVersion
+    {
+        get
+        {
+            var raw = Assembly.GetExecutingAssembly()
+                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+                ?? "unknown";
+            var plus = raw.IndexOf('+');
+            return plus >= 0 ? raw[..plus] : raw;
+        }
     }
 
     public static async Task<int> RunAsync(string[]? args = null)
@@ -148,7 +165,6 @@ internal static class InitCommand
         // Security: cap the JSON read at 1 MB. A malicious or corrupt config (from a
         // template repo, a stale upstream, or a paste accident) could otherwise OOM the
         // host on the very first `maf-doctor init`. Real config files are kilobytes at most.
-        const long McpJsonMaxBytes = 1 * 1024 * 1024;
         JsonObject root;
         if (File.Exists(mcpJsonPath))
         {
@@ -188,27 +204,217 @@ internal static class InitCommand
 
         var servers = root[serversKey]!.AsObject();
 
-        // Server key + command are both "maf-doctor" (full rename). Recognize the
-        // LEGACY "maf-autopilot" server key too, so re-running init on a repo
-        // configured by a pre-rename build doesn't add a duplicate entry.
-        if (servers.ContainsKey("maf-doctor") || servers.ContainsKey("maf-autopilot"))
+        var changed = UpsertCanonicalMcpEntry(servers, includeType, out var action);
+        if (!changed)
         {
-            Console.WriteLine($"  ✓ {label} — MAF Doctor server entry already present, no change");
+            Console.WriteLine($"  ✓ {label} — MAF Doctor server entry already current");
             return;
         }
 
-        // Add the global-tool entry (assumes `dotnet tool install -g maf-doctor`).
-        // VS Code wants an explicit "type": "stdio"; Claude Code's .mcp.json omits it.
-        var entry = new JsonObject();
-        if (includeType) entry["type"] = "stdio";
-        entry["command"] = "maf-doctor";
-        entry["args"] = new JsonArray();
-        entry["env"] = new JsonObject();
-        servers["maf-doctor"] = entry;
-
         var json = root.ToJsonString(new JsonSerializerOptions { WriteIndented = true });
         await File.WriteAllTextAsync(mcpJsonPath, json + Environment.NewLine);
-        Console.WriteLine($"  ✓ {label} — added MAF Doctor (maf-doctor) global-tool server entry");
+        Console.WriteLine($"  ✓ {label} — {action}");
+    }
+
+    internal static bool UpsertCanonicalMcpEntry(JsonObject servers, bool includeType, out string action)
+    {
+        var changed = false;
+        action = "updated MAF Doctor (maf-doctor) global-tool server entry";
+
+        JsonObject entry;
+        if (servers.TryGetPropertyValue("maf-doctor", out var existing) && existing is JsonObject existingObject)
+        {
+            entry = existingObject;
+        }
+        else if (servers.TryGetPropertyValue("maf-autopilot", out var legacy) && legacy is JsonObject legacyObject)
+        {
+            servers.Remove("maf-autopilot");
+            entry = legacyObject;
+            servers["maf-doctor"] = entry;
+            changed = true;
+            action = "migrated legacy maf-autopilot entry to maf-doctor and refreshed it";
+        }
+        else
+        {
+            entry = new JsonObject();
+            servers["maf-doctor"] = entry;
+            changed = true;
+            action = "added MAF Doctor (maf-doctor) global-tool server entry";
+        }
+
+        if (includeType)
+        {
+            changed |= SetString(entry, "type", "stdio");
+        }
+        else if (entry.Remove("type"))
+        {
+            changed = true;
+        }
+
+        changed |= SetString(entry, "command", "maf-doctor");
+        changed |= SetEmptyArray(entry, "args");
+        changed |= SetInitEnv(entry);
+
+        return changed;
+    }
+
+    private static bool SetString(JsonObject obj, string propertyName, string value)
+    {
+        if (obj.TryGetPropertyValue(propertyName, out var existing) &&
+            existing is JsonValue existingValue &&
+            existingValue.TryGetValue<string>(out var existingString) &&
+            string.Equals(existingString, value, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        obj[propertyName] = value;
+        return true;
+    }
+
+    private static bool SetEmptyArray(JsonObject obj, string propertyName)
+    {
+        if (obj.TryGetPropertyValue(propertyName, out var existing) &&
+            existing is JsonArray existingArray &&
+            existingArray.Count == 0)
+        {
+            return false;
+        }
+
+        obj[propertyName] = new JsonArray();
+        return true;
+    }
+
+    private static bool SetInitEnv(JsonObject entry)
+    {
+        var changed = false;
+        JsonObject env;
+        if (entry.TryGetPropertyValue("env", out var existing) && existing is JsonObject existingEnv)
+        {
+            env = existingEnv;
+        }
+        else
+        {
+            env = new JsonObject();
+            entry["env"] = env;
+            changed = true;
+        }
+
+        changed |= SetString(env, InitVersionEnvName, CurrentVersion);
+        return changed;
+    }
+
+    internal static InitStatus GetWorkspaceInitStatus(string targetDir)
+    {
+        var findings = new List<string>();
+
+        InspectMcpConfig(
+            Path.Combine(targetDir, ".vscode", "mcp.json"),
+            serversKey: "servers",
+            includeType: true,
+            label: ".vscode/mcp.json",
+            findings);
+        InspectMcpConfig(
+            Path.Combine(targetDir, ".mcp.json"),
+            serversKey: "mcpServers",
+            includeType: false,
+            label: ".mcp.json",
+            findings);
+
+        RequireFile(targetDir, ".github/instructions/maf-doctor.instructions.md", findings);
+        RequireFile(targetDir, ".claude/maf-doctor.md", findings);
+        RequireText(targetDir, "CLAUDE.md", "@.claude/maf-doctor.md", findings);
+        RequireText(targetDir, "AGENTS.md", "<!-- BEGIN maf-doctor", findings);
+
+        return new InitStatus(findings.Count == 0, findings);
+    }
+
+    private static void InspectMcpConfig(
+        string path,
+        string serversKey,
+        bool includeType,
+        string label,
+        List<string> findings)
+    {
+        if (!File.Exists(path))
+        {
+            findings.Add($"{label} is missing");
+            return;
+        }
+
+        var info = new FileInfo(path);
+        if (info.Length > McpJsonMaxBytes)
+        {
+            findings.Add($"{label} exceeds the 1 MB safety cap and should be repaired by init");
+            return;
+        }
+
+        JsonObject root;
+        try
+        {
+            root = JsonNode.Parse(File.ReadAllText(path), nodeOptions: null, documentOptions: JsoncOptions)!.AsObject();
+        }
+        catch
+        {
+            findings.Add($"{label} cannot be parsed and should be repaired by init");
+            return;
+        }
+
+        if (root[serversKey] is not JsonObject servers)
+        {
+            findings.Add($"{label} has no {serversKey} object");
+            return;
+        }
+
+        if (servers.ContainsKey("maf-autopilot"))
+            findings.Add($"{label} still uses the legacy maf-autopilot server key");
+
+        if (servers["maf-doctor"] is not JsonObject entry)
+        {
+            findings.Add($"{label} has no maf-doctor server entry");
+            return;
+        }
+
+        if (includeType && !StringPropertyEquals(entry, "type", "stdio"))
+            findings.Add($"{label} maf-doctor entry should declare type=stdio");
+        if (!includeType && entry.ContainsKey("type"))
+            findings.Add($"{label} maf-doctor entry should omit type for Claude Code");
+        if (!StringPropertyEquals(entry, "command", "maf-doctor"))
+            findings.Add($"{label} maf-doctor entry should run command=maf-doctor");
+        if (entry["args"] is not JsonArray args || args.Count != 0)
+            findings.Add($"{label} maf-doctor entry should use an empty args array");
+        if (entry["env"] is not JsonObject env || !StringPropertyEquals(env, InitVersionEnvName, CurrentVersion))
+            findings.Add($"{label} was initialized by an older maf-doctor; run init to refresh it");
+    }
+
+    private static bool StringPropertyEquals(JsonObject obj, string propertyName, string expected)
+        => obj[propertyName] is JsonValue value &&
+           value.TryGetValue<string>(out var actual) &&
+           string.Equals(actual, expected, StringComparison.Ordinal);
+
+    private static void RequireFile(string targetDir, string relativePath, List<string> findings)
+    {
+        if (!File.Exists(Path.Combine(targetDir, relativePath)))
+            findings.Add($"{relativePath} is missing");
+    }
+
+    private static void RequireText(string targetDir, string relativePath, string expectedText, List<string> findings)
+    {
+        var path = Path.Combine(targetDir, relativePath);
+        if (!File.Exists(path))
+        {
+            findings.Add($"{relativePath} is missing");
+            return;
+        }
+
+        var content = File.ReadAllText(path);
+        if (!content.Contains(expectedText, StringComparison.Ordinal))
+            findings.Add($"{relativePath} does not contain the maf-doctor managed marker");
+    }
+
+    internal sealed record InitStatus(bool IsCurrent, IReadOnlyList<string> Findings)
+    {
+        public bool NeedsRefresh => !IsCurrent;
     }
 
     // ------------------------------------------------------------------ //

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -177,6 +177,7 @@ builder.Logging.AddConsole(options =>
 // Load the registry once at startup and register as a singleton shared by all tools.
 builder.Services
     .AddSingleton<RegistryService>()
+    .AddHostedService<UpdateNoticeHostedService>()
     .AddMcpServer(options =>
     {
         // Advertise the server's identity + icon (MCP 2025-11 `icons` on the

--- a/src/maf-autopilot/Tools/StatusTool.cs
+++ b/src/maf-autopilot/Tools/StatusTool.cs
@@ -35,7 +35,7 @@ public sealed class StatusTool
         if (PathGuard.ValidateRepoPath(rawPath) is { } error)
             return error;
 
-        var targetDir = Path.GetFullPath(rawPath);
+        var targetDir = InitCommand.FindInitializedWorkspaceRoot(rawPath);
 
         var update = await UpdateAdvisor.CheckForUpdateAsync(timeout: TimeSpan.FromSeconds(3));
         var init = InitCommand.GetWorkspaceInitStatus(targetDir);

--- a/src/maf-autopilot/Tools/StatusTool.cs
+++ b/src/maf-autopilot/Tools/StatusTool.cs
@@ -1,0 +1,44 @@
+using System.ComponentModel;
+using ModelContextProtocol.Server;
+
+namespace MafDoctor.Tools;
+
+/// <summary>
+/// MCP tool: MafDoctorStatus
+///
+/// Reports whether the installed global tool package is current and whether the
+/// current workspace's MCP init/steering files match this installed binary.
+/// </summary>
+[McpServerToolType]
+public sealed class StatusTool
+{
+    [McpServerTool(ReadOnly = true, Destructive = false, OpenWorld = true)]
+    [Description("""
+        Check maf-doctor package freshness and workspace init freshness. Use this
+        when the user asks whether the MCP server itself needs an update or whether
+        they only need to rerun `maf-doctor init` for this workspace.
+
+        Input:
+          - repoPath: repository/workspace root to inspect. Defaults to the MCP
+            server current directory.
+
+        Returns markdown with exact update/init commands when action is needed.
+        """)]
+    public async Task<string> MafDoctorStatus(
+        [Description("Repository/workspace root to inspect. Defaults to the MCP server current directory.")]
+        string? repoPath = null)
+    {
+        var rawPath = string.IsNullOrWhiteSpace(repoPath)
+            ? Directory.GetCurrentDirectory()
+            : repoPath;
+
+        if (PathGuard.ValidateRepoPath(rawPath) is { } error)
+            return error;
+
+        var targetDir = Path.GetFullPath(rawPath);
+
+        var update = await UpdateAdvisor.CheckForUpdateAsync(timeout: TimeSpan.FromSeconds(3));
+        var init = InitCommand.GetWorkspaceInitStatus(targetDir);
+        return UpdateAdvisor.BuildMarkdown(update, init, targetDir);
+    }
+}

--- a/src/maf-autopilot/Tools/TourTool.cs
+++ b/src/maf-autopilot/Tools/TourTool.cs
@@ -117,6 +117,7 @@ public sealed class TourTool
 
         // — Health —
         new("MafDoctor", "Health", "Single-command A/B/C/F grade. Aggregates 4 scanners + reports the top 3 fixes (or every finding with `full: true`). Best triage signal in the toolkit."),
+        new("MafDoctorStatus", "Health", "Check whether the installed maf-doctor package is current and whether this workspace needs only a fresh `maf-doctor init`. Returns exact commands when action is needed."),
         new("MafExplainFinding", "Health", "Deep-dive ONE doctor finding (file + line): the offending code in context plus the rule's why / fix / auto-fixability. Grounded substrate for explaining or fixing it — pair with the `maf-explain-finding` prompt."),
 
         // — Discovery (this very tool) —

--- a/src/maf-autopilot/UpdateAdvisor.cs
+++ b/src/maf-autopilot/UpdateAdvisor.cs
@@ -21,7 +21,8 @@ internal sealed class UpdateNoticeHostedService(ILogger<UpdateNoticeHostedServic
                 timeout: TimeSpan.FromSeconds(3),
                 ignoreCache: false,
                 cancellationToken: cancellationToken);
-            var init = InitCommand.GetWorkspaceInitStatus(Directory.GetCurrentDirectory());
+            var workspaceRoot = InitCommand.FindInitializedWorkspaceRoot(Directory.GetCurrentDirectory());
+            var init = InitCommand.GetWorkspaceInitStatus(workspaceRoot);
             var notice = UpdateAdvisor.BuildStartupNotice(update, init);
             if (!string.IsNullOrWhiteSpace(notice))
                 logger.LogWarning("{Notice}", notice);

--- a/src/maf-autopilot/UpdateAdvisor.cs
+++ b/src/maf-autopilot/UpdateAdvisor.cs
@@ -60,7 +60,8 @@ internal static class UpdateAdvisor
         var ownsClient = httpClient is null;
         using var client = ownsClient ? new HttpClient() : null;
         var effectiveClient = httpClient ?? client!;
-        effectiveClient.DefaultRequestHeaders.UserAgent.ParseAdd("maf-doctor-update-check/1.0");
+        if (!effectiveClient.DefaultRequestHeaders.UserAgent.Any(v => v.Product?.Name == "maf-doctor-update-check"))
+            effectiveClient.DefaultRequestHeaders.UserAgent.ParseAdd("maf-doctor-update-check/1.0");
 
         using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(3));
@@ -190,32 +191,39 @@ internal static class UpdateAdvisor
 
     internal static int CompareSemanticVersions(string left, string right)
     {
-        var leftParts = ParseVersionParts(left);
-        var rightParts = ParseVersionParts(right);
-        for (var i = 0; i < Math.Max(leftParts.Length, rightParts.Length); i++)
+        var leftVersion = ParseVersion(left);
+        var rightVersion = ParseVersion(right);
+        for (var i = 0; i < Math.Max(leftVersion.Parts.Length, rightVersion.Parts.Length); i++)
         {
-            var leftPart = i < leftParts.Length ? leftParts[i] : 0;
-            var rightPart = i < rightParts.Length ? rightParts[i] : 0;
+            var leftPart = i < leftVersion.Parts.Length ? leftVersion.Parts[i] : 0;
+            var rightPart = i < rightVersion.Parts.Length ? rightVersion.Parts[i] : 0;
             var comparison = leftPart.CompareTo(rightPart);
             if (comparison != 0)
                 return comparison;
         }
 
+        if (leftVersion.IsPrerelease != rightVersion.IsPrerelease)
+            return leftVersion.IsPrerelease ? -1 : 1;
+
         return 0;
     }
 
-    private static int[] ParseVersionParts(string version)
+    private static ParsedVersion ParseVersion(string version)
     {
         var normalized = version.Trim();
         if (normalized.StartsWith('v')) normalized = normalized[1..];
         var plus = normalized.IndexOf('+');
         if (plus >= 0) normalized = normalized[..plus];
         var dash = normalized.IndexOf('-');
-        if (dash >= 0) normalized = normalized[..dash];
-        return normalized.Split('.', StringSplitOptions.RemoveEmptyEntries)
+        var isPrerelease = dash >= 0;
+        if (isPrerelease) normalized = normalized[..dash];
+        var parts = normalized.Split('.', StringSplitOptions.RemoveEmptyEntries)
             .Select(part => int.TryParse(part, out var value) ? value : 0)
             .ToArray();
+        return new ParsedVersion(parts, isPrerelease);
     }
+
+    private sealed record ParsedVersion(int[] Parts, bool IsPrerelease);
 
     private static UpdateStatus BuildStatus(string currentVersion, string latestVersion, bool fromCache, DateTimeOffset checkedAtUtc)
         => new(

--- a/src/maf-autopilot/UpdateAdvisor.cs
+++ b/src/maf-autopilot/UpdateAdvisor.cs
@@ -39,6 +39,7 @@ internal static class UpdateAdvisor
 {
     private const string PackageId = "maf-doctor";
     private const string NuGetIndexUrl = "https://api.nuget.org/v3-flatcontainer/maf-doctor/index.json";
+    private const long CacheMaxBytes = 64 * 1024;
     private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
     private static readonly JsonSerializerOptions CacheJsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
@@ -252,6 +253,8 @@ internal static class UpdateAdvisor
         checkedAtUtc = default;
         var path = CachePath;
         if (!File.Exists(path))
+            return false;
+        if (new FileInfo(path).Length > CacheMaxBytes)
             return false;
 
         try

--- a/src/maf-autopilot/UpdateAdvisor.cs
+++ b/src/maf-autopilot/UpdateAdvisor.cs
@@ -1,0 +1,307 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MafDoctor;
+
+internal sealed class UpdateNoticeHostedService(ILogger<UpdateNoticeHostedService> logger) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _ = Task.Run(() => CheckAndLogAsync(cancellationToken), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    private async Task CheckAndLogAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var update = await UpdateAdvisor.CheckForUpdateAsync(
+                timeout: TimeSpan.FromSeconds(3),
+                ignoreCache: false,
+                cancellationToken: cancellationToken);
+            var init = InitCommand.GetWorkspaceInitStatus(Directory.GetCurrentDirectory());
+            var notice = UpdateAdvisor.BuildStartupNotice(update, init);
+            if (!string.IsNullOrWhiteSpace(notice))
+                logger.LogWarning("{Notice}", notice);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogDebug(ex, "maf-doctor update check failed during MCP startup.");
+        }
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
+internal static class UpdateAdvisor
+{
+    private const string PackageId = "maf-doctor";
+    private const string NuGetIndexUrl = "https://api.nuget.org/v3-flatcontainer/maf-doctor/index.json";
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromHours(24);
+    private static readonly JsonSerializerOptions CacheJsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+
+    public static UpdateStatus? LastStatus { get; private set; }
+
+    public static async Task<UpdateStatus> CheckForUpdateAsync(
+        HttpClient? httpClient = null,
+        TimeSpan? timeout = null,
+        bool ignoreCache = false,
+        CancellationToken cancellationToken = default)
+    {
+        var currentVersion = InitCommand.CurrentVersion;
+        if (IsDisabled())
+            return Remember(new UpdateStatus(currentVersion, LatestVersion: null, State: UpdateState.Disabled, FromCache: false, Error: null));
+
+        if (!ignoreCache && TryReadFreshCache(out var cachedLatest, out var checkedAtUtc))
+            return Remember(BuildStatus(currentVersion, cachedLatest, fromCache: true, checkedAtUtc));
+
+        var ownsClient = httpClient is null;
+        using var client = ownsClient ? new HttpClient() : null;
+        var effectiveClient = httpClient ?? client!;
+        effectiveClient.DefaultRequestHeaders.UserAgent.ParseAdd("maf-doctor-update-check/1.0");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        cts.CancelAfter(timeout ?? TimeSpan.FromSeconds(3));
+
+        try
+        {
+            var json = await effectiveClient.GetStringAsync(NuGetIndexUrl, cts.Token);
+            var latest = ParseLatestStableVersion(json);
+            if (latest is null)
+                return Remember(new UpdateStatus(currentVersion, LatestVersion: null, State: UpdateState.CheckFailed, FromCache: false, Error: "NuGet returned no stable maf-doctor versions."));
+
+            WriteCache(latest);
+            return Remember(BuildStatus(currentVersion, latest, fromCache: false, DateTimeOffset.UtcNow));
+        }
+        catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException or OperationCanceledException)
+        {
+            return Remember(new UpdateStatus(currentVersion, LatestVersion: null, State: UpdateState.CheckFailed, FromCache: false, Error: ex.Message));
+        }
+    }
+
+    public static string BuildMarkdown(UpdateStatus update, InitCommand.InitStatus init, string repoPath)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("# maf-doctor status");
+        sb.AppendLine();
+        sb.AppendLine($"Current tool version: `{update.CurrentVersion}`");
+        if (!string.IsNullOrWhiteSpace(update.LatestVersion))
+            sb.AppendLine($"Latest NuGet version: `{update.LatestVersion}`{(update.FromCache ? " (cached)" : string.Empty)}");
+        sb.AppendLine($"Workspace: `{repoPath}`");
+        sb.AppendLine();
+
+        switch (update.State)
+        {
+            case UpdateState.UpdateAvailable:
+                sb.AppendLine("## Update available");
+                sb.AppendLine();
+                sb.AppendLine("Run:");
+                sb.AppendLine();
+                sb.AppendLine("```powershell");
+                sb.AppendLine("dotnet tool update --global maf-doctor");
+                sb.AppendLine("maf-doctor init");
+                sb.AppendLine("```");
+                sb.AppendLine();
+                sb.AppendLine("Then reload the editor or MCP host so it starts the new binary.");
+                break;
+            case UpdateState.UpToDate:
+                sb.AppendLine("## Tool package");
+                sb.AppendLine();
+                sb.AppendLine("The installed maf-doctor package is up to date.");
+                break;
+            case UpdateState.Disabled:
+                sb.AppendLine("## Tool package");
+                sb.AppendLine();
+                sb.AppendLine("Update checks are disabled by `MAF_DOCTOR_UPDATE_CHECK`.");
+                break;
+            case UpdateState.CheckFailed:
+                sb.AppendLine("## Tool package");
+                sb.AppendLine();
+                sb.AppendLine("Could not check NuGet for updates. The MCP server is still usable.");
+                if (!string.IsNullOrWhiteSpace(update.Error))
+                    sb.AppendLine($"Error: `{update.Error}`");
+                break;
+        }
+
+        sb.AppendLine();
+        sb.AppendLine("## Workspace init");
+        sb.AppendLine();
+        if (init.IsCurrent)
+        {
+            sb.AppendLine("This workspace's MCP config and steering sidecars are current for the installed maf-doctor.");
+        }
+        else
+        {
+            sb.AppendLine("This workspace should be refreshed with:");
+            sb.AppendLine();
+            sb.AppendLine("```powershell");
+            sb.AppendLine("maf-doctor init");
+            sb.AppendLine("```");
+            sb.AppendLine();
+            sb.AppendLine("Findings:");
+            foreach (var finding in init.Findings)
+                sb.AppendLine($"- {finding}");
+        }
+
+        return sb.ToString();
+    }
+
+    public static string? BuildStartupNotice(UpdateStatus update, InitCommand.InitStatus init)
+    {
+        var lines = new List<string>();
+        if (update.State == UpdateState.UpdateAvailable && update.LatestVersion is not null)
+        {
+            lines.Add($"maf-doctor {update.LatestVersion} is available; this MCP server is running {update.CurrentVersion}.");
+            lines.Add("Update when ready: dotnet tool update --global maf-doctor");
+            lines.Add("Then run: maf-doctor init");
+            lines.Add("Reload the editor or MCP host so it starts the new binary.");
+        }
+
+        if (update.State != UpdateState.UpdateAvailable && init.NeedsRefresh)
+        {
+            lines.Add("maf-doctor is running, but this workspace's MCP/steering init is stale or incomplete.");
+            lines.Add("Refresh it with: maf-doctor init");
+            lines.Add("Then reload the editor or MCP host.");
+        }
+
+        return lines.Count == 0 ? null : string.Join(Environment.NewLine, lines);
+    }
+
+    internal static string? ParseLatestStableVersion(string json)
+    {
+        using var document = JsonDocument.Parse(json);
+        if (!document.RootElement.TryGetProperty("versions", out var versions) || versions.ValueKind != JsonValueKind.Array)
+            return null;
+
+        string? latest = null;
+        foreach (var versionElement in versions.EnumerateArray())
+        {
+            var version = versionElement.GetString();
+            if (string.IsNullOrWhiteSpace(version) || version.Contains('-', StringComparison.Ordinal))
+                continue;
+            if (latest is null || CompareSemanticVersions(version, latest) > 0)
+                latest = version;
+        }
+
+        return latest;
+    }
+
+    internal static int CompareSemanticVersions(string left, string right)
+    {
+        var leftParts = ParseVersionParts(left);
+        var rightParts = ParseVersionParts(right);
+        for (var i = 0; i < Math.Max(leftParts.Length, rightParts.Length); i++)
+        {
+            var leftPart = i < leftParts.Length ? leftParts[i] : 0;
+            var rightPart = i < rightParts.Length ? rightParts[i] : 0;
+            var comparison = leftPart.CompareTo(rightPart);
+            if (comparison != 0)
+                return comparison;
+        }
+
+        return 0;
+    }
+
+    private static int[] ParseVersionParts(string version)
+    {
+        var normalized = version.Trim();
+        if (normalized.StartsWith('v')) normalized = normalized[1..];
+        var plus = normalized.IndexOf('+');
+        if (plus >= 0) normalized = normalized[..plus];
+        var dash = normalized.IndexOf('-');
+        if (dash >= 0) normalized = normalized[..dash];
+        return normalized.Split('.', StringSplitOptions.RemoveEmptyEntries)
+            .Select(part => int.TryParse(part, out var value) ? value : 0)
+            .ToArray();
+    }
+
+    private static UpdateStatus BuildStatus(string currentVersion, string latestVersion, bool fromCache, DateTimeOffset checkedAtUtc)
+        => new(
+            currentVersion,
+            latestVersion,
+            CompareSemanticVersions(latestVersion, currentVersion) > 0 ? UpdateState.UpdateAvailable : UpdateState.UpToDate,
+            fromCache,
+            Error: null,
+            CheckedAtUtc: checkedAtUtc);
+
+    private static UpdateStatus Remember(UpdateStatus status)
+    {
+        LastStatus = status;
+        return status;
+    }
+
+    private static bool IsDisabled()
+    {
+        var value = Environment.GetEnvironmentVariable("MAF_DOCTOR_UPDATE_CHECK");
+        return value is not null && value.Trim().ToLowerInvariant() is "0" or "false" or "off" or "no";
+    }
+
+    private static bool TryReadFreshCache(out string latestVersion, out DateTimeOffset checkedAtUtc)
+    {
+        latestVersion = string.Empty;
+        checkedAtUtc = default;
+        var path = CachePath;
+        if (!File.Exists(path))
+            return false;
+
+        try
+        {
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            latestVersion = document.RootElement.GetProperty("latestVersion").GetString() ?? string.Empty;
+            checkedAtUtc = document.RootElement.GetProperty("checkedAtUtc").GetDateTimeOffset();
+            return !string.IsNullOrWhiteSpace(latestVersion) && DateTimeOffset.UtcNow - checkedAtUtc < CacheTtl;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static void WriteCache(string latestVersion)
+    {
+        try
+        {
+            var path = CachePath;
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var payload = JsonSerializer.Serialize(new CacheRecord(latestVersion, DateTimeOffset.UtcNow), CacheJsonOptions);
+            File.WriteAllText(path, payload);
+        }
+        catch
+        {
+            // Cache failures should never affect MCP startup or tool calls.
+        }
+    }
+
+    private static string CachePath
+    {
+        get
+        {
+            var root = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrWhiteSpace(root)) root = Path.GetTempPath();
+            return Path.Combine(root, PackageId, "update-check.json");
+        }
+    }
+
+    private sealed record CacheRecord(string LatestVersion, DateTimeOffset CheckedAtUtc);
+}
+
+internal enum UpdateState
+{
+    UpToDate,
+    UpdateAvailable,
+    Disabled,
+    CheckFailed,
+}
+
+internal sealed record UpdateStatus(
+    string CurrentVersion,
+    string? LatestVersion,
+    UpdateState State,
+    bool FromCache,
+    string? Error,
+    DateTimeOffset? CheckedAtUtc = null)
+{
+    public bool UpdateAvailable => State == UpdateState.UpdateAvailable;
+}


### PR DESCRIPTION
## Summary

- Add a non-blocking MCP startup advisory that checks NuGet for newer `maf-doctor` releases and logs exact update/init commands.
- Add `MafDoctorStatus` so users can ask whether they need a package update or only a fresh `maf-doctor init`.
- Make `maf-doctor init` repair stale managed MCP entries, migrate legacy `maf-autopilot` entries, and stamp `MAF_DOCTOR_INIT_VERSION` for future freshness checks.
- Update docs/tool counts and add focused tests for version parsing and init repair behavior.

## Validation

- `dotnet test src/maf-autopilot.Tests/maf-autopilot.Tests.csproj -f net8.0` — 990/990 passed
- `dotnet build src/maf-autopilot/maf-autopilot.csproj -f net9.0` — passed
- `git diff --check` — clean

Note: local full multi-target validation was avoided because a running MCP process locks the `net10.0` apphost on Windows; CI should not have that local lock.