### PR TITLE
Phase 1: autofix engine remediation

### DIFF
--- a/src/maf-autopilot.Tests/AutoFixCliTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixCliTests.cs
@@ -191,4 +191,37 @@ public class AutoFixCliTests
         Assert.Contains("1 file changed", output);
         Assert.DoesNotContain("1 files changed", output);
     }
+
+    // -------------------------------------------------------------------------
+    // Format — WM-24 preview diffs
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Format_DryRun_WithDiffs_InlinesUnifiedDiff()
+    {
+        var report = new AutoFixTool.AutoFixAllReport(
+            DryRun: true,
+            OrderOfExecution: AutoFixTool.OrderedRuleIds,
+            TotalDistinctFilesChanged: 1,
+            AffectedFiles: new[] { "A.cs" },
+            PerRule: new[]
+            {
+                new AutoFixTool.AutoFixRuleReport("MAF-AP-WF-001", 1, new[] { "A.cs" }),
+                new AutoFixTool.AutoFixRuleReport("MAF-AP-SEC-003", 0, Array.Empty<string>()),
+                new AutoFixTool.AutoFixRuleReport("MAF-AP-SEC-001", 0, Array.Empty<string>()),
+                new AutoFixTool.AutoFixRuleReport("MAF130-FAN-IN-001", 0, Array.Empty<string>()),
+                new AutoFixTool.AutoFixRuleReport("MAF-AP-CONC-002", 0, Array.Empty<string>()),
+            },
+            Diffs: new[]
+            {
+                new AutoFixTool.AutoFixFileDiff("A.cs", new[] { "MAF-AP-WF-001" },
+                    "@@ -1,1 +1,1 @@\n-public class A {}\n+public sealed class A {}\n"),
+            });
+
+        var output = AutoFixCli.Format(report);
+
+        Assert.Contains("Preview (unified diff", output);
+        Assert.Contains("+public sealed class A {}", output);
+        Assert.Contains("A.cs", output);
+    }
 }

--- a/src/maf-autopilot.Tests/AutoFixToolTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixToolTests.cs
@@ -1248,4 +1248,106 @@ public class AutoFixToolTests
             Directory.Delete(dir, recursive: true);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // Adversarial-review follow-ups (Phase 1 verification pass).
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ExecutorSealedRewriter_ZeroModifierClass_KeepsIndentAndDocAttached()
+    {
+        // A bare (internal-by-default) Executor with a leading XML doc: `sealed`
+        // must carry the declaration's leading trivia, else the doc is stranded
+        // between `partial` and `class` (de-indent + CS1587 doc detachment).
+        var input = """
+            namespace N
+            {
+                /// <summary>Doc.</summary>
+                class MyExec : Executor
+                {
+                    [MessageHandler]
+                    public System.Threading.Tasks.Task<int> Handle(string s) => null!;
+                }
+            }
+            """;
+        var output = ApplyRewriter(new ExecutorSealedRewriter(), input).Replace("\r\n", "\n");
+        Assert.Contains("sealed partial class MyExec", output); // modifiers contiguous, class not stranded
+        var docIdx = output.IndexOf("/// <summary>Doc", StringComparison.Ordinal);
+        var sealedIdx = output.IndexOf("sealed partial class MyExec", StringComparison.Ordinal);
+        Assert.True(docIdx >= 0 && docIdx < sealedIdx, "doc comment must stay attached above the declaration");
+    }
+
+    [Fact]
+    public void EnableSensitiveDataRewriter_RemovesNestedFlagInSurvivingSibling()
+    {
+        // The outer entry is removed AND the nested flag inside a surviving sibling
+        // is cleaned in the same single pass (no fixpoint) — WM-22 review follow-up.
+        var input = """
+            class C {
+                void M() {
+                    var o = new AgentConfig {
+                        EnableSensitiveData = true,
+                        Telemetry = new TelemetryOptions { EnableSensitiveData = true },
+                    };
+                }
+            }
+            """;
+        var output = ApplyRewriter(new EnableSensitiveDataRewriter(), input);
+        Assert.DoesNotContain("EnableSensitiveData", output);          // BOTH flags gone
+        Assert.Contains("Telemetry = new TelemetryOptions", output);   // the sibling itself survives
+    }
+
+    [Fact]
+    public void MafAutoFixAll_Utf8BomWithInvalidBytes_SkippedWithError_NotCorrupted()
+    {
+        // A UTF-8-BOM file with an invalid byte must still be rejected (not U+FFFD'd)
+        // — the strict decode must hold for BOM'd files too, not only BOM-less ones.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-bomstrict-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "BomBad.cs");
+            // BOM + "class C \x80{}" (0x80 is a lone continuation byte — invalid UTF-8).
+            var bytes = new byte[] { 0xEF, 0xBB, 0xBF, 0x63, 0x6C, 0x61, 0x73, 0x73, 0x20, 0x43, 0x20, 0x80, 0x7B, 0x7D };
+            File.WriteAllBytes(file, bytes);
+            var json = new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var doc = JsonSerializer.Deserialize<JsonDocument>(json)!;
+            Assert.True(doc.RootElement.GetProperty("errors").GetArrayLength() >= 1, json);
+            Assert.Equal(bytes, File.ReadAllBytes(file)); // byte-identical, no corruption
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void MafAutoFixAll_LockedFile_RecordedAsError_PassContinues()
+    {
+        // A file locked by another process must be a per-file error, not a whole-pass
+        // abort — and every OTHER file must still be fixed. (Exclusive-share read
+        // blocking is a Windows behavior; the assertion runs there.)
+        if (!OperatingSystem.IsWindows()) return;
+        var dir = Path.Combine(Path.GetTempPath(), "maf-lockedfile-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Good.cs"), """
+                using System.Threading.Tasks;
+                public class Executor { }
+                public sealed class MessageHandlerAttribute : System.Attribute { }
+                public partial class MyExec : Executor {
+                  [MessageHandler]
+                  public Task<int> Handle(string s) => Task.FromResult(0);
+                }
+                """);
+            var bad = Path.Combine(dir, "Bad.cs");
+            File.WriteAllText(bad, "public class Bad {}");
+            using (new FileStream(bad, FileMode.Open, FileAccess.Read, FileShare.None)) // exclusive lock
+            {
+                var json = new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+                var doc = JsonSerializer.Deserialize<JsonDocument>(json)!;
+                Assert.True(doc.RootElement.GetProperty("errors").GetArrayLength() >= 1, json); // locked file reported
+                Assert.Contains("sealed partial", File.ReadAllText(Path.Combine(dir, "Good.cs"))); // other file still fixed
+            }
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
 }

--- a/src/maf-autopilot.Tests/AutoFixToolTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixToolTests.cs
@@ -1135,4 +1135,117 @@ public class AutoFixToolTests
         }
         finally { Directory.Delete(dir, recursive: true); }
     }
+
+    // -------------------------------------------------------------------------
+    // WM-22 / WM-42 / WM-43: rewriter-correctness regressions.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void EnableSensitiveDataRewriter_PreservesSurvivingEntryCommentsAndLines()
+    {
+        var input = """
+            class C {
+                void M() {
+                    var o = new Options {
+                        Name = "x", // keep me
+                        EnableSensitiveData = true,
+                        Count = 3,
+                    };
+                }
+            }
+            """;
+        var output = ApplyRewriter(new EnableSensitiveDataRewriter(), input).Replace("\r\n", "\n");
+        Assert.DoesNotContain("EnableSensitiveData", output);
+        Assert.Contains("// keep me", output);   // inline comment survives (was deleted before WM-22)
+        Assert.Contains("Name = \"x\"", output);
+        Assert.Contains("Count = 3", output);
+        // Surviving entries are NOT collapsed onto one line: a newline separates them.
+        var idxComment = output.IndexOf("// keep me", StringComparison.Ordinal);
+        var idxCount = output.IndexOf("Count = 3", StringComparison.Ordinal);
+        Assert.True(idxComment >= 0 && idxCount > idxComment);
+        Assert.Contains('\n', output[idxComment..idxCount]);
+    }
+
+    [Fact]
+    public void SyncOverAsyncRewriter_SkipTodo_UsesFileNewline_Crlf()
+    {
+        // `.Result` in a NON-async method → skip-with-TODO. CRLF source: the
+        // inserted comment line must end CRLF, not splice in a lone LF (WM-42).
+        var src = "class C {\r\n    int M() {\r\n        return Foo().Result;\r\n    }\r\n    System.Threading.Tasks.Task<int> Foo() => null!;\r\n}\r\n";
+        var output = ApplyRewriter(new SyncOverAsyncRewriter(), src);
+        var idx = output.IndexOf("// MAF-AP-CONC-002", StringComparison.Ordinal);
+        Assert.True(idx >= 0, "expected a skip-with-TODO comment");
+        var firstNl = output.IndexOf('\n', idx);
+        Assert.True(firstNl > 0 && output[firstNl - 1] == '\r',
+            "the inserted TODO line must end with CRLF in a CRLF file, not a lone LF");
+    }
+
+    [Fact]
+    public void FanInArgOrderRewriter_DoesNotSwap_TypeMerelyContainingList()
+    {
+        // `ListenerNode` merely CONTAINS "List" but is not a collection — must not
+        // be mistaken for a sources array and trigger a wrong swap (WM-43).
+        var input = """
+            class ListenerNode {}
+            class B { void AddFanInBarrierEdge(object target, object sources) {} }
+            class C { void M() { var b = new B(); object t = null; b.AddFanInBarrierEdge(t, new ListenerNode()); } }
+            """;
+        var output = ApplyRewriter(new FanInArgOrderRewriter(), input);
+        Assert.Contains("AddFanInBarrierEdge(t, new ListenerNode())", output); // unchanged
+    }
+
+    [Fact]
+    public void FanInArgOrderRewriter_StillSwaps_GenericListSource()
+    {
+        var input = """
+            using System.Collections.Generic;
+            class B {
+              void AddFanInBarrierEdge(object target, List<object> sources) {}
+              void AddFanInBarrierEdge(List<object> sources, object target) {}
+            }
+            class C { void M() { var b = new B(); object t = null; b.AddFanInBarrierEdge(t, new List<object>()); } }
+            """;
+        var output = ApplyRewriter(new FanInArgOrderRewriter(), input);
+        Assert.Contains("AddFanInBarrierEdge(new List<object>(), t)", output); // genuine List still swaps
+    }
+
+    // -------------------------------------------------------------------------
+    // WM-44: concurrent applies on one repo are serialised by an exclusive lock.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void MafAutoFixAll_Apply_WhenLockHeld_ReturnsError_ButDryRunIsNeverBlocked()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-wm44-lock-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var lockPath = AutoFixTool.ApplyLockPath(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "C.cs"), "public class C {}");
+
+            using (new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            {
+                // A concurrent APPLY is refused while the lock is held...
+                var applyJson = new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+                var applyDoc = JsonSerializer.Deserialize<JsonDocument>(applyJson)!;
+                Assert.True(applyDoc.RootElement.TryGetProperty("error", out var err), applyJson);
+                Assert.Contains("already applying", err.GetString(), StringComparison.OrdinalIgnoreCase);
+
+                // ...but a DRY-RUN writes nothing, so it must never be blocked.
+                var dryDoc = JsonSerializer.Deserialize<JsonDocument>(
+                    new AutoFixTool().MafAutoFixAll(dir, dryRun: true))!;
+                Assert.False(dryDoc.RootElement.TryGetProperty("error", out _));
+            }
+
+            // Lock released → apply succeeds.
+            var okDoc = JsonSerializer.Deserialize<JsonDocument>(
+                new AutoFixTool().MafAutoFixAll(dir, dryRun: false))!;
+            Assert.False(okDoc.RootElement.TryGetProperty("error", out _));
+        }
+        finally
+        {
+            try { File.Delete(lockPath); } catch { /* best-effort */ }
+            Directory.Delete(dir, recursive: true);
+        }
+    }
 }

--- a/src/maf-autopilot.Tests/AutoFixToolTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixToolTests.cs
@@ -906,19 +906,21 @@ public class AutoFixToolTests
     [Fact]
     public void SyncOverAsyncRewriter_AsyncMethodOutsideLock_StillRewritten()
     {
-        // Sanity check — the guard doesn't break the happy path.
+        // Sanity check — the guard doesn't break the happy path. Method named
+        // `*Async` so the syntax-only awaitability gate rewrites it (a non-Async
+        // name would now be a safe skip — see SemaphoreSlim/custom-.Result cases).
         var src = """
             class C
             {
                 async System.Threading.Tasks.Task M()
                 {
-                    var x = Foo().Result;
+                    var x = FooAsync().Result;
                 }
-                System.Threading.Tasks.Task<int> Foo() => null!;
+                System.Threading.Tasks.Task<int> FooAsync() => null!;
             }
             """;
         var output = ApplyRewriter(new SyncOverAsyncRewriter(), src);
-        Assert.Contains("await Foo()", output);
+        Assert.Contains("await FooAsync()", output);
         Assert.DoesNotContain(".Result", output);
     }
 

--- a/src/maf-autopilot.Tests/AutoFixToolTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixToolTests.cs
@@ -1101,4 +1101,38 @@ public class AutoFixToolTests
         }
         finally { Directory.Delete(dir, recursive: true); }
     }
+
+    // -------------------------------------------------------------------------
+    // WM-24: dry-run preview carries a reviewable per-file diff, not just names.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void MafAutoFixAll_DryRun_IncludesReviewableDiff()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-wm24-diff-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Exec.cs");
+            var original = """
+                using System.Threading.Tasks;
+                public class Executor { }
+                public sealed class MessageHandlerAttribute : System.Attribute { }
+                public partial class MyExec : Executor {
+                  [MessageHandler]
+                  public Task<int> Handle(string s) => Task.FromResult(0);
+                }
+                """;
+            File.WriteAllText(file, original);
+            var json = new AutoFixTool().MafAutoFixAll(dir, dryRun: true);
+            var doc = JsonSerializer.Deserialize<JsonDocument>(json)!;
+            var diffs = doc.RootElement.GetProperty("diffs");
+            Assert.Equal(1, diffs.GetArrayLength());
+            var diffText = diffs[0].GetProperty("diff").GetString()!;
+            Assert.Contains("+", diffText);                    // a real added line, not just a file name
+            Assert.Contains("sealed partial class MyExec", diffText); // the rewrite is shown
+            Assert.Equal(original, File.ReadAllText(file));    // dry-run wrote nothing
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
 }

--- a/src/maf-autopilot.Tests/AutoFixToolTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixToolTests.cs
@@ -971,4 +971,134 @@ public class AutoFixToolTests
             Directory.Delete(tempRoot, recursive: true);
         }
     }
+
+    // -------------------------------------------------------------------------
+    // WM-41: a missing / non-.cs specificFile is an ERROR, not a silent 0-change.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void MafAutoFix_MissingSpecificFile_ReturnsError()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-wm41-missing-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var json = new AutoFixTool().MafAutoFix(dir, "MAF-AP-CONC-002", specificFile: "nope.cs", dryRun: true);
+            var doc = JsonSerializer.Deserialize<JsonDocument>(json)!;
+            Assert.True(doc.RootElement.TryGetProperty("error", out var err), json);
+            Assert.Contains("not found", err.GetString(), StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void MafAutoFix_NonCsSpecificFile_ReturnsError()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-wm41-noncs-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "readme.txt"), "not code");
+            var json = new AutoFixTool().MafAutoFix(dir, "MAF-AP-CONC-002", specificFile: "readme.txt", dryRun: true);
+            var doc = JsonSerializer.Deserialize<JsonDocument>(json)!;
+            Assert.True(doc.RootElement.TryGetProperty("error", out var err), json);
+            Assert.Contains(".cs file", err.GetString(), StringComparison.OrdinalIgnoreCase);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
+    // WM-20: encoding/BOM preservation + undecodable-file safety on apply.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void MafAutoFixAll_PreservesUtf8Bom_OnApply()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-wm20-bom-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Bom.cs");
+            var code = """
+                using System.Threading.Tasks;
+                public class Executor { }
+                public sealed class MessageHandlerAttribute : System.Attribute { }
+                public partial class MyExec : Executor {
+                  [MessageHandler]
+                  public Task<int> Handle(string s) => Task.FromResult(0);
+                }
+                """;
+            File.WriteAllText(file, code, new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: true));
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false); // WF-001 adds `sealed` → file rewritten
+            var bytes = File.ReadAllBytes(file);
+            Assert.True(bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF,
+                "UTF-8 BOM must be preserved across the rewrite");
+            Assert.Contains("sealed partial", File.ReadAllText(file));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void MafAutoFixAll_UndecodableFile_SkippedWithError_NotCorrupted()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-wm20-invalid-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Bad.cs");
+            // "class \x80C {}" — 0x80 is a lone UTF-8 continuation byte (invalid).
+            var badBytes = new byte[] { 0x63, 0x6C, 0x61, 0x73, 0x73, 0x20, 0x80, 0x43, 0x20, 0x7B, 0x7D };
+            File.WriteAllBytes(file, badBytes);
+            var json = new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var doc = JsonSerializer.Deserialize<JsonDocument>(json)!;
+            Assert.True(doc.RootElement.GetProperty("errors").GetArrayLength() >= 1,
+                "an undecodable file must be reported, not silently swallowed: " + json);
+            Assert.Equal(badBytes, File.ReadAllBytes(file)); // left byte-identical, no U+FFFD corruption
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
+    // WM-23: single per-file pass — dry-run composes rewriters exactly as apply,
+    // both rules land in one pass, and a second apply is a no-op (idempotent).
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void MafAutoFixAll_DryRunComposesLikeApply_AndIsIdempotent()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-wm23-compose-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "Multi.cs");
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class Executor { }
+                public sealed class MessageHandlerAttribute : System.Attribute { }
+                public partial class MyExec : Executor {
+                  [MessageHandler]
+                  public async Task<int> Handle(string s) { return FetchAsync().Result; }
+                  static Task<int> FetchAsync() => Task.FromResult(0);
+                }
+                """);
+            var tool = new AutoFixTool();
+
+            var preview = JsonSerializer.Deserialize<JsonDocument>(tool.MafAutoFixAll(dir, dryRun: true))!;
+            var previewTotal = preview.RootElement.GetProperty("totalDistinctFilesChanged").GetInt32();
+
+            var apply = JsonSerializer.Deserialize<JsonDocument>(tool.MafAutoFixAll(dir, dryRun: false))!;
+            var applyTotal = apply.RootElement.GetProperty("totalDistinctFilesChanged").GetInt32();
+
+            Assert.Equal(previewTotal, applyTotal); // dry-run reported exactly what apply did
+            Assert.Equal(1, applyTotal);
+
+            var after = File.ReadAllText(file);
+            Assert.Contains("sealed partial", after);        // WF-001 applied
+            Assert.Contains("(await FetchAsync())", after);  // CONC-002 applied in the SAME pass
+
+            var again = JsonSerializer.Deserialize<JsonDocument>(tool.MafAutoFixAll(dir, dryRun: false))!;
+            Assert.Equal(0, again.RootElement.GetProperty("totalDistinctFilesChanged").GetInt32());
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
 }

--- a/src/maf-autopilot.Tests/AutoFixToolTests.cs
+++ b/src/maf-autopilot.Tests/AutoFixToolTests.cs
@@ -23,6 +23,26 @@ public class AutoFixToolTests
         return newRoot.ToFullString();
     }
 
+    // A clean WF-001 Executor target (so a rewriter WILL match) with one invalid
+    // UTF-8 byte (0x80) inside a `//` comment, optionally UTF-8-BOM-prefixed. Because
+    // a rewriter matches, the "byte-identical after apply" assertion is load-bearing:
+    // if the strict decode were reverted the file would be U+FFFD-decoded, gain
+    // `sealed`, and be written back — no longer byte-identical.
+    private static byte[] ExecutorSourceWithInvalidByte(bool utf8Bom)
+    {
+        const string head =
+            "using System.Threading.Tasks;\npublic class Executor { }\n" +
+            "public sealed class MessageHandlerAttribute : System.Attribute { }\n" +
+            "public partial class MyExec : Executor {\n  // ";
+        const string tail =
+            "\n  [MessageHandler]\n  public Task<int> Handle(string s) => Task.FromResult(0);\n}\n";
+        IEnumerable<byte> bytes = System.Text.Encoding.ASCII.GetBytes(head)
+            .Concat(new byte[] { 0x80 })
+            .Concat(System.Text.Encoding.ASCII.GetBytes(tail));
+        if (utf8Bom) bytes = new byte[] { 0xEF, 0xBB, 0xBF }.Concat(bytes);
+        return bytes.ToArray();
+    }
+
     // -------------------------------------------------------------------------
     // DefaultAzureCredentialRewriter (MAF-AP-SEC-001 / MAF002)
     // -------------------------------------------------------------------------
@@ -1045,15 +1065,17 @@ public class AutoFixToolTests
         Directory.CreateDirectory(dir);
         try
         {
-            var file = Path.Combine(dir, "Bad.cs");
-            // "class \x80C {}" — 0x80 is a lone UTF-8 continuation byte (invalid).
-            var badBytes = new byte[] { 0x63, 0x6C, 0x61, 0x73, 0x73, 0x20, 0x80, 0x43, 0x20, 0x7B, 0x7D };
+            // A WF-001-matching Executor with an invalid byte in a comment — so if the
+            // strict decode were reverted, WF-001 would add `sealed` and the file WOULD
+            // be rewritten (0x80 → EF BF BD), making the byte-identical check fail.
+            var file = Path.Combine(dir, "MyExec.cs");
+            var badBytes = ExecutorSourceWithInvalidByte(utf8Bom: false);
             File.WriteAllBytes(file, badBytes);
             var json = new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
             var doc = JsonSerializer.Deserialize<JsonDocument>(json)!;
             Assert.True(doc.RootElement.GetProperty("errors").GetArrayLength() >= 1,
                 "an undecodable file must be reported, not silently swallowed: " + json);
-            Assert.Equal(badBytes, File.ReadAllBytes(file)); // left byte-identical, no U+FFFD corruption
+            Assert.Equal(badBytes, File.ReadAllBytes(file)); // skipped whole — not U+FFFD-rewritten
         }
         finally { Directory.Delete(dir, recursive: true); }
     }
@@ -1306,9 +1328,11 @@ public class AutoFixToolTests
         Directory.CreateDirectory(dir);
         try
         {
-            var file = Path.Combine(dir, "BomBad.cs");
-            // BOM + "class C \x80{}" (0x80 is a lone continuation byte — invalid UTF-8).
-            var bytes = new byte[] { 0xEF, 0xBB, 0xBF, 0x63, 0x6C, 0x61, 0x73, 0x73, 0x20, 0x43, 0x20, 0x80, 0x7B, 0x7D };
+            // UTF-8-BOM + a WF-001 target + an invalid byte: proves the strict decode
+            // holds for BOM'd files too (StreamReader's BOM path would otherwise swap in
+            // a replacement-fallback decoder, U+FFFD the byte, then rewrite the file).
+            var file = Path.Combine(dir, "MyExec.cs");
+            var bytes = ExecutorSourceWithInvalidByte(utf8Bom: true);
             File.WriteAllBytes(file, bytes);
             var json = new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
             var doc = JsonSerializer.Deserialize<JsonDocument>(json)!;
@@ -1319,13 +1343,12 @@ public class AutoFixToolTests
     }
 
     [Fact]
-    public void MafAutoFixAll_LockedFile_RecordedAsError_PassContinues()
+    public void MafAutoFixAll_UnreadableFile_RecordedAsError_PassContinues()
     {
-        // A file locked by another process must be a per-file error, not a whole-pass
-        // abort — and every OTHER file must still be fixed. (Exclusive-share read
-        // blocking is a Windows behavior; the assertion runs there.)
-        if (!OperatingSystem.IsWindows()) return;
-        var dir = Path.Combine(Path.GetTempPath(), "maf-lockedfile-" + Guid.NewGuid().ToString("N"));
+        // An unreadable .cs (locked / permission-denied) must be a per-file error, not
+        // a whole-pass abort — and every OTHER file must still be fixed. Forced via a
+        // Windows exclusive-share lock or a POSIX chmod-000 so it runs on Linux CI too.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-unreadable-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
         try
         {
@@ -1340,14 +1363,125 @@ public class AutoFixToolTests
                 """);
             var bad = Path.Combine(dir, "Bad.cs");
             File.WriteAllText(bad, "public class Bad {}");
-            using (new FileStream(bad, FileMode.Open, FileAccess.Read, FileShare.None)) // exclusive lock
+
+            FileStream? winLock = null;
+            if (OperatingSystem.IsWindows())
+            {
+                winLock = new FileStream(bad, FileMode.Open, FileAccess.Read, FileShare.None); // exclusive
+            }
+            else
+            {
+                File.SetUnixFileMode(bad, UnixFileMode.None); // chmod 000
+                // Running as root (common in CI containers) ignores the mode; then the
+                // failure can't be forced, so skip rather than assert a false negative.
+                try { using var probe = File.OpenRead(bad); File.SetUnixFileMode(bad, UnixFileMode.UserRead | UnixFileMode.UserWrite); return; }
+                catch { /* good — genuinely unreadable */ }
+            }
+
+            try
             {
                 var json = new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
                 var doc = JsonSerializer.Deserialize<JsonDocument>(json)!;
-                Assert.True(doc.RootElement.GetProperty("errors").GetArrayLength() >= 1, json); // locked file reported
-                Assert.Contains("sealed partial", File.ReadAllText(Path.Combine(dir, "Good.cs"))); // other file still fixed
+                Assert.True(doc.RootElement.GetProperty("errors").GetArrayLength() >= 1, json); // unreadable file reported
+                Assert.Contains("sealed partial", File.ReadAllText(Path.Combine(dir, "Good.cs"))); // other file STILL fixed
+            }
+            finally
+            {
+                winLock?.Dispose();
+                if (!OperatingSystem.IsWindows()) File.SetUnixFileMode(bad, UnixFileMode.UserRead | UnixFileMode.UserWrite);
             }
         }
         finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Theory]
+    [InlineData(false)] // UTF-16 LE
+    [InlineData(true)]  // UTF-16 BE
+    public void MafAutoFixAll_PreservesUtf16Bom_OnApply(bool bigEndian)
+    {
+        // The UTF-16 detect+preserve branches must round-trip byte-faithfully: the BOM
+        // (and endianness) survive and the file is NOT normalised to UTF-8.
+        var dir = Path.Combine(Path.GetTempPath(), "maf-utf16-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "U16.cs");
+            var enc = new System.Text.UnicodeEncoding(bigEndian, byteOrderMark: true);
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class Executor { }
+                public sealed class MessageHandlerAttribute : System.Attribute { }
+                public partial class MyExec : Executor {
+                  [MessageHandler]
+                  public Task<int> Handle(string s) => Task.FromResult(0);
+                }
+                """, enc);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false); // WF-001 adds `sealed`
+            var bytes = File.ReadAllBytes(file);
+            if (bigEndian) Assert.True(bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF, "UTF-16 BE BOM preserved");
+            else Assert.True(bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE, "UTF-16 LE BOM preserved");
+            Assert.Contains("sealed partial", File.ReadAllText(file, enc)); // rewrite applied, still UTF-16
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Theory]
+    [InlineData(false)] // UTF-32 LE (FF FE 00 00) — must NOT be misread as UTF-16 LE
+    [InlineData(true)]  // UTF-32 BE (00 00 FE FF)
+    public void MafAutoFixAll_PreservesUtf32Bom_OnApply(bool bigEndian)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-utf32-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var file = Path.Combine(dir, "U32.cs");
+            var enc = new System.Text.UTF32Encoding(bigEndian, byteOrderMark: true);
+            File.WriteAllText(file, """
+                using System.Threading.Tasks;
+                public class Executor { }
+                public sealed class MessageHandlerAttribute : System.Attribute { }
+                public partial class MyExec : Executor {
+                  [MessageHandler]
+                  public Task<int> Handle(string s) => Task.FromResult(0);
+                }
+                """, enc);
+            new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
+            var bytes = File.ReadAllBytes(file);
+            if (bigEndian) Assert.True(bytes.Length >= 4 && bytes[0] == 0x00 && bytes[1] == 0x00 && bytes[2] == 0xFE && bytes[3] == 0xFF, "UTF-32 BE BOM preserved");
+            else Assert.True(bytes.Length >= 4 && bytes[0] == 0xFF && bytes[1] == 0xFE && bytes[2] == 0x00 && bytes[3] == 0x00, "UTF-32 LE BOM preserved");
+            Assert.Contains("sealed partial", File.ReadAllText(file, enc)); // decoded as UTF-32, rewrite applied
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void ApplyLockPath_TrailingSeparator_MapsToSameLock()
+    {
+        // `C:\repo` and `C:\repo\` must resolve to ONE lock key, else two callers
+        // spelling the path differently fail to serialise (WM-44).
+        var dir = Path.Combine(Path.GetTempPath(), "maf-locktrim-" + Guid.NewGuid().ToString("N"));
+        Assert.Equal(AutoFixTool.ApplyLockPath(dir), AutoFixTool.ApplyLockPath(dir + Path.DirectorySeparatorChar));
+    }
+
+    [Fact]
+    public void ExecutorSealedRewriter_AttributedZeroModifierClass_StaysIndented()
+    {
+        // A zero-modifier Executor WITH an attribute: `sealed partial` must inherit the
+        // declaration's indentation, not de-indent to column 0.
+        var input = """
+            namespace N
+            {
+                [System.Obsolete]
+                class Worker : Executor
+                {
+                    [MessageHandler]
+                    public System.Threading.Tasks.Task<int> Handle(string s) => null!;
+                }
+            }
+            """;
+        var output = ApplyRewriter(new ExecutorSealedRewriter(), input).Replace("\r\n", "\n");
+        Assert.Contains("    sealed partial class Worker", output); // indented, not column 0
+        Assert.DoesNotContain("\nsealed partial", output);          // never at column 0
+        Assert.Contains("[System.Obsolete]", output);               // attribute untouched
     }
 }

--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -811,10 +811,10 @@ public class DoctorToolTests
                 using System.Collections.Generic;
                 using System.Threading.Tasks;
                 public class C {
-                  Task<List<int>> Foo() => Task.FromResult(new List<int>());
+                  Task<List<int>> FooAsync() => Task.FromResult(new List<int>());
                   public async Task M() {
                     var b = new List<int>();
-                    var q = from x in b join y in Foo().Result on x equals y select x;
+                    var q = from x in b join y in FooAsync().Result on x equals y select x;
                     await Task.Yield();
                     _ = q.ToList();
                   }
@@ -864,8 +864,8 @@ public class DoctorToolTests
             var file = Path.Combine(dir, "Ok.cs");
             File.WriteAllText(file, """
                 using System.Threading.Tasks;
-                public class C { static Task<int> Foo() => Task.FromResult(1);
-                  public async Task<int> M() { return Foo().Result; } }
+                public class C { static Task<int> FooAsync() => Task.FromResult(1);
+                  public async Task<int> M() { return FooAsync().Result; } }
                 """);
             new AutoFixTool().MafAutoFixAll(dir, dryRun: false);
             var after = File.ReadAllText(file);
@@ -915,10 +915,10 @@ public class DoctorToolTests
             File.WriteAllText(file, """
                 using System.Threading.Tasks;
                 public class C {
-                  static Task<int> Foo() => Task.FromResult(1);
+                  static Task<int> FooAsync() => Task.FromResult(1);
                   public async Task M() {
                     try { await Task.Yield(); }
-                    catch (System.Exception) { var x = Foo().Result; }
+                    catch (System.Exception) { var x = FooAsync().Result; }
                   }
                 }
                 """);
@@ -1050,9 +1050,9 @@ public class DoctorToolTests
                 using System.Threading.Tasks;
                 public class C {
                   readonly object _lock = new();
-                  static Task<int> Foo() => Task.FromResult(1);
+                  static Task<int> FooAsync() => Task.FromResult(1);
                   public async Task M() {
-                    lock (_lock) { Func<Task> a = async () => { var x = Foo().Result; }; }
+                    lock (_lock) { Func<Task> a = async () => { var x = FooAsync().Result; }; }
                     await Task.Yield();
                   }
                 }
@@ -1079,9 +1079,9 @@ public class DoctorToolTests
                 using System.Threading.Tasks;
                 public class C {
                   readonly object _lock = new();
-                  static Task<int> Foo() => Task.FromResult(1);
+                  static Task<int> FooAsync() => Task.FromResult(1);
                   public void M() {
-                    lock (_lock) { async Task Inner() { var x = Foo().Result; } _ = Inner(); }
+                    lock (_lock) { async Task Inner() { var x = FooAsync().Result; } _ = Inner(); }
                   }
                 }
                 """);

--- a/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
+++ b/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
@@ -308,16 +308,16 @@ public class RewriterCompileRoundtripTests
         yield return F("conc002-rewrite-async-method-body", """
             using System.Threading.Tasks;
             public class C {
-              static Task<int> Foo() => Task.FromResult(1);
-              public async Task<int> M() { return Foo().Result; }
+              static Task<int> FooAsync() => Task.FromResult(1);
+              public async Task<int> M() { return FooAsync().Result; }
             }
             """);
 
         yield return F("conc002-rewrite-wait-async-method-body", """
             using System.Threading.Tasks;
             public class C {
-              static Task Foo() => Task.CompletedTask;
-              public async Task M() { Foo().Wait(); await Task.Yield(); }
+              static Task FooAsync() => Task.CompletedTask;
+              public async Task M() { FooAsync().Wait(); await Task.Yield(); }
             }
             """);
 
@@ -326,10 +326,10 @@ public class RewriterCompileRoundtripTests
             using System.Collections.Generic;
             using System.Threading.Tasks;
             public class C {
-              Task<List<int>> Foo() => Task.FromResult(new List<int>());
+              Task<List<int>> FooAsync() => Task.FromResult(new List<int>());
               public async Task M() {
                 var b = new List<int>();
-                var q = from x in b join y in Foo().Result on x equals y select x;
+                var q = from x in b join y in FooAsync().Result on x equals y select x;
                 await Task.Yield();
                 _ = q.ToList();
               }
@@ -341,8 +341,8 @@ public class RewriterCompileRoundtripTests
             using System.Threading.Tasks;
             public class C {
               readonly object _lock = new();
-              static Task<int> Foo() => Task.FromResult(1);
-              public async Task M() { lock (_lock) { Func<Task> f = async () => { var x = Foo().Result; }; } await Task.Yield(); }
+              static Task<int> FooAsync() => Task.FromResult(1);
+              public async Task M() { lock (_lock) { Func<Task> f = async () => { var x = FooAsync().Result; }; } await Task.Yield(); }
             }
             """);
 
@@ -350,16 +350,48 @@ public class RewriterCompileRoundtripTests
             using System;
             using System.Threading.Tasks;
             public class C {
-              static Task<int> Foo() => Task.FromResult(1);
-              public async Task M() { try { await Task.Yield(); } catch (Exception) { var x = Foo().Result; } }
+              static Task<int> FooAsync() => Task.FromResult(1);
+              public async Task M() { try { await Task.Yield(); } catch (Exception) { var x = FooAsync().Result; } }
             }
             """);
 
         yield return F("conc002-rewrite-async-finally", """
             using System.Threading.Tasks;
             public class C {
-              static Task<int> Foo() => Task.FromResult(1);
-              public async Task M() { try { await Task.Yield(); } finally { var x = Foo().Result; } }
+              static Task<int> FooAsync() => Task.FromResult(1);
+              public async Task M() { try { await Task.Yield(); } finally { var x = FooAsync().Result; } }
+            }
+            """);
+
+        // ---- CONC-002: WM-03 regression — non-awaitable receivers must SKIP. ----
+        // Valid inputs. Without the syntax-only awaitability gate the rewriter injected
+        // `await` and produced CS1061 (SemaphoreSlim / a custom `.Result` wrapper have
+        // no GetAwaiter). The skip-with-comment output still compiles ⇒ roundtrip green;
+        // a regression that drops the gate makes the output fail to compile ⇒ red.
+        yield return F("conc002-skip-semaphore-wait-nonawaitable", """
+            using System.Threading;
+            using System.Threading.Tasks;
+            public class C {
+              readonly SemaphoreSlim _sem = new(1);
+              SemaphoreSlim GetLock() => _sem;
+              public async Task M() { GetLock().Wait(); await Task.Yield(); }
+            }
+            """);
+
+        yield return F("conc002-skip-custom-result-property", """
+            using System.Threading.Tasks;
+            public class OpResult { public int Result { get; set; } }
+            public class C {
+              OpResult Parse(string s) => new OpResult();
+              public async Task M() { var x = Parse("a").Result; await Task.Yield(); }
+            }
+            """);
+
+        // A Task/ValueTask factory receiver IS recognised as awaitable ⇒ still rewrites.
+        yield return F("conc002-rewrite-task-run-result", """
+            using System.Threading.Tasks;
+            public class C {
+              public async Task<int> M() { return Task.Run(() => 1).Result; }
             }
             """);
 
@@ -379,6 +411,19 @@ public class RewriterCompileRoundtripTests
             public class Executor<TIn, TOut> { }
             public sealed class MessageHandlerAttribute : System.Attribute { }
             public partial class MyExec : Executor<string, int> {
+              [MessageHandler]
+              public Task<int> Handle(string s) => Task.FromResult(0);
+            }
+            """);
+
+        // WM-02 regression: `partial`-first with NO access modifier (idiomatic
+        // internal-by-default). Pre-fix the rewriter inserted `sealed` AFTER `partial`
+        // → `partial sealed class` → CS0267. Output must compile as `sealed partial`.
+        yield return F("wf001-rewrite-partial-first-no-access-modifier", """
+            using System.Threading.Tasks;
+            public class Executor { }
+            public sealed class MessageHandlerAttribute : System.Attribute { }
+            partial class MyExec : Executor {
               [MessageHandler]
               public Task<int> Handle(string s) => Task.FromResult(0);
             }

--- a/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
+++ b/src/maf-autopilot.Tests/RewriterCompileRoundtripTests.cs
@@ -429,6 +429,19 @@ public class RewriterCompileRoundtripTests
             }
             """);
 
+        // WM-02 review follow-up: ZERO-modifier Executor (no access modifier, no
+        // `partial`) — `sealed` becomes the declaration's first token; it must carry
+        // the class keyword's leading trivia rather than strand it.
+        yield return F("wf001-rewrite-zero-modifier-executor", """
+            using System.Threading.Tasks;
+            public class Executor { }
+            public sealed class MessageHandlerAttribute : System.Attribute { }
+            class MyExec : Executor {
+              [MessageHandler]
+              public Task<int> Handle(string s) => Task.FromResult(0);
+            }
+            """);
+
         yield return F("wf001-noop-abstract-executor", """
             using System.Threading.Tasks;
             public class Executor { }

--- a/src/maf-autopilot.Tests/RewriterIdempotenceTests.cs
+++ b/src/maf-autopilot.Tests/RewriterIdempotenceTests.cs
@@ -153,20 +153,21 @@ public sealed class RewriterIdempotenceTests
     [Fact]
     public void SyncOverAsyncRewriter_Idempotent_AsyncMethod_HappyPath()
     {
-        // After the rewrite produces `await Foo()`, a second pass should NOT
-        // re-rewrite (`.Result` is gone; nothing matches).
+        // After the rewrite produces `await FooAsync()`, a second pass should NOT
+        // re-rewrite (`.Result` is gone; nothing matches). Method named `*Async` so
+        // the syntax-only awaitability gate (LooksAwaitableReceiver) rewrites it.
         const string src = """
             class C
             {
                 async System.Threading.Tasks.Task M()
                 {
-                    var x = Foo().Result;
+                    var x = FooAsync().Result;
                 }
-                System.Threading.Tasks.Task<int> Foo() => null!;
+                System.Threading.Tasks.Task<int> FooAsync() => null!;
             }
             """;
         var output = ApplyTwice(new SyncOverAsyncRewriter(), src);
-        Assert.Contains("await Foo()", output);
+        Assert.Contains("await FooAsync()", output);
         Assert.DoesNotContain(".Result", output);
     }
 
@@ -202,12 +203,12 @@ public sealed class RewriterIdempotenceTests
             {
                 async System.Threading.Tasks.Task M()
                 {
-                    Foo().Wait();
+                    FooAsync().Wait();
                 }
-                System.Threading.Tasks.Task Foo() => null!;
+                System.Threading.Tasks.Task FooAsync() => null!;
             }
             """;
         var output = ApplyTwice(new SyncOverAsyncRewriter(), src);
-        Assert.Contains("await Foo()", output);
+        Assert.Contains("await FooAsync()", output);
     }
 }

--- a/src/maf-autopilot/Commands/AutoFixCli.cs
+++ b/src/maf-autopilot/Commands/AutoFixCli.cs
@@ -69,6 +69,18 @@ internal static class AutoFixCli
             : "🔧 maf-doctor autofix-all — deterministic Roslyn fixes (mechanical only)");
         sb.AppendLine();
 
+        // WM-21: surface per-file failures that previously vanished. A non-empty
+        // list means the pass did NOT fully succeed — some files were skipped —
+        // and (in Program.cs) drives a non-zero exit code.
+        var errors = report.Errors ?? Array.Empty<AutoFixTool.AutoFixError>();
+        if (errors.Count > 0)
+        {
+            sb.AppendLine($"  ⚠ {Count(errors.Count, "file")} could not be processed and {(errors.Count == 1 ? "was" : "were")} skipped:");
+            foreach (var e in errors)
+                sb.AppendLine($"      - {e.File}: {e.Message}");
+            sb.AppendLine();
+        }
+
         var total = report.TotalDistinctFilesChanged;
 
         if (total == 0)
@@ -76,7 +88,7 @@ internal static class AutoFixCli
             sb.AppendLine($"  ✓ 0 files {verb} — nothing mechanical to fix here.");
             sb.AppendLine();
             sb.AppendLine("  This is normal, and does NOT mean your code is clean. autofix-all only");
-            sb.AppendLine("  applies these 5 deterministic rewriters, and found none of them:");
+            sb.AppendLine($"  applies these {report.PerRule.Count} deterministic rewriters, and found none of them:");
             sb.AppendLine();
             foreach (var r in report.PerRule)
                 sb.AppendLine($"      • {r.RuleId,-18} {Describe(r.RuleId)}");

--- a/src/maf-autopilot/Commands/AutoFixCli.cs
+++ b/src/maf-autopilot/Commands/AutoFixCli.cs
@@ -119,12 +119,38 @@ internal static class AutoFixCli
             sb.AppendLine($"      - {f}");
         sb.AppendLine();
         if (report.DryRun)
+        {
+            // WM-24: a preview that shows only file NAMES gives the F-11
+            // "review before apply" gate nothing to review. Inline the actual
+            // unified diff for each changed file when the set is small enough to
+            // read; otherwise point at --json for the full per-file diffs.
+            var diffs = report.Diffs ?? Array.Empty<AutoFixTool.AutoFixFileDiff>();
+            const int inlineDiffCap = 10;
+            if (diffs.Count > 0 && total <= inlineDiffCap)
+            {
+                sb.AppendLine("  Preview (unified diff — nothing has been written):");
+                sb.AppendLine();
+                foreach (var d in diffs)
+                {
+                    sb.AppendLine($"      ── {d.File}   [{string.Join(", ", d.RuleIds)}]");
+                    foreach (var line in d.Diff.TrimEnd('\n').Split('\n'))
+                        sb.AppendLine("        " + line);
+                    sb.AppendLine();
+                }
+            }
+            else if (diffs.Count > 0)
+            {
+                sb.AppendLine($"  ({total} files would change — too many to inline; re-run with --json for the full per-file diffs.)");
+                sb.AppendLine();
+            }
+
             // F-11 (2026-07-19 security assessment, found in a subsequent review
             // round): dry-run is now the DEFAULT, so "re-run without --dry-run"
             // was stale/misleading advice for the common case (a user who ran
             // `autofix-all <path>` with no flags never passed --dry-run in the
             // first place). --apply is the actual opt-in flag.
             sb.AppendLine("  Dry run — re-run with --apply to apply these changes.");
+        }
         sb.AppendLine("  Next: `maf-doctor doctor .` to re-grade.");
         sb.AppendLine();
         AppendRemediationGuidance(sb);

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -146,24 +146,29 @@ if (args.Length >= 1 && args[0] == "autofix-all")
     // Round-4 review fixup — this unconditionally exited 0 below, even on the
     // `error is not null` branch that already prints "❌ {error}" — the exit
     // code contradicted the tool's own visible error indicator.
-    var succeeded = true;
-    if (json)
+    // Compute the report ONCE, then render it as JSON or human text. Success is
+    // derived from that same report — a top-level error (bad path/specificFile)
+    // OR, on an actual apply, any per-file failure (WM-21) that used to be
+    // swallowed. Dry-run per-file errors are shown but don't fail the preview.
+    var report = tool.RunAll(path, specificFile: null, dryRun: dryRun, out var error);
+    if (report is null)
     {
-        // Machine-readable: identical to the MafAutoFixAll MCP tool output.
-        // MafAutoFixAll's sole failure source is the same PathGuard check
-        // Run/RunAll use internally.
-        Console.WriteLine(tool.MafAutoFixAll(path, dryRun: dryRun));
-        succeeded = PathGuard.ValidateRepoPath(path) is null;
+        // On the error path RunAll returned null fast (bad path/specificFile);
+        // re-running MafAutoFixAll here just re-fails the same way and yields the
+        // structured { "error": ... } JSON — cheap, and only on this branch.
+        Console.WriteLine(json
+            ? tool.MafAutoFixAll(path, dryRun: dryRun)
+            : $"❌ {error}");
+        Environment.Exit(1);
+        return;
     }
-    else
-    {
-        var report = tool.RunAll(path, specificFile: null, dryRun: dryRun, out var error);
-        Console.WriteLine(error is not null
-            ? $"❌ {error}"
-            : MafDoctor.Commands.AutoFixCli.Format(report!));
-        succeeded = error is null;
-    }
-    Environment.Exit(succeeded ? 0 : 1);
+
+    Console.WriteLine(json
+        ? MafDoctor.Tools.AutoFixTool.SerializeReport(report)
+        : MafDoctor.Commands.AutoFixCli.Format(report));
+
+    var applyErrors = !dryRun && report.Errors is { Count: > 0 };
+    Environment.Exit(applyErrors ? 1 : 0);
     return;
 }
 if (args.Length >= 1 && args[0] == "migrate-scan")

--- a/src/maf-autopilot/Tools/AutoFixTool.cs
+++ b/src/maf-autopilot/Tools/AutoFixTool.cs
@@ -495,9 +495,18 @@ public sealed class AutoFixTool
         // invalid-bytes decode in force even for a BOM'd file: StreamReader silently
         // swaps in the detected encoding's REPLACEMENT-fallback decoder, so invalid
         // bytes after a BOM would become U+FFFD instead of being rejected.
+        // UTF-32 BOMs must be checked BEFORE UTF-16: a UTF-32 LE file starts
+        // `FF FE 00 00`, whose first two bytes also match the UTF-16 LE BOM — sniffing
+        // UTF-16 first would strip 2 bytes and decode the UTF-32 payload as UTF-16
+        // (silent garbage, no throw). Real UTF-16 files never begin with a U+0000, so
+        // the trailing `00 00` disambiguates.
         Encoding detected;
         int bomLength;
-        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+        if (bytes.Length >= 4 && bytes[0] == 0xFF && bytes[1] == 0xFE && bytes[2] == 0x00 && bytes[3] == 0x00)
+        { detected = new UTF32Encoding(bigEndian: false, byteOrderMark: true, throwOnInvalidCharacters: true); bomLength = 4; }
+        else if (bytes.Length >= 4 && bytes[0] == 0x00 && bytes[1] == 0x00 && bytes[2] == 0xFE && bytes[3] == 0xFF)
+        { detected = new UTF32Encoding(bigEndian: true, byteOrderMark: true, throwOnInvalidCharacters: true); bomLength = 4; }
+        else if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
         { detected = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true, throwOnInvalidBytes: true); bomLength = 3; }
         else if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
         { detected = new UnicodeEncoding(bigEndian: false, byteOrderMark: true, throwOnInvalidBytes: true); bomLength = 2; }

--- a/src/maf-autopilot/Tools/AutoFixTool.cs
+++ b/src/maf-autopilot/Tools/AutoFixTool.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using MafDoctor.Tools.Rewriters;
@@ -187,6 +188,15 @@ public sealed class AutoFixTool
                 error = $"Unknown ruleId '{ruleId}'. Supported: {string.Join(", ", SupportedRuleIds)}",
             });
 
+        // WM-44: serialise concurrent applies on the same repo (apply mode only).
+        IDisposable? applyLock = null;
+        if (!dryRun)
+        {
+            applyLock = TryAcquireApplyLock(repoPath, out var lockErr);
+            if (applyLock is null) return JsonSerializer.Serialize(new { error = lockErr });
+        }
+        using var _lock = applyLock;
+
         var outcomes = RunPipeline(new[] { (ruleId, factory()) }, repoPath, specificFile, dryRun);
         var changedFiles = outcomes.Where(o => o.ChangedByRules.Count > 0).Select(o => o.Relative).ToList();
         var errors = outcomes.Where(o => o.Error is not null).Select(o => o.Error!).ToList();
@@ -313,6 +323,16 @@ public sealed class AutoFixTool
             .Where(_factories.ContainsKey)
             .Select(id => (RuleId: id, Rewriter: _factories[id]()))
             .ToList();
+
+        // WM-44: serialise concurrent applies on the same repo (apply mode only —
+        // a dry-run writes nothing and needs no lock).
+        IDisposable? applyLock = null;
+        if (!dryRun)
+        {
+            applyLock = TryAcquireApplyLock(repoPath, out var lockErr);
+            if (applyLock is null) { error = lockErr; return null; }
+        }
+        using var _lock = applyLock;
 
         var outcomes = RunPipeline(rewriters, repoPath, specificFile, dryRun);
 
@@ -496,6 +516,39 @@ public sealed class AutoFixTool
         if (!resolved.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
             return $"Error: specificFile must be a .cs file: {specificFile}";
         return null;
+    }
+
+    /// <summary>
+    /// WM-44: cross-process apply lock. Two concurrent apply runs on the same repo
+    /// could interleave their read → rewrite → write cycles and silently revert
+    /// each other's fixes. An exclusive OS file lock (keyed by the repo's canonical
+    /// path, kept in the temp dir so the repo itself is never polluted) serialises
+    /// applies; a second concurrent apply fails fast. Returns the held lock —
+    /// dispose to release — or <see langword="null"/> with an error message.
+    /// </summary>
+    private static IDisposable? TryAcquireApplyLock(string repoPath, out string? error)
+    {
+        error = null;
+        try
+        {
+            return new FileStream(ApplyLockPath(repoPath), FileMode.OpenOrCreate,
+                FileAccess.ReadWrite, FileShare.None, bufferSize: 1, FileOptions.DeleteOnClose);
+        }
+        catch (IOException)
+        {
+            error = "Error: another maf-doctor autofix is already applying changes to this repository. Re-run once it finishes.";
+            return null;
+        }
+    }
+
+    /// <summary>Deterministic per-repo apply-lock path (temp dir; canonical-path hash,
+    /// case-folded on Windows). Internal for test coordination.</summary>
+    internal static string ApplyLockPath(string repoPath)
+    {
+        var canonical = Path.GetFullPath(repoPath);
+        if (OperatingSystem.IsWindows()) canonical = canonical.ToLowerInvariant();
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)), 0, 8);
+        return Path.Combine(Path.GetTempPath(), $"maf-doctor-autofix-{hash}.lock");
     }
 
     /// <summary>

--- a/src/maf-autopilot/Tools/AutoFixTool.cs
+++ b/src/maf-autopilot/Tools/AutoFixTool.cs
@@ -473,21 +473,48 @@ public sealed class AutoFixTool
         text = string.Empty;
         encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
         error = null;
+
+        byte[] bytes;
         try
         {
-            // Strict UTF-8 as the fallback decoder (throws on invalid bytes);
-            // detectEncodingFromByteOrderMarks lets a UTF-8/UTF-16 BOM override it.
-            using var reader = new StreamReader(
-                File.OpenRead(file),
-                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true),
-                detectEncodingFromByteOrderMarks: true);
-            text = reader.ReadToEnd();
-            encoding = reader.CurrentEncoding; // UTF-8(+BOM) / UTF-16 / … as detected
+            bytes = File.ReadAllBytes(file);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            // A locked / permission-denied / vanished file must be a per-file error,
+            // NOT a whole-pass abort — the strict-decode catch below only covers
+            // invalid bytes. Message carries no absolute path (the caller adds the
+            // repo-relative name); FileNotFound/DirectoryNotFound are IOExceptions.
+            error = $"could not be read ({ex.GetType().Name})";
+            return false;
+        }
+
+        // Detect a BOM BY HAND and pick the encoding to PRESERVE on write-back.
+        // Doing it manually (rather than via StreamReader's
+        // detectEncodingFromByteOrderMarks) is what keeps the strict, throw-on-
+        // invalid-bytes decode in force even for a BOM'd file: StreamReader silently
+        // swaps in the detected encoding's REPLACEMENT-fallback decoder, so invalid
+        // bytes after a BOM would become U+FFFD instead of being rejected.
+        Encoding detected;
+        int bomLength;
+        if (bytes.Length >= 3 && bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF)
+        { detected = new UTF8Encoding(encoderShouldEmitUTF8Identifier: true, throwOnInvalidBytes: true); bomLength = 3; }
+        else if (bytes.Length >= 2 && bytes[0] == 0xFF && bytes[1] == 0xFE)
+        { detected = new UnicodeEncoding(bigEndian: false, byteOrderMark: true, throwOnInvalidBytes: true); bomLength = 2; }
+        else if (bytes.Length >= 2 && bytes[0] == 0xFE && bytes[1] == 0xFF)
+        { detected = new UnicodeEncoding(bigEndian: true, byteOrderMark: true, throwOnInvalidBytes: true); bomLength = 2; }
+        else
+        { detected = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true); bomLength = 0; }
+
+        try
+        {
+            text = detected.GetString(bytes, bomLength, bytes.Length - bomLength);
+            encoding = detected;
             return true;
         }
         catch (DecoderFallbackException)
         {
-            error = "not valid UTF-8; skipped to avoid corruption";
+            error = "not valid text (invalid byte sequence); skipped to avoid corruption";
             return false;
         }
     }
@@ -534,9 +561,13 @@ public sealed class AutoFixTool
             return new FileStream(ApplyLockPath(repoPath), FileMode.OpenOrCreate,
                 FileAccess.ReadWrite, FileShare.None, bufferSize: 1, FileOptions.DeleteOnClose);
         }
-        catch (IOException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
-            error = "Error: another maf-doctor autofix is already applying changes to this repository. Re-run once it finishes.";
+            // A held lock surfaces as a sharing violation (IOException) OR, on the
+            // Windows delete-pending race when a peer is releasing its DeleteOnClose
+            // lock, as UnauthorizedAccessException. An unwritable temp dir also lands
+            // here. Either way, fail gracefully instead of throwing out of the tool.
+            error = "Error: another maf-doctor autofix is already applying changes to this repository (or the temp directory is not writable). Re-run once it finishes.";
             return null;
         }
     }
@@ -545,7 +576,11 @@ public sealed class AutoFixTool
     /// case-folded on Windows). Internal for test coordination.</summary>
     internal static string ApplyLockPath(string repoPath)
     {
-        var canonical = Path.GetFullPath(repoPath);
+        // TrimEndingDirectorySeparator so `C:\repo` and `C:\repo\` (which
+        // Path.GetFullPath keeps distinct) collapse to ONE lock key — else two
+        // callers spelling the path differently would take different locks and
+        // fail to serialise, defeating the point of WM-44.
+        var canonical = Path.TrimEndingDirectorySeparator(Path.GetFullPath(repoPath));
         if (OperatingSystem.IsWindows()) canonical = canonical.ToLowerInvariant();
         var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(canonical)), 0, 8);
         return Path.Combine(Path.GetTempPath(), $"maf-doctor-autofix-{hash}.lock");

--- a/src/maf-autopilot/Tools/AutoFixTool.cs
+++ b/src/maf-autopilot/Tools/AutoFixTool.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel;
+using System.Text;
 using System.Text.Json;
 using MafDoctor.Tools.Rewriters;
 using Microsoft.CodeAnalysis;
@@ -86,19 +87,27 @@ public sealed class AutoFixTool
 
     /// <summary>Structured result of an <see cref="RunAll"/> pass. Rendered to
     /// JSON by <see cref="MafAutoFixAll"/> (MCP) and to human-readable text by
-    /// the CLI — one computation, two presentations.</summary>
+    /// the CLI — one computation, two presentations.
+    /// <para><see cref="Errors"/> is additive (defaults to empty): per-file
+    /// read/parse/write failures that previously vanished. A non-empty list
+    /// means the pass did NOT fully succeed.</para></summary>
     internal sealed record AutoFixAllReport(
         bool DryRun,
         IReadOnlyList<string> OrderOfExecution,
         int TotalDistinctFilesChanged,
         IReadOnlyList<string> AffectedFiles,
-        IReadOnlyList<AutoFixRuleReport> PerRule);
+        IReadOnlyList<AutoFixRuleReport> PerRule,
+        IReadOnlyList<AutoFixError>? Errors = null);
 
     /// <summary>Per-rule slice of an <see cref="AutoFixAllReport"/>.</summary>
     internal sealed record AutoFixRuleReport(
         string RuleId,
         int FilesChanged,
         IReadOnlyList<string> ChangedFiles);
+
+    /// <summary>A single per-file failure. <see cref="File"/> is repo-relative
+    /// and <see cref="Message"/> is scrubbed of absolute host paths.</summary>
+    internal sealed record AutoFixError(string File, string Message);
 
     /// <summary>
     /// Internal helper for sibling tools (e.g. <see cref="BeforeAfterTool"/>)
@@ -128,19 +137,20 @@ public sealed class AutoFixTool
           - repoPath: absolute path to the repo or project to fix.
           - ruleId: which rule's auto-fixer to run.
           - specificFile: optional. Limit fixes to a single file (path relative to repoPath).
+            Must exist and be a .cs file, else an error JSON is returned.
           - dryRun: if true, no files are written — just returns the JSON summary
             of what WOULD change. Default true (preview-only) — pass dryRun: false
             to actually write.
 
         Returns a JSON document with `ruleId`, `dryRun`, `filesChanged` count,
-        `changedFiles` list, and any per-file `error` strings.
+        `changedFiles` list, and any per-file `errors` (each `{file, error}`).
 
-        Bad ruleId or empty repoPath returns an error JSON.
+        Bad ruleId, empty repoPath, or a missing/non-.cs specificFile returns an error JSON.
         """)]
     public string MafAutoFix(
         [Description("Absolute path to the repo or project to fix.")] string repoPath,
         [Description("Rule ID, e.g. 'MAF-AP-SEC-001' or 'MAF130-FAN-IN-001'.")] string ruleId,
-        [Description("Optional: relative path to limit fixes to a single file.")] string? specificFile = null,
+        [Description("Optional: relative path to limit fixes to a single existing .cs file.")] string? specificFile = null,
         [Description("If true (the default), no files written — preview only. Pass false to write.")] bool dryRun = true)
     {
         if (PathGuard.ValidateRepoPath(repoPath) is { } err)
@@ -158,6 +168,10 @@ public sealed class AutoFixTool
             {
                 return JsonSerializer.Serialize(new { error = $"Error: {ex.Message}" });
             }
+            // WM-41: a missing or non-.cs specificFile previously yielded a silent
+            // "0 changes" success. Surface it as an error instead.
+            if (ValidateSpecificFile(repoPath, specificFile) is { } fileErr)
+                return JsonSerializer.Serialize(new { error = fileErr });
         }
 
         if (!_factories.TryGetValue(ruleId, out var factory))
@@ -166,14 +180,17 @@ public sealed class AutoFixTool
                 error = $"Unknown ruleId '{ruleId}'. Supported: {string.Join(", ", SupportedRuleIds)}",
             });
 
-        var result = ApplyRewriterToRepo(factory(), repoPath, specificFile, dryRun);
+        var outcomes = RunPipeline(new[] { (ruleId, factory()) }, repoPath, specificFile, dryRun);
+        var changedFiles = outcomes.Where(o => o.ChangedByRules.Count > 0).Select(o => o.Relative).ToList();
+        var errors = outcomes.Where(o => o.Error is not null).Select(o => o.Error!).ToList();
+
         return JsonSerializer.Serialize(new
         {
             ruleId,
             dryRun,
-            filesChanged = result.ChangedFiles.Count,
-            changedFiles = result.ChangedFiles,
-            errors = result.Errors,
+            filesChanged = changedFiles.Count,
+            changedFiles,
+            errors = errors.Select(e => new { file = e.File, error = e.Message }).ToList(),
         }, new JsonSerializerOptions { WriteIndented = true });
     }
 
@@ -192,26 +209,37 @@ public sealed class AutoFixTool
 
         Input:
           - repoPath: absolute path to the repo or project to fix.
-          - specificFile: optional, relative path to limit fixes to a single file.
+          - specificFile: optional, relative path to limit fixes to a single existing .cs file.
           - dryRun: if true, no files are written — just returns the JSON
             summary of what WOULD change. Default true (preview-only) — pass
             dryRun: false to actually write.
 
         Returns aggregate JSON with the ordered rule list + total distinct files
-        changed (union across all rules) + per-rule breakdown.
+        changed (union across all rules) + per-rule breakdown + any per-file
+        `errors` (each `{file, error}`).
         """)]
     public string MafAutoFixAll(
         [Description("Absolute path to the repo or project to fix.")] string repoPath,
-        [Description("Optional: relative path to limit fixes to a single file.")] string? specificFile = null,
+        [Description("Optional: relative path to limit fixes to a single existing .cs file.")] string? specificFile = null,
         [Description("If true (the default), no files written — preview only. Pass false to write.")] bool dryRun = true)
     {
         var report = RunAll(repoPath, specificFile, dryRun, out var error);
-        if (report is null)
-            return JsonSerializer.Serialize(new { error });
+        return report is null
+            ? JsonSerializer.Serialize(new { error })
+            : SerializeReport(report);
+    }
 
-        // Project the structured report back onto the EXACT anonymous shape the
-        // MCP contract (and the tests) depend on. The dictionary preserves
-        // insertion order, so `perRule`'s key order matches OrderOfExecution.
+    /// <summary>
+    /// Projects an <see cref="AutoFixAllReport"/> onto the EXACT anonymous JSON
+    /// shape the MCP contract (and the tests) depend on. Shared by
+    /// <see cref="MafAutoFixAll"/> and the CLI so the machine output — and the
+    /// exit-code decision derived from <see cref="AutoFixAllReport.Errors"/> —
+    /// come from one computed report, never a re-run.
+    /// </summary>
+    internal static string SerializeReport(AutoFixAllReport report)
+    {
+        // The dictionary preserves insertion order, so `perRule`'s key order
+        // matches OrderOfExecution.
         var perRule = new Dictionary<string, object>();
         foreach (var r in report.PerRule)
             perRule[r.RuleId] = new { filesChanged = r.FilesChanged, changedFiles = r.ChangedFiles };
@@ -223,18 +251,26 @@ public sealed class AutoFixTool
             totalDistinctFilesChanged = report.TotalDistinctFilesChanged,
             affectedFiles = report.AffectedFiles,
             perRule,
+            // Additive: previously-swallowed per-file failures.
+            errors = (report.Errors ?? Array.Empty<AutoFixError>())
+                .Select(e => new { file = e.File, error = e.Message }).ToList(),
         }, new JsonSerializerOptions { WriteIndented = true });
     }
 
     /// <summary>
     /// Computation core shared by the MCP JSON path (<see cref="MafAutoFixAll"/>)
     /// and the CLI's human-readable path. Runs every supported rewriter in
-    /// <see cref="OrderedRuleIds"/> order and returns a structured report —
-    /// presentation (JSON vs. human text) is the caller's concern.
+    /// <see cref="OrderedRuleIds"/> order — as a SINGLE per-file pass (each file
+    /// is enumerated, read, and parsed exactly once; the rewriters are folded
+    /// over the one syntax tree in order) — and returns a structured report.
+    /// Presentation (JSON vs. human text) is the caller's concern.
+    /// <para>Because the fold composes rewriters in memory, <c>dryRun</c> now
+    /// reports exactly what an apply would produce (previously dry-run ran each
+    /// rule against the ORIGINAL file, so preview could diverge from apply).</para>
     /// </summary>
-    /// <param name="error">On failure (invalid repo path / path-escape), the
-    /// error message; <see langword="null"/> on success. When non-null the
-    /// return value is <see langword="null"/>.</param>
+    /// <param name="error">On failure (invalid repo path / path-escape / bad
+    /// specificFile), the error message; <see langword="null"/> on success. When
+    /// non-null the return value is <see langword="null"/>.</param>
     internal AutoFixAllReport? RunAll(string repoPath, string? specificFile, bool dryRun, out string? error)
     {
         error = null;
@@ -256,83 +292,174 @@ public sealed class AutoFixTool
                 error = $"Error: {ex.Message}";
                 return null;
             }
+            if (ValidateSpecificFile(repoPath, specificFile) is { } fileErr) // WM-41
+            {
+                error = fileErr;
+                return null;
+            }
         }
 
-        var perRule = new List<AutoFixRuleReport>(OrderedRuleIds.Count);
-        var allChangedFiles = new SortedSet<string>(StringComparer.Ordinal);
+        var rewriters = OrderedRuleIds
+            .Where(_factories.ContainsKey)
+            .Select(id => (RuleId: id, Rewriter: _factories[id]()))
+            .ToList();
 
-        foreach (var ruleId in OrderedRuleIds)
-        {
-            if (!_factories.TryGetValue(ruleId, out var factory)) continue;
-            var result = ApplyRewriterToRepo(factory(), repoPath, specificFile, dryRun);
-            perRule.Add(new AutoFixRuleReport(ruleId, result.ChangedFiles.Count, result.ChangedFiles));
-            foreach (var f in result.ChangedFiles) allChangedFiles.Add(f);
-        }
+        var outcomes = RunPipeline(rewriters, repoPath, specificFile, dryRun);
+
+        var perRule = rewriters
+            .Select(r =>
+            {
+                var files = outcomes.Where(o => o.ChangedByRules.Contains(r.RuleId))
+                                    .Select(o => o.Relative).ToList();
+                return new AutoFixRuleReport(r.RuleId, files.Count, files);
+            })
+            .ToList();
+
+        var allChanged = new SortedSet<string>(
+            outcomes.Where(o => o.ChangedByRules.Count > 0).Select(o => o.Relative),
+            StringComparer.Ordinal);
+
+        var errors = outcomes.Where(o => o.Error is not null).Select(o => o.Error!).ToList();
 
         return new AutoFixAllReport(
             DryRun: dryRun,
             OrderOfExecution: OrderedRuleIds,
-            TotalDistinctFilesChanged: allChangedFiles.Count,
-            AffectedFiles: allChangedFiles.ToList(),
-            PerRule: perRule);
+            TotalDistinctFilesChanged: allChanged.Count,
+            AffectedFiles: allChanged.ToList(),
+            PerRule: perRule,
+            Errors: errors);
     }
 
-    /// <summary>
-    /// Per-rule run result. Returned by <see cref="ApplyRewriterToRepo"/> and
-    /// shared between <see cref="MafAutoFix"/> and <see cref="MafAutoFixAll"/>.
-    /// </summary>
-    private sealed record RewriterRunResult(IReadOnlyList<string> ChangedFiles, IReadOnlyList<object> Errors);
+    /// <summary>Per-file result of one pipeline pass.</summary>
+    private sealed record FileOutcome(
+        string Relative,
+        IReadOnlyList<string> ChangedByRules,
+        AutoFixError? Error);
 
     /// <summary>
-    /// Walks every .cs file (or just one), applies the rewriter, and writes
-    /// changed files atomically. Pure helper — no JSON, no PathGuard (caller
-    /// has already validated).
+    /// The single per-file engine shared by <see cref="MafAutoFix"/> (one rewriter)
+    /// and <see cref="RunAll"/> (all rewriters). Enumerates every candidate file
+    /// ONCE, reads + parses it ONCE, folds the <paramref name="rewriters"/> over the
+    /// one tree in order (attributing each change to its rule via a reference check),
+    /// and writes ONCE at the end preserving the file's original encoding. Per-file
+    /// failures are recorded, never thrown — so one unreadable/locked file can no
+    /// longer abort the whole pass.
     /// </summary>
-    private static RewriterRunResult ApplyRewriterToRepo(
-        IRuleRewriter rewriter, string repoPath, string? specificFile, bool dryRun)
+    private static IReadOnlyList<FileOutcome> RunPipeline(
+        IReadOnlyList<(string RuleId, IRuleRewriter Rewriter)> rewriters,
+        string repoPath, string? specificFile, bool dryRun)
     {
-        var changedFiles = new List<string>();
-        var errors = new List<object>();
+        var outcomes = new List<FileOutcome>();
 
         foreach (var file in EnumerateFiles(repoPath, specificFile))
         {
-            // Compute the relative path ONCE up-front. Post-Phase-5.4,
-            // `MakeRelative` throws when the file is out-of-root rather than
-            // silently leaking the absolute path. Computing here (with the
-            // happy-path file from `EnumerateFiles`) keeps the catch handler
-            // free of any call that itself might throw — without this, an
-            // OS-level symlink race between enumeration and catch would
-            // double-fault out of `ApplyRewriterToRepo`. Falls back to the
-            // raw file path (acceptable for error reporting) if MakeRelative
-            // does throw.
+            // Compute the relative path up-front so the failure path never calls
+            // MakeRelative again (an OS symlink race between enumeration and the
+            // catch could otherwise double-fault). Falls back to the raw path.
             string relative;
             try { relative = SourceFileWalker.MakeRelative(repoPath, file); }
             catch (InvalidOperationException) { relative = file; }
 
+            // WM-20: read with a strict UTF-8 decoder + BOM detection so an
+            // undecodable file is SKIPPED-with-error rather than corrupted to
+            // U+FFFD, and the detected encoding is preserved on write-back.
+            if (!TryReadSourcePreservingEncoding(file, out var src, out var encoding, out var readError))
+            {
+                outcomes.Add(new FileOutcome(relative, Array.Empty<string>(),
+                    new AutoFixError(relative, readError!)));
+                continue;
+            }
+
             try
             {
-                var src = File.ReadAllText(file);
-                var tree = CSharpSyntaxTree.ParseText(src);
-                var oldRoot = tree.GetRoot();
-                var newRoot = rewriter.Visit(oldRoot);
+                var root = CSharpSyntaxTree.ParseText(src).GetRoot();
+                var changedBy = new List<string>();
+                foreach (var (ruleId, rewriter) in rewriters)
+                {
+                    var next = rewriter.Visit(root);
+                    if (!ReferenceEquals(next, root))
+                    {
+                        changedBy.Add(ruleId);
+                        root = next;
+                    }
+                }
 
-                if (ReferenceEquals(newRoot, oldRoot)) continue;
+                if (changedBy.Count == 0)
+                {
+                    outcomes.Add(new FileOutcome(relative, changedBy, null));
+                    continue;
+                }
 
                 if (!dryRun)
-                    SafeWorkspaceWriter.WriteAtomic(repoPath, file, newRoot.ToFullString());
+                    SafeWorkspaceWriter.WriteAtomic(repoPath, file, root.ToFullString(), encoding);
 
-                changedFiles.Add(relative);
+                outcomes.Add(new FileOutcome(relative, changedBy, null));
             }
             catch (Exception ex)
             {
-                errors.Add(new
-                {
-                    file = relative,
-                    error = ex.Message,
-                });
+                outcomes.Add(new FileOutcome(relative, Array.Empty<string>(),
+                    new AutoFixError(relative, Scrub(repoPath, file, relative, ex.Message))));
             }
         }
-        return new RewriterRunResult(changedFiles, errors);
+
+        return outcomes;
+    }
+
+    /// <summary>
+    /// Reads <paramref name="file"/> as text while (a) detecting a BOM and
+    /// preserving the resulting encoding for a faithful write-back, and (b)
+    /// rejecting invalid UTF-8 rather than silently substituting U+FFFD. Returns
+    /// <see langword="false"/> with a message on an undecodable file.
+    /// </summary>
+    private static bool TryReadSourcePreservingEncoding(
+        string file, out string text, out Encoding encoding, out string? error)
+    {
+        text = string.Empty;
+        encoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        error = null;
+        try
+        {
+            // Strict UTF-8 as the fallback decoder (throws on invalid bytes);
+            // detectEncodingFromByteOrderMarks lets a UTF-8/UTF-16 BOM override it.
+            using var reader = new StreamReader(
+                File.OpenRead(file),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true),
+                detectEncodingFromByteOrderMarks: true);
+            text = reader.ReadToEnd();
+            encoding = reader.CurrentEncoding; // UTF-8(+BOM) / UTF-16 / … as detected
+            return true;
+        }
+        catch (DecoderFallbackException)
+        {
+            error = "not valid UTF-8; skipped to avoid corruption";
+            return false;
+        }
+    }
+
+    /// <summary>Best-effort removal of absolute host paths from an exception
+    /// message before it is surfaced to the caller (IOException messages embed
+    /// the full path). Keeps the repo-relative form the rest of the output uses.</summary>
+    private static string Scrub(string repoPath, string file, string relative, string message) =>
+        message.Replace(file, relative, StringComparison.OrdinalIgnoreCase)
+               .Replace(repoPath, "<repo>", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// WM-41 guard: a <paramref name="specificFile"/> that does not exist, or is
+    /// not a .cs file, must be an explicit error — not a silent 0-change success.
+    /// Returns the error message, or <see langword="null"/> when the file is valid.
+    /// Callers MUST have already run <see cref="PathGuard.ValidateContainment"/>.
+    /// </summary>
+    private static string? ValidateSpecificFile(string repoPath, string specificFile)
+    {
+        var resolved = Path.IsPathRooted(specificFile)
+            ? specificFile
+            : Path.Combine(repoPath, specificFile);
+
+        if (!File.Exists(resolved))
+            return $"Error: specificFile not found under repoPath: {specificFile}";
+        if (!resolved.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+            return $"Error: specificFile must be a .cs file: {specificFile}";
+        return null;
     }
 
     /// <summary>

--- a/src/maf-autopilot/Tools/AutoFixTool.cs
+++ b/src/maf-autopilot/Tools/AutoFixTool.cs
@@ -97,7 +97,8 @@ public sealed class AutoFixTool
         int TotalDistinctFilesChanged,
         IReadOnlyList<string> AffectedFiles,
         IReadOnlyList<AutoFixRuleReport> PerRule,
-        IReadOnlyList<AutoFixError>? Errors = null);
+        IReadOnlyList<AutoFixError>? Errors = null,
+        IReadOnlyList<AutoFixFileDiff>? Diffs = null);
 
     /// <summary>Per-rule slice of an <see cref="AutoFixAllReport"/>.</summary>
     internal sealed record AutoFixRuleReport(
@@ -108,6 +109,12 @@ public sealed class AutoFixTool
     /// <summary>A single per-file failure. <see cref="File"/> is repo-relative
     /// and <see cref="Message"/> is scrubbed of absolute host paths.</summary>
     internal sealed record AutoFixError(string File, string Message);
+
+    /// <summary>A per-file unified diff for the preview (dry-run) surface — so a
+    /// human (or an MCP agent) can review the actual change before applying it,
+    /// not just a bare file name. <see cref="Diff"/> is secret-redacted and
+    /// line-capped. WM-24.</summary>
+    internal sealed record AutoFixFileDiff(string File, IReadOnlyList<string> RuleIds, string Diff);
 
     /// <summary>
     /// Internal helper for sibling tools (e.g. <see cref="BeforeAfterTool"/>)
@@ -254,6 +261,9 @@ public sealed class AutoFixTool
             // Additive: previously-swallowed per-file failures.
             errors = (report.Errors ?? Array.Empty<AutoFixError>())
                 .Select(e => new { file = e.File, error = e.Message }).ToList(),
+            // Additive (WM-24): per-file preview diffs for agent review.
+            diffs = (report.Diffs ?? Array.Empty<AutoFixFileDiff>())
+                .Select(d => new { file = d.File, ruleIds = d.RuleIds, diff = d.Diff }).ToList(),
         }, new JsonSerializerOptions { WriteIndented = true });
     }
 
@@ -321,20 +331,45 @@ public sealed class AutoFixTool
 
         var errors = outcomes.Where(o => o.Error is not null).Select(o => o.Error!).ToList();
 
+        // WM-24: a per-file unified diff so the preview is actually reviewable.
+        // Reuses BeforeAfterTool's secret-redacting renderer; each diff is line-capped.
+        var diffs = outcomes
+            .Where(o => o.ChangedByRules.Count > 0 && o.OldText is not null && o.NewText is not null)
+            .Select(o => new AutoFixFileDiff(
+                o.Relative,
+                o.ChangedByRules,
+                CapLines(BeforeAfterTool.RenderUnifiedDiff(o.OldText!, o.NewText!, contextLines: 2), maxLines: 200)))
+            .ToList();
+
         return new AutoFixAllReport(
             DryRun: dryRun,
             OrderOfExecution: OrderedRuleIds,
             TotalDistinctFilesChanged: allChanged.Count,
             AffectedFiles: allChanged.ToList(),
             PerRule: perRule,
-            Errors: errors);
+            Errors: errors,
+            Diffs: diffs);
     }
 
-    /// <summary>Per-file result of one pipeline pass.</summary>
+    /// <summary>Truncates a rendered diff to <paramref name="maxLines"/> lines with
+    /// a pointer to the full form, so one huge file cannot flood the terminal.</summary>
+    private static string CapLines(string text, int maxLines)
+    {
+        var lines = text.Split('\n');
+        if (lines.Length <= maxLines) return text;
+        return string.Join('\n', lines.Take(maxLines))
+            + $"\n… (+{lines.Length - maxLines} more diff lines — re-run with --json for the full diff)";
+    }
+
+    /// <summary>Per-file result of one pipeline pass. <see cref="OldText"/> /
+    /// <see cref="NewText"/> are captured only for changed files, for the
+    /// preview diff (WM-24).</summary>
     private sealed record FileOutcome(
         string Relative,
         IReadOnlyList<string> ChangedByRules,
-        AutoFixError? Error);
+        AutoFixError? Error,
+        string? OldText = null,
+        string? NewText = null);
 
     /// <summary>
     /// The single per-file engine shared by <see cref="MafAutoFix"/> (one rewriter)
@@ -390,10 +425,11 @@ public sealed class AutoFixTool
                     continue;
                 }
 
+                var newText = root.ToFullString();
                 if (!dryRun)
-                    SafeWorkspaceWriter.WriteAtomic(repoPath, file, root.ToFullString(), encoding);
+                    SafeWorkspaceWriter.WriteAtomic(repoPath, file, newText, encoding);
 
-                outcomes.Add(new FileOutcome(relative, changedBy, null));
+                outcomes.Add(new FileOutcome(relative, changedBy, null, OldText: src, NewText: newText));
             }
             catch (Exception ex)
             {

--- a/src/maf-autopilot/Tools/Rewriters/EnableSensitiveDataRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/EnableSensitiveDataRewriter.cs
@@ -34,17 +34,19 @@ internal sealed class EnableSensitiveDataRewriter : CSharpSyntaxRewriter, IRuleR
 
     public override SyntaxNode? VisitInitializerExpression(InitializerExpressionSyntax node)
     {
-        var filtered = node.Expressions
-            .Where(e => !IsEnableSensitiveDataTrueAssignment(e))
-            .ToArray();
+        var toRemove = node.Expressions
+            .Where(IsEnableSensitiveDataTrueAssignment)
+            .ToList();
 
-        if (filtered.Length == node.Expressions.Count)
-            return base.VisitInitializerExpression(node); // no removal
+        if (toRemove.Count == 0)
+            return base.VisitInitializerExpression(node); // no removal — recurse into children
 
-        // Rebuild the initializer with the filtered list, preserving the
-        // outer braces and any trivia on the unchanged expressions.
-        var newList = SyntaxFactory.SeparatedList(filtered);
-        return node.WithExpressions(newList);
+        // WM-22: the previous `SyntaxFactory.SeparatedList(filtered)` rebuild
+        // dropped ALL separator trivia — collapsing the surviving entries onto a
+        // single line and deleting their comments. RemoveNodes excises each flagged
+        // entry together with its OWN adjacent separator while leaving the surviving
+        // entries' separators — newlines, inline comments, trailing comma — intact.
+        return node.RemoveNodes(toRemove, SyntaxRemoveOptions.KeepNoTrivia)!;
     }
 
     /// <summary>

--- a/src/maf-autopilot/Tools/Rewriters/EnableSensitiveDataRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/EnableSensitiveDataRewriter.cs
@@ -34,19 +34,25 @@ internal sealed class EnableSensitiveDataRewriter : CSharpSyntaxRewriter, IRuleR
 
     public override SyntaxNode? VisitInitializerExpression(InitializerExpressionSyntax node)
     {
-        var toRemove = node.Expressions
+        // Recurse FIRST so a nested `EnableSensitiveData = true` inside a SURVIVING
+        // sibling entry is cleaned too — the autofix pipeline runs each rewriter
+        // exactly once (no fixpoint pass), so a missed nested flag would otherwise
+        // silently stay enabled.
+        var visited = (InitializerExpressionSyntax)base.VisitInitializerExpression(node)!;
+
+        var toRemove = visited.Expressions
             .Where(IsEnableSensitiveDataTrueAssignment)
             .ToList();
 
         if (toRemove.Count == 0)
-            return base.VisitInitializerExpression(node); // no removal — recurse into children
+            return visited;
 
-        // WM-22: the previous `SyntaxFactory.SeparatedList(filtered)` rebuild
-        // dropped ALL separator trivia — collapsing the surviving entries onto a
-        // single line and deleting their comments. RemoveNodes excises each flagged
-        // entry together with its OWN adjacent separator while leaving the surviving
-        // entries' separators — newlines, inline comments, trailing comma — intact.
-        return node.RemoveNodes(toRemove, SyntaxRemoveOptions.KeepNoTrivia)!;
+        // WM-22: the previous `SyntaxFactory.SeparatedList(filtered)` rebuild dropped
+        // ALL separator trivia — collapsing the surviving entries onto one line and
+        // deleting their comments. RemoveNodes excises each flagged entry together
+        // with its OWN adjacent separator while leaving the survivors' separators —
+        // newlines, inline comments, trailing comma — intact.
+        return visited.RemoveNodes(toRemove, SyntaxRemoveOptions.KeepNoTrivia)!;
     }
 
     /// <summary>

--- a/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
@@ -71,13 +71,15 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
                 sealedToken = sealedToken.WithLeadingTrivia(list[0].LeadingTrivia);
                 list[0] = list[0].WithLeadingTrivia();
             }
-            else if (insertAt == 0 && node.AttributeLists.Count == 0)
+            else if (insertAt == 0)
             {
-                // No modifiers AND no attributes: `sealed` becomes the first token of
-                // the whole declaration. Carry the `class` keyword's leading trivia
-                // (indentation + any `///` doc) onto `sealed`, else it strands between
-                // the modifiers and `class` — de-indenting the line and DETACHING the
-                // XML doc from the type (CS1587, documentation lost).
+                // No modifiers: `sealed` becomes the first MODIFIER. Carry the `class`
+                // keyword's leading trivia onto it, else the modifiers strand between
+                // the keyword's indentation and `class` — de-indenting the line and,
+                // when there are no attributes, DETACHING a leading `///` doc (CS1587,
+                // documentation lost). With attributes the keyword's leading trivia is
+                // just the indentation (the doc sits on the attribute list, which is
+                // left untouched), so carrying it is correct there too.
                 sealedToken = sealedToken.WithLeadingTrivia(node.Keyword.LeadingTrivia);
                 node = node.WithKeyword(node.Keyword.WithLeadingTrivia());
             }

--- a/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
@@ -64,13 +64,22 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
             // `partial sealed class X`.
             var partialIdx = list.FindIndex(t => t.IsKind(SyntaxKind.PartialKeyword));
             var insertAt = partialIdx >= 0 ? partialIdx : Math.Min(1, list.Count);
-            // When `sealed` becomes the new first modifier, carry the leading trivia
-            // (indentation / xmldoc) from the token that is currently first so the
-            // declaration stays laid out correctly.
             if (insertAt == 0 && list.Count > 0)
             {
+                // `sealed` becomes the new first MODIFIER — carry the old first
+                // modifier's leading trivia (indentation / xmldoc) onto it.
                 sealedToken = sealedToken.WithLeadingTrivia(list[0].LeadingTrivia);
                 list[0] = list[0].WithLeadingTrivia();
+            }
+            else if (insertAt == 0 && node.AttributeLists.Count == 0)
+            {
+                // No modifiers AND no attributes: `sealed` becomes the first token of
+                // the whole declaration. Carry the `class` keyword's leading trivia
+                // (indentation + any `///` doc) onto `sealed`, else it strands between
+                // the modifiers and `class` — de-indenting the line and DETACHING the
+                // XML doc from the type (CS1587, documentation lost).
+                sealedToken = sealedToken.WithLeadingTrivia(node.Keyword.LeadingTrivia);
+                node = node.WithKeyword(node.Keyword.WithLeadingTrivia());
             }
             list.Insert(insertAt, sealedToken);
         }

--- a/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/ExecutorSealedRewriter.cs
@@ -55,8 +55,24 @@ internal sealed class ExecutorSealedRewriter : CSharpSyntaxRewriter, IRuleRewrit
         {
             var sealedToken = SyntaxFactory.Token(SyntaxKind.SealedKeyword)
                 .WithTrailingTrivia(SyntaxFactory.Space);
-            // Insert after the first modifier; if there are none, prepend.
-            list.Insert(list.Count == 0 ? 0 : 1, sealedToken);
+            // `partial` MUST stay immediately before `class` (CS0267), so `sealed`
+            // has to be inserted BEFORE any existing `partial`. Insert right at the
+            // first `partial` if present; otherwise after the access modifier
+            // (index 1), or at the front when there are no modifiers at all.
+            // Without this, a `partial`-first declaration (`partial class X`, the
+            // idiomatic internal-by-default shape) was rewritten to the uncompilable
+            // `partial sealed class X`.
+            var partialIdx = list.FindIndex(t => t.IsKind(SyntaxKind.PartialKeyword));
+            var insertAt = partialIdx >= 0 ? partialIdx : Math.Min(1, list.Count);
+            // When `sealed` becomes the new first modifier, carry the leading trivia
+            // (indentation / xmldoc) from the token that is currently first so the
+            // declaration stays laid out correctly.
+            if (insertAt == 0 && list.Count > 0)
+            {
+                sealedToken = sealedToken.WithLeadingTrivia(list[0].LeadingTrivia);
+                list[0] = list[0].WithLeadingTrivia();
+            }
+            list.Insert(insertAt, sealedToken);
         }
         if (needsPartial)
         {

--- a/src/maf-autopilot/Tools/Rewriters/FanInArgOrderRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/FanInArgOrderRewriter.cs
@@ -84,8 +84,30 @@ internal sealed class FanInArgOrderRewriter : CSharpSyntaxRewriter, IRuleRewrite
         CollectionExpressionSyntax => true,               // [a, b, c] (C# 12)
         InitializerExpressionSyntax => true,              // { ... }
         ObjectCreationExpressionSyntax oce when oce.Type is ArrayTypeSyntax => true,
-        ObjectCreationExpressionSyntax oce when oce.Type.ToString().Contains("List") => true,
+        // WM-42/WM-43: match KNOWN collection types by their rightmost simple name,
+        // not a `Contains("List")` substring — the latter also matched non-collection
+        // types like `ListenerNode` / `Playlist` / `Blacklist`, which could trigger a
+        // WRONG argument swap on a correctly-ordered call.
+        ObjectCreationExpressionSyntax oce when IsKnownCollectionType(oce.Type) => true,
         _ => false,
+    };
+
+    private static readonly HashSet<string> CollectionTypeNames = new(StringComparer.Ordinal)
+    {
+        "List", "IList", "IReadOnlyList", "IEnumerable", "ICollection",
+        "IReadOnlyCollection", "Collection", "HashSet", "ISet",
+    };
+
+    private static bool IsKnownCollectionType(TypeSyntax type) =>
+        RightmostName(type) is { } n && CollectionTypeNames.Contains(n);
+
+    // `List<T>` → "List", `System.Collections.Generic.List<T>` → "List", `List` → "List".
+    private static string? RightmostName(TypeSyntax type) => type switch
+    {
+        GenericNameSyntax g => g.Identifier.ValueText,
+        IdentifierNameSyntax i => i.Identifier.ValueText,
+        QualifiedNameSyntax q => RightmostName(q.Right),
+        _ => null,
     };
 
     private static ArgumentSyntax StripNamedLabel(ArgumentSyntax arg) =>

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -297,6 +297,22 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
         return node.WithLeadingTrivia(
             node.GetLeadingTrivia()
                 .Add(SyntaxFactory.Comment(commentText))
-                .Add(SyntaxFactory.EndOfLine("\n")));
+                .Add(SyntaxFactory.EndOfLine(DetectNewLine(node))));
+    }
+
+    /// <summary>
+    /// WM-42: the skip-with-TODO comment must use the FILE's newline, not a
+    /// hard-coded LF — otherwise a CRLF file gets a lone LF spliced in, producing
+    /// mixed line endings. Detect the convention from the first end-of-line trivia
+    /// in the tree; default to LF for a single-line source with none.
+    /// </summary>
+    private static string DetectNewLine(SyntaxNode node)
+    {
+        var root = node.SyntaxTree?.GetRoot();
+        if (root is not null)
+            foreach (var trivia in root.DescendantTrivia())
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                    return trivia.ToString();
+        return "\n";
     }
 }

--- a/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
+++ b/src/maf-autopilot/Tools/Rewriters/SyncOverAsyncRewriter.cs
@@ -36,6 +36,53 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
 {
     public string RuleId => "MAF-AP-CONC-002";
 
+    private const string NonAwaitableReason =
+        "// MAF-AP-CONC-002: cannot verify the awaited call returns a Task (no semantic model) — review manually. If it does, give the method an 'Async' suffix or await it explicitly.";
+
+    // Well-known Task / ValueTask static factory methods whose result is awaitable.
+    private static readonly HashSet<string> TaskFactoryMethods = new(StringComparer.Ordinal)
+    {
+        "Run", "FromResult", "FromCanceled", "FromException", "WhenAll", "WhenAny", "WhenEach", "Delay",
+    };
+
+    /// <summary>
+    /// Syntax-only heuristic (this rewriter has no semantic model) for whether
+    /// <paramref name="inv"/> is likely to return an awaitable (Task/ValueTask).
+    /// We rewrite ONLY when the receiver is syntactically recognizable as a task
+    /// source — the invoked method's simple name ends in <c>Async</c>, or it is a
+    /// well-known <c>Task</c>/<c>ValueTask</c> factory (<c>Task.Run</c>,
+    /// <c>Task.WhenAll</c>, …). Everything else is left untouched with a
+    /// review-manually TODO: a safe skip always beats corrupting source by awaiting
+    /// a non-Task (e.g. <c>SemaphoreSlim.Wait()</c> or a custom <c>.Result</c>).
+    /// </summary>
+    private static bool LooksAwaitableReceiver(InvocationExpressionSyntax inv)
+    {
+        var name = InvokedSimpleName(inv);
+        if (name is null) return false;
+        if (name.EndsWith("Async", StringComparison.Ordinal)) return true;
+        return inv.Expression is MemberAccessExpressionSyntax ma
+            && TaskFactoryMethods.Contains(name)
+            && ReceiverTypeName(ma.Expression) is "Task" or "ValueTask";
+    }
+
+    private static string? InvokedSimpleName(InvocationExpressionSyntax inv) => inv.Expression switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        GenericNameSyntax gn => gn.Identifier.ValueText,
+        MemberAccessExpressionSyntax ma => ma.Name.Identifier.ValueText,
+        MemberBindingExpressionSyntax mb => mb.Name.Identifier.ValueText,
+        _ => null,
+    };
+
+    // Rightmost identifier of a factory receiver: `Task`, `System.Threading.Tasks.Task` → "Task".
+    private static string? ReceiverTypeName(ExpressionSyntax expr) => expr switch
+    {
+        IdentifierNameSyntax id => id.Identifier.ValueText,
+        GenericNameSyntax gn => gn.Identifier.ValueText,
+        MemberAccessExpressionSyntax ma => ma.Name.Identifier.ValueText,
+        _ => null,
+    };
+
     public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
     {
         // Pattern: <invocation>.Result
@@ -44,6 +91,14 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
         {
             if (ShouldSkipForContext(node, out var reason))
                 return WithTodoTrivia(node, reason);
+
+            // Syntax-only awaitability gate: with no semantic model we cannot tell a
+            // Task-returning invocation from `GetLock()` (SemaphoreSlim) or a custom
+            // `.Result` wrapper — rewriting the latter to `await …` emits uncompilable
+            // code (CS1061). Rewrite only when the receiver is syntactically a task
+            // source (see LooksAwaitableReceiver); otherwise leave it with a TODO.
+            if (!LooksAwaitableReceiver(inv))
+                return WithTodoTrivia(node, NonAwaitableReason);
 
             // Rewrite `Foo().Result` → `(await Foo())`.
             // Wrap in parens so the surrounding member-access / arg context
@@ -69,6 +124,13 @@ internal sealed class SyncOverAsyncRewriter : CSharpSyntaxRewriter, IRuleRewrite
         {
             if (ShouldSkipForContext(node, out var reason))
                 return WithTodoTrivia(node, reason);
+
+            // Same syntax-only awaitability gate as the `.Result` path: `_sem.Wait()`
+            // is not matched (receiver is not an invocation), but `GetLock().Wait()`
+            // on a SemaphoreSlim IS — and awaiting it would not compile. Skip unless
+            // the receiver is syntactically a task source.
+            if (!LooksAwaitableReceiver(inner))
+                return WithTodoTrivia(node, NonAwaitableReason);
 
             // Rewrite `Foo().Wait()` → `await Foo()`. Need an explicit
             // trailing-space on the `await` token.

--- a/src/maf-autopilot/Tools/SafeWorkspaceWriter.cs
+++ b/src/maf-autopilot/Tools/SafeWorkspaceWriter.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace MafDoctor.Tools;
 
 /// <summary>
@@ -45,6 +47,19 @@ internal static class SafeWorkspaceWriter
     /// itself a symlink/reparse point.
     /// </exception>
     public static void WriteAtomic(string workspaceRoot, string destinationPath, string contents)
+        // Default encoding: UTF-8 without a BOM — the historical behaviour of the
+        // bare `new StreamWriter(fs)` this overload replaces. New-file writers
+        // (scaffolders, init) rely on it.
+        => WriteAtomic(workspaceRoot, destinationPath, contents, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+
+    /// <summary>
+    /// Encoding-preserving variant of <see cref="WriteAtomic(string,string,string)"/>.
+    /// Writes <paramref name="contents"/> using <paramref name="encoding"/> so a
+    /// rewriter that read a file's original encoding (UTF-8-with-BOM, UTF-16, …)
+    /// can round-trip it byte-faithfully instead of silently normalising to
+    /// UTF-8-no-BOM. Same atomic-replace + symlink-containment guarantees.
+    /// </summary>
+    public static void WriteAtomic(string workspaceRoot, string destinationPath, string contents, Encoding encoding)
     {
         var resolved = PathGuard.ValidateContainment(workspaceRoot, destinationPath, nameof(destinationPath));
 
@@ -61,7 +76,7 @@ internal static class SafeWorkspaceWriter
         try
         {
             using (var fs = new FileStream(tmp, FileMode.CreateNew, FileAccess.Write, FileShare.None))
-            using (var writer = new StreamWriter(fs))
+            using (var writer = new StreamWriter(fs, encoding))
             {
                 writer.Write(contents);
                 writer.Flush();


### PR DESCRIPTION
Phase 1 of the Fable 5 remediation plan (`private/fable5review/PLAN.md`) — all **12 Phase-1 findings** on the deterministic autofix engine, plus two adversarial-review rounds that caught and fixed 8 more real bugs.

## Findings fixed (12)

**Rewriter source-corruption (High):**
- **WM-02** `ExecutorSealedRewriter` wrote uncompilable `partial sealed class` (CS0267) for `partial`-first classes; `sealed` is now placed before `partial`, with correct leading-trivia carry for zero-modifier and attributed classes.
- **WM-03** `SyncOverAsyncRewriter` rewrote `.Wait()`/`.Result` on non-Task receivers (SemaphoreSlim, custom wrappers) into uncompilable `await`; now gated on a syntax-only awaitability check (name ends `Async` or a `Task`/`ValueTask` factory), else a safe review-manually TODO.

**Pipeline & robustness:**
- **WM-23** single parse-once / fold / write-once pipeline (was O(files × rules) walks+parses; dry-run now composes exactly like apply).
- **WM-20** encoding/BOM preservation on write-back (UTF-8 / UTF-8-BOM / UTF-16 LE-BE / UTF-32 LE-BE) with a strict decoder that skips-with-error rather than U+FFFD-corrupting an undecodable file.
- **WM-21** per-file read/rewrite/write failures are surfaced (JSON `errors`, CLI section) and drive a non-zero apply exit — no longer silently swallowed; a locked/denied file no longer aborts the whole pass.
- **WM-41** a missing / non-`.cs` `specificFile` is now an explicit error, not a silent 0-change success.
- **WM-24** the preview (default dry-run) shows a reviewable per-file unified diff, not just file names.
- **WM-44** concurrent applies on one repo are serialised by an exclusive OS lock (keyed by the repo's canonical path, in temp — repo never polluted).

**Rewriter correctness:**
- **WM-22** `EnableSensitiveDataRewriter` preserves surviving entries' comments/lines (was collapsing + deleting comments) and now removes nested flags too.
- **WM-42** CONC-002 TODO uses the file's newline (no CRLF/LF mixing).
- **WM-43** FanIn collection heuristic matches known collection types precisely (was a `Contains("List")` substring that mis-swapped `ListenerNode` etc.).
- **REP-26** the zero-change CLI text derives the rewriter count from the report.

## Review

Two adversarial-review rounds (Opus) on the diff caught **8 additional real bugs** the tests missed — including two regressions this phase introduced (a locked-file read aborting the pass; the strict decode silently disabled for BOM'd files) and several vacuous tests. All fixed; see commits `a8c77ba` and `d6ae727`.

## Intended contract changes (for release notes)

These are the *intended* behavior of this phase — correct by design, but worth calling out for consumers:
1. **WM-41** — `MafAutoFix`/`MafAutoFixAll` with a missing/non-`.cs` `specificFile` now returns `{error}` instead of a zero-change report (consistent with the existing bad-`repoPath` error shape).
2. **WM-21** — `autofix-all --apply` now exits **1** on any per-file failure (was always 0 on a valid repo). Dry-run still exits 0.
3. **WM-23** — dry-run per-rule counts now reflect the composed pipeline (== what apply produces), not each rule applied to the original file independently.

## Tests

Full suite green on **net8.0 and net9.0 (1140/1140 each)**; ~30 new regression tests (compile-roundtrip fixtures that compile every rewriter's output, encoding round-trips, idempotence, lock, error-surfacing). **net10.0 was not built locally** (a running maf-doctor MCP server held the net10 binary) — this PR's CI is the first net10 verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
