### PR TITLE
fix: stop config-reload file watcher from ballooning memory in MCP mode

### DIFF
--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
 
-// CLI mode: short-circuit before Host.CreateApplicationBuilder so stdin/stdout remain clean.
+// CLI mode: short-circuit before the host builder so stdin/stdout remain clean.
 // Supported subcommands:
 //   maf-doctor init                       — scaffold .vscode/mcp.json + copilot-instructions
 //   maf-doctor new agent <Name>           — generate a MAF agent + smoke test
@@ -168,7 +168,12 @@ if (args.Length >= 1 && args[0] == "registry-extract")
 }
 
 // All logs must go to stderr — stdout is reserved for the MCP JSON-RPC protocol.
-var builder = Host.CreateApplicationBuilder(args);
+// CreateEmptyApplicationBuilder, not CreateApplicationBuilder: the server reads no
+// appsettings/host config, and the defaults register a reloadOnChange file watcher
+// on the content root (= cwd). MCP hosts spawn stdio servers with cwd = the user's
+// home directory, where that watcher (recursive FSEvents on macOS) allocates
+// unboundedly under normal filesystem activity — GBs while idle (#146).
+var builder = Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings { Args = args });
 builder.Logging.AddConsole(options =>
 {
     options.LogToStandardErrorThreshold = LogLevel.Trace;


### PR DESCRIPTION
Fixes #146.

## What

One functional line: `Host.CreateApplicationBuilder(args)` → `Host.CreateEmptyApplicationBuilder(new HostApplicationBuilderSettings { Args = args })` in the MCP-server path of `Program.cs`, plus a comment explaining why.

## Why

`CreateApplicationBuilder` registers `appsettings.json` config sources with `reloadOnChange: true`, which creates a file watcher on the content root (= cwd). MCP hosts (Claude Code, VS Code, Cursor) spawn stdio servers with **cwd = the user's home directory**, and on macOS the watcher observes it **recursively via FSEvents**. Under normal machine activity the watcher thread stat/lstats subtrees and allocates path strings without bound — observed ~9 GB footprint in 20 minutes on an idle server, multiplied per concurrent MCP host session (details, `sample` stacks, and measurements in #146).

The server never reads host/appsettings configuration — logging (stderr console) and all DI registrations are explicit — so the empty builder is a drop-in.

## Verification

- `sample` on the patched binary: the `.NET File Watcher` thread is no longer created (0 vs 1 with the default builder)
- 3-minute A/B under synthetic $HOME file churn: default builder grows 106 → 175 MB (~25 MB/min, unbounded while churn continues); patched binary stays flat at 75–76 MB
- `dotnet build` clean (0 warnings), all **994 tests pass** on net10.0
- CLI subcommands are unaffected — they short-circuit before the host builder

## Notes for affected users (pre-merge workaround)

`"env": { "DOTNET_hostBuilder__reloadConfigOnChange": "false" }` in the MCP server config achieves the same effect without a code change.