### PR TITLE
fix: harden PathGuard, cap repo scans, fix fork-PR audit comments (#148)

### DIFF
--- a/.github/workflows/maf-pr-audit-comment.yml
+++ b/.github/workflows/maf-pr-audit-comment.yml
@@ -1,0 +1,64 @@
+name: MAF PR Audit Comment
+
+# Companion to maf-pr-audit.yml (#148 finding 3). GitHub force-downgrades
+# GITHUB_TOKEN to read-only for `pull_request`-triggered runs when the PR is
+# from a fork, regardless of any `permissions:` the workflow declares — so
+# maf-pr-audit.yml, which runs Roslyn analysis over the PR's own (possibly
+# fork-supplied, untrusted) source, can never safely hold write access to post
+# a PR comment itself. This workflow runs on `workflow_run` instead: it
+# executes in the base repo's context (a normal write-scoped token even when
+# the underlying PR is a fork) and only ever touches the plain markdown
+# artifact the already-completed, permission-restricted job produced above —
+# it never checks out or executes fork-supplied code. This is GitHub's
+# documented safe pattern for commenting on fork PRs; `pull_request_target`
+# was deliberately avoided since that would hand write-scoped secrets to a job
+# that still has to process fork-supplied content.
+
+on:
+  workflow_run:
+    workflows: ["MAF PR Audit"]
+    types: [completed]
+
+# `actions: read` is required for actions/download-artifact to fetch an
+# artifact from a DIFFERENT run via `run-id` (a cross-run download calls the
+# Actions API, unlike the same-run case which upload/download-artifact handle
+# via the internal runtime token regardless of permissions). Declaring a
+# `permissions:` block sets every unlisted scope to `none` — omitting this
+# would make the download step fail on every single run.
+permissions:
+  pull-requests: write
+  actions: read
+
+jobs:
+  comment:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      # maf-pr-audit.yml now ALWAYS uploads this artifact on a successful run
+      # (a placeholder message when the audit was intentionally skipped, the
+      # real report otherwise) — so reaching this step with the artifact
+      # missing is a genuine problem, not an expected case to swallow. No
+      # continue-on-error: a failure here should be visible.
+      - name: Download audit result
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
+        with:
+          name: pr-audit-result
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # workflow_run's `pull_requests` context is empty for fork PRs (a known
+      # GitHub Actions limitation) — the PR number travels in the artifact
+      # itself (written by maf-pr-audit.yml) instead of being read from the event.
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Comment on PR
+        # SHA-pinned per supply-chain hardening. Verify against tag with:
+        #   gh api repos/marocchino/sticky-pull-request-comment/git/refs/tags/v2.9.2 --jq .object.sha
+        # Update via Dependabot (.github/dependabot.yml).
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v2.9.2
+        with:
+          header: maf-autopilot-audit
+          path: pr-audit-full.md
+          number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/maf-pr-audit.yml
+++ b/.github/workflows/maf-pr-audit.yml
@@ -12,9 +12,18 @@ on:
       - '**.cs'
       - '**.csproj'
 
+# #148 finding 3 — this job runs Roslyn analysis over the PR's own (possibly
+# untrusted, fork-supplied) source, so it must never hold write-scoped
+# permissions. GitHub already enforces that for `pull_request` runs from a
+# fork (GITHUB_TOKEN is force-downgraded to read-only regardless of what's
+# declared here) — declaring only `contents: read` makes the same constraint
+# explicit for same-repo PRs too. Posting the actual PR comment is handled by
+# the companion workflow maf-pr-audit-comment.yml (triggered by workflow_run),
+# which runs in the base repo's context with a normal write-scoped token and
+# never touches fork-supplied code — only the plain markdown artifact this
+# job produces below.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   audit:
@@ -140,12 +149,38 @@ jobs:
           echo "Full doctor report:"
           cat pr-audit-full.md
 
-      - name: Comment on PR
-        if: steps.scope.outputs.skip != 'true'
-        # SHA-pinned per supply-chain hardening. Verify against tag with:
-        #   gh api repos/marocchino/sticky-pull-request-comment/git/refs/tags/v2.9.2 --jq .object.sha
-        # Update via Dependabot (.github/dependabot.yml).
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v2.9.2
+      - name: Write skip placeholder (when the audit was intentionally skipped)
+        if: steps.scope.outputs.skip == 'true'
+        # The "Run MCP server..." step above never runs in this branch, so
+        # pr-audit-full.md wouldn't otherwise exist — an artifact must still be
+        # produced so the companion workflow can tell "intentionally skipped"
+        # apart from "something actually went wrong" (#148 finding 3 review).
+        run: |
+          echo "ℹ️ **MAF audit skipped for this PR.** See this workflow run's annotations for why (only samples/ changed, or the diff exceeded the compiler-bomb cap — CI-side scanners still ran)." > pr-audit-full.md
+
+      - name: Record PR number for the comment workflow
+        # No `if:` guard — runs whenever the job reaches this point without an
+        # earlier step failing (the implicit default), covering BOTH the
+        # skip=true and skip=false success paths so an artifact is always
+        # produced for a successful run. workflow_run's `pull_requests` context
+        # is empty for fork PRs (a known GitHub Actions limitation) — hand the
+        # PR number to the companion workflow explicitly via the artifact
+        # instead of relying on it.
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload audit result
+        # #148 finding 3 — this job's GITHUB_TOKEN is read-only (enforced by
+        # GitHub for fork PRs regardless of the `permissions:` above), so it
+        # cannot post the sticky comment itself. maf-pr-audit-comment.yml
+        # (workflow_run) downloads this artifact and posts it instead. Always
+        # uploading (skip or not) means a successful run of THIS workflow
+        # guarantees the artifact exists — the companion workflow can then
+        # treat a download failure as a genuine problem instead of having to
+        # guess whether it's the expected "audit was skipped" case.
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          header: maf-autopilot-audit
-          path: pr-audit-full.md
+          name: pr-audit-result
+          path: |
+            pr-audit-full.md
+            pr-number.txt
+          retention-days: 1

--- a/docs/output-schemas.md
+++ b/docs/output-schemas.md
@@ -27,7 +27,9 @@ Pass `format: "json"` to get machine-readable output.
       "confidence": "high"
     }
   ],
-  "summary_md": "...the full markdown report that format:markdown would emit..."
+  "summary_md": "...the full markdown report that format:markdown would emit...",
+  "scan_truncated": false,
+  "files_scanned": 155
 }
 ```
 
@@ -51,6 +53,8 @@ Pass `format: "json"` to get machine-readable output.
   - `why`: one-line consequence / rationale for the finding. **Always present**; the empty string `""` when no rationale is defined for the rule.
   - `confidence`: detector trust level for **false-positive triage** — `"certain"` (compiler ground-truth) | `"high"` (structural AST, low FP) | `"heuristic"` (name-only / text / scope-limited — **verify before fixing**). Additive within schema v1; consumers that don't recognize it can ignore it. The `maf-remediate` prompt reads this to decide which findings to confirm before changing code.
 - `summary_md`: the same markdown that `format: "markdown"` would emit (for hybrid consumers). It includes the offending source line per finding, so it inherits the markdown report's **best-effort, content-aware secret redaction** — the structured `top_fixes` array carries no source text and is the safer channel for machine consumers.
+- `scan_truncated`: `true` if the repo-size cap (file count or per-file size) meant the scan did NOT cover every file — the verdict/findings above reflect a partial repo, not the whole one. Additive within schema v1; consumers that don't recognize it can ignore it, but a CI gate reading only the typed fields (not `summary_md`) should check it before trusting a clean verdict.
+- `files_scanned`: how many files were actually included in the scan (integer).
 
 ### Usage in CI
 
@@ -120,7 +124,9 @@ false positives without parsing prose. Schema version `"1"`.
       "fix": "Set MaxOutputTokens on the nearest ChatOptions to cap the per-call cost.",
       "occurrences": [ { "file": "AGUIClient/Program.cs", "line": 90 } ]
     }
-  ]
+  ],
+  "scan_truncated": false,
+  "files_scanned": 155
 }
 ```
 
@@ -128,6 +134,8 @@ false positives without parsing prose. Schema version `"1"`.
 - `phase1_autofix` — `null` if there are no auto-fixable findings; otherwise the single command + the rules it clears.
 - `phase2_semantic[].verify_first` — `true` for `heuristic` findings: confirm the finding is real (e.g. via `MafExplainFinding`) **before** editing.
 - `phase2_semantic[].occurrences` — every `file`/`line` for that rule (a group of N hits is one entry with N occurrences).
+- `scan_truncated` — `true` if the repo-size cap meant this plan does NOT cover the whole repo. An automated consumer (the `maf-remediate` loop) MUST check this before treating the plan as complete — clearing every listed finding would otherwise look like "fully remediated" when it isn't. Additive within schema v1.
+- `files_scanned` — how many files were actually included in the scan (integer).
 - Invalid path / scan failure returns the same `{ "schema_version": "1", "error": "…" }` shape as `--json`.
 
 ---

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -1473,4 +1473,111 @@ public class DoctorToolTests
             Directory.Delete(root, recursive: true);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Scan truncation — #148 finding 2. AnalyzeRepo takes an optional
+    // ScanBudget (test-only param; production always passes null → a fresh,
+    // default-capped budget) so the truncation path is exercisable without
+    // creating tens of thousands of files.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void AnalyzeRepo_UnderCap_NotTruncated()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "maf-doctor-scancap-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "Clean.cs"), "public class Clean { }");
+
+            var summary = DoctorTool.AnalyzeRepo(root, excludes: null);
+
+            Assert.False(summary.ScanTruncated);
+            Assert.False(summary.ScanIncomplete);
+            Assert.Equal(0, summary.FilesSkippedOversized);
+            Assert.Equal(1, summary.FilesScanned);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void AnalyzeRepo_OverCap_ReportsTruncatedAndFilesScanned()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "maf-doctor-scancap-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            for (var i = 0; i < 5; i++)
+                File.WriteAllText(Path.Combine(root, $"File{i}.cs"), "public class C { }");
+
+            var summary = DoctorTool.AnalyzeRepo(root, excludes: null, new SourceFileWalker.ScanBudget { MaxFiles = 2 });
+
+            Assert.True(summary.ScanTruncated);
+            Assert.True(summary.ScanIncomplete);
+            Assert.Equal(2, summary.FilesScanned);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void AnalyzeRepo_OversizedFile_SkippedAndReportedWithoutTruncatingTheRest()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "maf-doctor-scancap-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "Normal.cs"), "public class Normal { }");
+            File.WriteAllText(Path.Combine(root, "Huge.cs"), "public class Huge { }");
+
+            var budget = new SourceFileWalker.ScanBudget { MaxFileBytes = 5 }; // "public class Huge { }" > 5 bytes
+            var summary = DoctorTool.AnalyzeRepo(root, excludes: null, budget);
+
+            // The oversized file is skipped, but the walk still covers Normal.cs —
+            // ScanTruncated (the file-COUNT cap) stays false; only the oversized
+            // signal fires, and ScanIncomplete reflects it either way.
+            Assert.False(summary.ScanTruncated);
+            Assert.True(summary.FilesSkippedOversized >= 1);
+            Assert.True(summary.ScanIncomplete);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void FormatReport_Truncated_IncludesWarningNote()
+    {
+        var summary = DoctorTool.Grade([], []) with { ScanTruncated = true, FilesScanned = 42 };
+        var report = DoctorTool.FormatReport("/some/repo", summary);
+
+        Assert.Contains("Scan incomplete", report, StringComparison.Ordinal);
+        Assert.Contains("42", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatReport_OversizedSkipOnly_IncludesWarningNote()
+    {
+        var summary = DoctorTool.Grade([], []) with { FilesSkippedOversized = 3 };
+        var report = DoctorTool.FormatReport("/some/repo", summary);
+
+        Assert.Contains("Scan incomplete", report, StringComparison.Ordinal);
+        Assert.Contains("3", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatReport_NotTruncated_OmitsWarningNote()
+    {
+        var summary = DoctorTool.Grade([], []);
+        var report = DoctorTool.FormatReport("/some/repo", summary);
+
+        Assert.DoesNotContain("Scan incomplete", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FormatPlan_Truncated_IncludesWarningNote()
+    {
+        var finding = new AntiPatternFinding("MAF-AP-SEC-001", "name", AntiPatternSeverity.Error, "f", 1, "m");
+        var summary = DoctorTool.Grade([finding], []) with { ScanTruncated = true, FilesScanned = 7 };
+        var plan = DoctorTool.FormatPlan("/some/repo", summary);
+
+        Assert.Contains("Scan incomplete", plan, StringComparison.Ordinal);
+    }
 }

--- a/src/maf-autopilot.Tests/PathGuardTests.cs
+++ b/src/maf-autopilot.Tests/PathGuardTests.cs
@@ -44,7 +44,13 @@ public class PathGuardTests
     [Fact]
     public void NonexistentDirectory_Rejected()
     {
-        var err = PathGuard.ValidateRepoPath("/definitely/does/not/exist/anywhere");
+        // Built from Path.GetTempPath() rather than a hardcoded "/..." literal so
+        // it's genuinely fully-qualified on whichever OS the test runs on — a
+        // bare "/foo/bar" is rooted-to-current-drive but NOT fully qualified on
+        // Windows, which would now (correctly) fail this as "not absolute"
+        // instead of exercising the "does not exist" branch this test targets.
+        var path = Path.Combine(Path.GetTempPath(), "maf-doctor-definitely-does-not-exist-" + Guid.NewGuid().ToString("N"));
+        var err = PathGuard.ValidateRepoPath(path);
         Assert.NotNull(err);
         Assert.Contains("does not exist", err, StringComparison.OrdinalIgnoreCase);
     }
@@ -54,6 +60,53 @@ public class PathGuardTests
     {
         var err = PathGuard.ValidateRepoPath(Path.GetTempPath());
         Assert.Null(err);
+    }
+
+    // -------------------------------------------------------------------------
+    // Relative-path rejection — #148 finding 1.
+    //
+    // An MCP-spawned server's cwd is typically the user's home directory, not
+    // the repo the LLM caller meant. A relative repoPath must be rejected
+    // rather than silently resolved against Environment.CurrentDirectory.
+    // -------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("src")]
+    [InlineData("./src/Tools")]
+    public void RelativePath_Rejected(string path)
+    {
+        var err = PathGuard.ValidateRepoPath(path);
+        Assert.NotNull(err);
+        Assert.Contains("absolute path", err, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void RelativePath_TakesPrecedenceOverNonexistence()
+    {
+        // A relative path that also doesn't exist must still be flagged as
+        // "not absolute" (the caller's real mistake), not "does not exist"
+        // (which would encourage retrying with a resolved-but-still-relative path).
+        var err = PathGuard.ValidateRepoPath("relative/does/not/exist");
+        Assert.NotNull(err);
+        Assert.Contains("absolute path", err, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("C:tmp")]      // drive-relative — resolves against the current directory ON that drive
+    [InlineData(@"\tmp")]      // rooted to the current drive, no drive letter
+    public void WindowsDriveRelativePath_Rejected(string path)
+    {
+        // Path.IsPathRooted returns true for both of these on Windows even
+        // though neither is actually unambiguous — IsPathFullyQualified must
+        // be what PathGuard uses, or this regression silently reopens #148
+        // finding 1 for exactly the inputs it was written to close.
+        if (!OperatingSystem.IsWindows())
+            return; // these strings aren't meaningfully "drive-relative" on POSIX
+
+        var err = PathGuard.ValidateRepoPath(path);
+        Assert.NotNull(err);
+        Assert.Contains("absolute path", err, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/src/maf-autopilot.Tests/SourceFileWalkerTests.cs
+++ b/src/maf-autopilot.Tests/SourceFileWalkerTests.cs
@@ -1,0 +1,143 @@
+using MafDoctor.Tools;
+using Xunit;
+
+namespace MafDoctor.Tests;
+
+public class SourceFileWalkerTests
+{
+    // -------------------------------------------------------------------------
+    // ScanBudget cap — #148 finding 2. A single repo walk must not be able to
+    // run unbounded; verify the cap actually stops enumeration and reports
+    // truncation rather than silently returning everything.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void EnumerateCsFiles_UnderDefaultBudget_ReturnsEveryFile_NotTruncated()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            for (var i = 0; i < 5; i++)
+                File.WriteAllText(Path.Combine(root, $"File{i}.cs"), "// content");
+
+            var budget = new SourceFileWalker.ScanBudget();
+            var files = SourceFileWalker.EnumerateCsFiles(root, excludes: null, budget).ToList();
+
+            Assert.Equal(5, files.Count);
+            Assert.Equal(5, budget.FilesSeen);
+            Assert.False(budget.Truncated);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void EnumerateCsFiles_OverBudget_StopsEarlyAndReportsTruncated()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            for (var i = 0; i < 10; i++)
+                File.WriteAllText(Path.Combine(root, $"File{i}.cs"), "// content");
+
+            var budget = new SourceFileWalker.ScanBudget { MaxFiles = 3 };
+            var files = SourceFileWalker.EnumerateCsFiles(root, excludes: null, budget).ToList();
+
+            Assert.Equal(3, files.Count);
+            Assert.Equal(3, budget.FilesSeen);
+            Assert.True(budget.Truncated);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void EnumerateCsFiles_TwoArgOverload_AppliesDefaultBudgetSilently()
+    {
+        // The 2-arg overload (used by every scanning tool today) must still be
+        // bounded even though callers don't pass a ScanBudget explicitly —
+        // that's what protects existing call sites without touching them.
+        var root = CreateTempRoot();
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "Solo.cs"), "// content");
+            var files = SourceFileWalker.EnumerateCsFiles(root, excludes: null).ToList();
+            Assert.Single(files);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void ScanBudget_ExcludesAndCapInteract_ExcludedFilesDoNotCountAgainstBudget()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "samples"));
+            File.WriteAllText(Path.Combine(root, "samples", "Bait.cs"), "// bait");
+            File.WriteAllText(Path.Combine(root, "Real.cs"), "// real");
+
+            var budget = new SourceFileWalker.ScanBudget { MaxFiles = 1 };
+            var files = SourceFileWalker.EnumerateCsFiles(root, excludes: ["samples/"], budget).ToList();
+
+            Assert.Single(files);
+            Assert.EndsWith("Real.cs", files[0]);
+            Assert.False(budget.Truncated);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-file size cap — lives in the shared ScanBudget (not per-tool) so
+    // EVERY caller of EnumerateCsFiles (AntiPatternScannerTool, EstimateCostTool,
+    // AutoFixTool, etc.), not just DoctorTool, is protected against a single
+    // pathologically large file.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void EnumerateCsFiles_OversizedFile_SkippedButWalkContinues()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "Small.cs"), "// x");
+            File.WriteAllText(Path.Combine(root, "Big.cs"), new string('x', 100));
+
+            var budget = new SourceFileWalker.ScanBudget { MaxFileBytes = 10 };
+            var files = SourceFileWalker.EnumerateCsFiles(root, excludes: null, budget).ToList();
+
+            Assert.Single(files);
+            Assert.EndsWith("Small.cs", files[0]);
+            Assert.Equal(1, budget.FilesSkippedOversized);
+            Assert.False(budget.Truncated); // count cap never entered into it
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    [Fact]
+    public void EnumerateCsFiles_OversizedSkip_DoesNotCountAgainstFileCountCap()
+    {
+        var root = CreateTempRoot();
+        try
+        {
+            File.WriteAllText(Path.Combine(root, "Big.cs"), new string('x', 100));
+            File.WriteAllText(Path.Combine(root, "Small1.cs"), "// x");
+            File.WriteAllText(Path.Combine(root, "Small2.cs"), "// x");
+
+            var budget = new SourceFileWalker.ScanBudget { MaxFileBytes = 10, MaxFiles = 2 };
+            var files = SourceFileWalker.EnumerateCsFiles(root, excludes: null, budget).ToList();
+
+            // Both small files fit under MaxFiles=2 even though Big.cs was seen
+            // first in enumeration order — the oversized skip must not consume
+            // a slot in the file-count budget.
+            Assert.Equal(2, files.Count);
+            Assert.False(budget.Truncated);
+        }
+        finally { Directory.Delete(root, recursive: true); }
+    }
+
+    private static string CreateTempRoot()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "sourcefilewalker-test-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        return root;
+    }
+}

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -79,6 +79,15 @@ if (args.Length >= 2 && args[0] == "new")
     Environment.Exit(exitCode);
     return;
 }
+
+// #148: PathGuard now requires repoPath to be absolute (an MCP caller's
+// relative path resolves against the wrong cwd). A human typing a relative
+// path at their own shell is fine and expected — resolve it here so CLI
+// usage like `maf-doctor doctor .` keeps working against every command below
+// that ultimately hits PathGuard (doctor, badge, autofix-all, migrate-scan).
+static string ResolveCliPath(string? parsedPath)
+    => Path.GetFullPath(parsedPath ?? Directory.GetCurrentDirectory());
+
 if (args.Length >= 1 && args[0] == "doctor")
 {
     // Usage: maf-doctor doctor [path] [--exclude <substr>]... [--all|--full] [--json]
@@ -87,7 +96,7 @@ if (args.Length >= 1 && args[0] == "doctor")
     // detector scopes to product code); `--all`/`--full` lists every finding
     // (grouped); `--json` emits machine-readable output.
     var (parsedPath, format, excludes, full) = MafDoctor.Commands.DoctorCli.Parse(args);
-    var path = parsedPath ?? Directory.GetCurrentDirectory();
+    var path = ResolveCliPath(parsedPath);
     var report = new MafDoctor.Tools.DoctorTool().Run(path, format, excludes, full);
     Console.WriteLine(report);
     Environment.Exit(0);
@@ -98,7 +107,10 @@ if (args.Length >= 1 && args[0] == "badge")
     // Phase W.13 — emit a shields.io endpoint-badge JSON payload. Consumers
     // host the JSON output (X.4) and reference it from shields.io URLs like
     // https://img.shields.io/endpoint?url=<your-hosted-json>.
-    var path = args.Length >= 2 ? args[1] : Directory.GetCurrentDirectory();
+    // Resolved via ResolveCliPath too: BadgeCommand.Build runs through
+    // DoctorTool.MafDoctor, which hits the same PathGuard absolute-path
+    // requirement as every other repoPath-taking tool (#148 finding 1).
+    var path = ResolveCliPath(args.Length >= 2 ? args[1] : null);
     var badge = MafDoctor.Commands.BadgeCommand.Build(path);
     Console.WriteLine(badge);
     Environment.Exit(0);
@@ -112,7 +124,7 @@ if (args.Length >= 1 && args[0] == "autofix-all")
     // Default output is human-readable; `--json` emits the machine-readable
     // (MCP-tool) shape. Parsing lives in AutoFixCli so it's unit-testable.
     var (parsedPath, json, dryRun) = MafDoctor.Commands.AutoFixCli.Parse(args);
-    var path = parsedPath ?? Directory.GetCurrentDirectory();
+    var path = ResolveCliPath(parsedPath);
     var tool = new MafDoctor.Tools.AutoFixTool();
     if (json)
     {
@@ -137,7 +149,7 @@ if (args.Length >= 1 && args[0] == "migrate-scan")
     // Parsing lives in MigrateScanCli so the flag handling is unit-testable and so the
     // `--source` value is never mistaken for the path (in either `--source v` form).
     var (parsedPath, source, json) = MafDoctor.Commands.MigrateScanCli.Parse(args);
-    var path = parsedPath ?? Directory.GetCurrentDirectory();
+    var path = ResolveCliPath(parsedPath);
     // --source is currently always semantic-kernel (AutoGen is a later phase); validate
     // the flag so the surface is forward-compatible and an unknown source fails loudly.
     if (!MafDoctor.Commands.MigrateScanCli.IsSupportedSource(source))

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -315,7 +315,9 @@ public sealed class DoctorTool
             SilentStarvationRisks: s.SilentStarvationRisks,
             UnboundedCostSites: s.UnboundedCostSites,
             TopFixes: findings,
-            SummaryMd: markdownSummary);
+            SummaryMd: markdownSummary,
+            ScanTruncated: s.ScanIncomplete,
+            FilesScanned: s.FilesScanned);
     }
 
     /// <summary>
@@ -426,14 +428,27 @@ public sealed class DoctorTool
     // Helpers
     // -------------------------------------------------------------------------
 
-    private static DoctorSummary AnalyzeRepo(string repoPath, IReadOnlyList<string>? excludes)
+    /// <summary>
+    /// Internal (not private) + the budget parameter is test-only: production
+    /// code always calls this with <paramref name="budget"/> null (a fresh,
+    /// default-capped <see cref="SourceFileWalker.ScanBudget"/>). Tests inject a
+    /// tiny cap to exercise the truncation path without creating 50,000 files.
+    ///
+    /// Does NOT itself validate <paramref name="repoPath"/> — every caller
+    /// (today, only <c>RunCore</c>) MUST run it through
+    /// <see cref="PathGuard.ValidateRepoPath"/> first. A future caller that
+    /// invokes this directly "for convenience" would skip that check entirely.
+    /// </summary>
+    internal static DoctorSummary AnalyzeRepo(
+        string repoPath, IReadOnlyList<string>? excludes, SourceFileWalker.ScanBudget? budget = null)
     {
         var antiPatterns = new List<AntiPatternFinding>();
         var handlers = new List<MessageHandlerFinding>();
         var promptFindings = new List<PromptFinding>();
         var costFindings = new List<CostFinding>();
 
-        foreach (var path in EnumerateScannableFiles(repoPath, excludes))
+        budget ??= new SourceFileWalker.ScanBudget();
+        foreach (var path in EnumerateScannableFiles(repoPath, excludes, budget))
         {
             string source, rel;
             try
@@ -441,7 +456,9 @@ public sealed class DoctorTool
                 // Guard ONLY the read + relative-path resolve: a file can be
                 // deleted/locked/raced between enumeration and read. Narrow catch
                 // so analyzer/parse bugs still propagate (the grade must never be
-                // silently degraded by swallowing a logic error).
+                // silently degraded by swallowing a logic error). The oversized-file
+                // skip itself now lives in SourceFileWalker.ScanBudget, shared by
+                // every caller of EnumerateCsFiles, not just this one.
                 source = File.ReadAllText(path);
                 rel = MakeRelative(repoPath, path);
             }
@@ -458,16 +475,42 @@ public sealed class DoctorTool
             costFindings.AddRange(EstimateCostTool.AnalyzeSource(source, rel));
         }
 
-        return Grade(antiPatterns, handlers, promptFindings, costFindings);
+        var summary = Grade(antiPatterns, handlers, promptFindings, costFindings);
+        return summary with
+        {
+            FilesScanned = budget.FilesSeen,
+            FilesSkippedOversized = budget.FilesSkippedOversized,
+            ScanTruncated = budget.Truncated,
+        };
     }
 
-    private static IEnumerable<string> EnumerateScannableFiles(string repoRoot, IReadOnlyList<string>? excludes)
-        => SourceFileWalker.EnumerateCsFiles(repoRoot, excludes);
+    private static IEnumerable<string> EnumerateScannableFiles(
+        string repoRoot, IReadOnlyList<string>? excludes, SourceFileWalker.ScanBudget budget)
+        => SourceFileWalker.EnumerateCsFiles(repoRoot, excludes, budget);
 
     private static string MakeRelative(string root, string file)
         => SourceFileWalker.MakeRelative(root, file);
 
-    private static string FormatReport(string repoPath, DoctorSummary s, bool full = false)
+    /// <summary>
+    /// Shared by <see cref="FormatReport"/> and <see cref="FormatPlan"/> — #148
+    /// finding 2. No-op when the scan was complete. <paramref name="tail"/> is
+    /// the caller-specific closing sentence (report vs. plan read differently).
+    /// </summary>
+    private static void AppendScanIncompleteNote(StringBuilder sb, DoctorSummary s, string tail)
+    {
+        if (!s.ScanIncomplete) return;
+
+        var clauses = new List<string>();
+        if (s.ScanTruncated)
+            clauses.Add($"stopped after {s.FilesScanned:N0} files (repo-size cap reached)");
+        if (s.FilesSkippedOversized > 0)
+            clauses.Add($"skipped {s.FilesSkippedOversized:N0} oversized file(s) (over the per-file size cap)");
+
+        sb.AppendLine($"> ⚠️ **Scan incomplete** — {string.Join("; ", clauses)}. {tail}");
+        sb.AppendLine();
+    }
+
+    internal static string FormatReport(string repoPath, DoctorSummary s, bool full = false)
     {
         var sb = new StringBuilder();
         var emoji = GradeEmoji(s.Grade);
@@ -478,6 +521,7 @@ public sealed class DoctorTool
         sb.AppendLine();
         sb.AppendLine($"**Repo:** `{repoPath.Replace('`', '\'')}`");
         sb.AppendLine();
+        AppendScanIncompleteNote(sb, s, "The grade and findings below reflect a partial scan, not the whole repo.");
         // `doctor` is read-only by design — it diagnoses and grades but never
         // edits files. Spelled out here because "doctor didn't fix anything" is
         // a common first-run misread; the fix path is autofix-all + the agent.
@@ -688,7 +732,7 @@ public sealed class DoctorTool
     /// covers every finding (a partial plan would be misleading). No source
     /// snippets — file:line + why + fix only — so it never echoes a secret.
     /// </summary>
-    private static string FormatPlan(string repoPath, DoctorSummary s)
+    internal static string FormatPlan(string repoPath, DoctorSummary s)
     {
         var sb = new StringBuilder();
         var emoji = GradeEmoji(s.Grade);
@@ -698,6 +742,7 @@ public sealed class DoctorTool
         sb.AppendLine();
         sb.AppendLine($"**Repo:** `{repoPath.Replace('`', '\'')}`");
         sb.AppendLine();
+        AppendScanIncompleteNote(sb, s, "This plan does NOT cover the whole repo.");
 
         var all = s.AllFixes;
         if (all.Count == 0)
@@ -790,7 +835,9 @@ public sealed class DoctorTool
             Repo: repoPath,
             Counts: new PlanCounts(all.Count, auto.Count, manual.Count, heuristicCount),
             Phase1Autofix: phase1,
-            Phase2Semantic: phase2);
+            Phase2Semantic: phase2,
+            ScanTruncated: s.ScanIncomplete,
+            FilesScanned: s.FilesScanned);
     }
 
     /// <summary>
@@ -859,7 +906,21 @@ public sealed record DoctorSummary(
     int UnboundedCostSites,
     int AgentCallSitesChecked,
     IReadOnlyList<DoctorRecommendation> TopFixes,
-    IReadOnlyList<DoctorRecommendation> AllFixes);
+    IReadOnlyList<DoctorRecommendation> AllFixes,
+    // #148 finding 2 — set by AnalyzeRepo from the ScanBudget it walked with.
+    // Trailing + defaulted so every existing Grade(...) call site (production
+    // and tests) keeps compiling unchanged; AnalyzeRepo stamps the real values
+    // via `with` after grading. ScanTruncated means the file-COUNT cap was hit
+    // (the walk stopped early — there ARE unscanned files); FilesSkippedOversized
+    // is a separate, additive signal (individual files skipped for exceeding the
+    // per-file size cap — the walk still covered every other file).
+    int FilesScanned = 0,
+    bool ScanTruncated = false,
+    int FilesSkippedOversized = 0)
+{
+    /// <summary>True if the scan did NOT cover every file in the repo, for any reason.</summary>
+    public bool ScanIncomplete => ScanTruncated || FilesSkippedOversized > 0;
+}
 
 public sealed record DoctorRecommendation(
     int Priority,
@@ -890,7 +951,13 @@ public sealed record DoctorJsonResult(
     [property: JsonPropertyName("silent_starvation_risks")] int SilentStarvationRisks,
     [property: JsonPropertyName("unbounded_cost_sites")] int UnboundedCostSites,
     [property: JsonPropertyName("top_fixes")] IReadOnlyList<DoctorJsonFinding> TopFixes,
-    [property: JsonPropertyName("summary_md")] string SummaryMd);
+    [property: JsonPropertyName("summary_md")] string SummaryMd,
+    // #148 finding 2 — additive within schema_version "1" (consumers ignore
+    // unknown fields, same convention as DoctorJsonFinding.Confidence). A
+    // machine consumer that only reads typed fields (not summary_md) still
+    // needs a structured way to know the scan didn't cover the whole repo.
+    [property: JsonPropertyName("scan_truncated")] bool ScanTruncated = false,
+    [property: JsonPropertyName("files_scanned")] int FilesScanned = 0);
 
 /// <summary>Error shape for format:"json" when the request fails validation (e.g. bad path).</summary>
 public sealed record DoctorJsonError(
@@ -921,7 +988,15 @@ public sealed record DoctorPlanJson(
     [property: JsonPropertyName("repo")] string Repo,
     [property: JsonPropertyName("counts")] PlanCounts Counts,
     [property: JsonPropertyName("phase1_autofix")] PlanPhase1? Phase1Autofix,
-    [property: JsonPropertyName("phase2_semantic")] IReadOnlyList<PlanFinding> Phase2Semantic);
+    [property: JsonPropertyName("phase2_semantic")] IReadOnlyList<PlanFinding> Phase2Semantic,
+    // #148 finding 2 — additive within schema_version "1". This manifest is
+    // built specifically for automated consumption (the maf-remediate loop);
+    // an automated consumer that only reads structured fields (not markdown)
+    // must be able to tell a partial-repo plan apart from a complete one —
+    // silently treating a truncated scan as "fully remediated" is worse for a
+    // machine consumer than for a human reading the markdown --plan banner.
+    [property: JsonPropertyName("scan_truncated")] bool ScanTruncated = false,
+    [property: JsonPropertyName("files_scanned")] int FilesScanned = 0);
 
 public sealed record PlanCounts(
     [property: JsonPropertyName("total")] int Total,

--- a/src/maf-autopilot/Tools/PathGuard.cs
+++ b/src/maf-autopilot/Tools/PathGuard.cs
@@ -47,6 +47,23 @@ internal static class PathGuard
             if (segment == "..")
                 return $"Error: {parameterName} must not contain '..' segments (path traversal).";
 
+        // #148 finding 1 — every tool description tells the LLM caller to pass an
+        // absolute path, but nothing enforced it. A relative value (e.g. ".")
+        // resolves against Environment.CurrentDirectory, which for an MCP-spawned
+        // process is the host's cwd — typically the user's home directory, NOT
+        // the repo the caller meant. Reject here rather than silently resolving
+        // against the wrong root (autofix tools write by default).
+        //
+        // IsPathFullyQualified, not IsPathRooted: on Windows, IsPathRooted
+        // returns true for drive-relative paths like "C:tmp" (no separator
+        // after the colon) and rooted-to-current-drive paths like "\tmp" —
+        // both still resolve against the process's current directory (on that
+        // drive, or on the current drive respectively), reproducing exactly
+        // the "wrong root" bug this check exists to close. IsPathFullyQualified
+        // rejects both and only accepts genuinely unambiguous paths.
+        if (!Path.IsPathFullyQualified(path))
+            return $"Error: {parameterName} must be an absolute path (got a relative path).";
+
         if (!Directory.Exists(path))
             return $"Error: directory does not exist: '{path}'.";
 

--- a/src/maf-autopilot/Tools/SourceFileWalker.cs
+++ b/src/maf-autopilot/Tools/SourceFileWalker.cs
@@ -56,6 +56,50 @@ internal static class SourceFileWalker
     };
 
     /// <summary>
+    /// Hard ceiling on how many files a single repo walk yields. #148 finding 2 —
+    /// none of the scanning tools capped scan size, so an accidentally-huge
+    /// target (a big monorepo, a mounted drive, or a misresolved cwd) turned one
+    /// call into an unbounded-time, unbounded-memory walk. Iterator methods
+    /// can't use <c>out</c> parameters, so truncation is surfaced by mutating
+    /// this shared, caller-owned counter as <see cref="EnumerateCsFiles(string, IReadOnlyList{string}?, ScanBudget)"/>
+    /// yields — inspect <see cref="Truncated"/> after enumerating.
+    ///
+    /// The default (50,000 files) is deliberately generous: this repo alone has
+    /// ~155 <c>.cs</c> files, and even a very large real-world C# codebase rarely
+    /// exceeds a few tens of thousands — the cap exists to bound pathological
+    /// targets, not to constrain normal repos.
+    /// </summary>
+    internal sealed class ScanBudget
+    {
+        public int MaxFiles { get; init; } = 50_000;
+
+        // A single pathologically large file (deeply-nested generics, a giant
+        // generated source file) fully materialized via File.ReadAllText can
+        // dominate memory just like an unbounded file COUNT can dominate time.
+        // Lives here (not per-tool) so every caller of EnumerateCsFiles gets the
+        // same protection — matches the order of magnitude of the CI
+        // "compiler-bomb cap" (maf-pr-audit.yml).
+        public long MaxFileBytes { get; init; } = 10 * 1024 * 1024; // 10 MB
+
+        public int FilesSeen { get; private set; }
+        public int FilesSkippedOversized { get; private set; }
+        public bool Truncated { get; private set; }
+
+        public bool TryAccept()
+        {
+            if (FilesSeen >= MaxFiles)
+            {
+                Truncated = true;
+                return false;
+            }
+            FilesSeen++;
+            return true;
+        }
+
+        internal void RecordOversizedSkip() => FilesSkippedOversized++;
+    }
+
+    /// <summary>
     /// Enumerates every <c>*.cs</c> file under <paramref name="repoRoot"/>,
     /// excluding common build artefact paths (<c>/bin/</c>, <c>/obj/</c>).
     /// Unreadable subdirectories are silently skipped (see
@@ -75,8 +119,20 @@ internal static class SourceFileWalker
     /// (not glob) by design: simple, no edge cases, and the <em>relative</em>
     /// path is tested (not the absolute one) so the repo's on-disk location
     /// can't accidentally match an exclude token.
+    ///
+    /// Bounded by a default <see cref="ScanBudget"/> — see the 3-argument
+    /// overload if the caller wants to know whether the walk was truncated.
     /// </summary>
     public static IEnumerable<string> EnumerateCsFiles(string repoRoot, IReadOnlyList<string>? excludes)
+        => EnumerateCsFiles(repoRoot, excludes, new ScanBudget());
+
+    /// <summary>
+    /// Same as the two-argument overload, but stops once <paramref name="budget"/>'s
+    /// file-count ceiling is reached. Callers that want to surface a "scan
+    /// truncated" note (e.g. <c>DoctorTool</c>) should pass their own
+    /// <see cref="ScanBudget"/> and inspect it after enumerating.
+    /// </summary>
+    public static IEnumerable<string> EnumerateCsFiles(string repoRoot, IReadOnlyList<string>? excludes, ScanBudget budget)
     {
         var skip = (excludes ?? [])
             .Where(e => !string.IsNullOrWhiteSpace(e))
@@ -93,6 +149,21 @@ internal static class SourceFileWalker
                 var rel = MakeRelative(repoRoot, path);
                 if (skip.Any(s => rel.Contains(s, PathComparison))) continue;
             }
+
+            long length;
+            try { length = new FileInfo(path).Length; }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                continue; // raced/unreadable between enumeration and stat — same skip as IgnoreInaccessible
+            }
+            if (length > budget.MaxFileBytes)
+            {
+                budget.RecordOversizedSkip();
+                continue; // skip just this one file — the walk keeps going
+            }
+
+            if (!budget.TryAccept())
+                yield break; // file-count cap — stop the walk entirely
             yield return path;
         }
     }


### PR DESCRIPTION
Fixes #148.

## Summary

Three fixes, plus the fallout from self-reviewing them with a 5-angle multi-agent pass before opening this PR.

### 1. `PathGuard.ValidateRepoPath` now requires a genuinely absolute path

Every tool's description tells the caller to pass an absolute `repoPath`, but nothing enforced it — a relative value (e.g. `"."`) resolved against `Environment.CurrentDirectory`, which for an MCP-spawned server is typically the user's **home directory**, not the repo the caller meant (per #146). Combined with `MafAutoFix`/`MafAutoFixAll` defaulting `dryRun` to `false`, that's a path to unintended writes outside the intended repo.

Uses `Path.IsPathFullyQualified`, not `Path.IsPathRooted` — the self-review caught that `IsPathRooted` wrongly accepts Windows drive-relative paths like `"C:tmp"` (no separator after the colon) and `"\tmp"` (rooted to the current drive), both of which still resolve against the process's current directory and would have silently reopened the exact bug this closes.

CLI usage (`maf-doctor doctor .`, `autofix-all .`, `migrate-scan .`, and — caught in review — `badge .`, which transitively hits the same check via `DoctorTool.MafDoctor`) is unaffected: a shared `ResolveCliPath` helper in `Program.cs` resolves relative CLI input to absolute before it reaches `PathGuard`.

### 2. Repo scans are now bounded

None of the scanning tools capped how much work a single call could do. `SourceFileWalker.EnumerateCsFiles` now carries a shared `ScanBudget`:
- a file-count ceiling (default 50,000 — deliberately generous; this repo has ~155 `.cs` files) applied automatically to **every** caller, not just `DoctorTool`
- a per-file size ceiling (10 MB) that skips a pathologically large file without stopping the rest of the walk

`DoctorTool` surfaces both as a "Scan incomplete" note in markdown/plan output, and as additive `scan_truncated` / `files_scanned` fields in `--json` / `--plan --json` (documented in `docs/output-schemas.md`) — a machine consumer of the remediation manifest shouldn't be able to mistake a partial scan for a fully-remediated repo.

### 3. `MAF PR Audit` no longer fails on fork PRs (including #147)

GitHub force-downgrades `GITHUB_TOKEN` to read-only for `pull_request`-triggered runs from a fork, regardless of the workflow's declared `permissions:` — which is exactly why this check has been failing on every external PR. `maf-pr-audit.yml` no longer tries to post its own comment: it always uploads an artifact (the real report, or a placeholder when the audit was intentionally skipped) and a new companion workflow, `maf-pr-audit-comment.yml` (triggered by `workflow_run`), posts the sticky comment with a normal write-scoped token — it never checks out or executes fork-supplied code, only the plain markdown artifact the already-completed, read-only job produced.

Self-review caught that the companion workflow was missing the `actions: read` permission needed for `download-artifact`'s cross-run download (`run-id`) — without it, every run would have silently failed to comment while still showing green, defeating the whole fix.

## Verification

- 5-angle multi-agent self-review (line-by-line, removed-behavior, cross-file tracer, reuse/simplification/efficiency/altitude, CLAUDE.md conventions) run before finalizing — findings incorporated above.
- `dotnet test` — **1013 tests green on net8.0 and net9.0** (net10.0 build was blocked locally by this session's own live MCP server holding the DLL open; unrelated to the change — CI runs clean).
- Manually verified `actions/download-artifact@v7.0.0`'s `run-id`/`github-token` cross-run inputs and `marocchino/sticky-pull-request-comment@v2.9.2`'s `number` input against the exact pinned SHAs already used in this repo (not just the action's latest docs).
- YAML syntax-checked both workflow files.

## Notes

- `badge` and `new agent/executor` CLI commands were left untouched where they don't currently call `PathGuard` — no behavior change needed there.
- The oversized-file cap now lives in the shared `SourceFileWalker`, so every caller (`AntiPatternScannerTool`, `EstimateCostTool`, `AutoFixTool`, etc.) is protected, not just `DoctorTool` — but only `DoctorTool` surfaces a "scan incomplete" note in its own output today. Extending that visibility to every other tool's output would be a much larger, separate change; flagging as a reasonable follow-up rather than folding it into this PR.
- A regex-catastrophic-backtracking audit of the anti-pattern/prompt-lint rules (flagged as an open question in #148) is still outstanding — not attempted here.
