### PR TITLE
Phase 2 (Fable 5): CLI & MCP lifecycle — entry conventions, strict args, honest exit codes & streams

### DIFF
--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -1383,14 +1383,14 @@ public class DoctorToolTests
     [Fact]
     public void DoctorCli_Parse_JsonFlag_SetsJsonFormat()
     {
-        var (_, format, _, _) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--json" });
+        var (_, format, _, _, _, _) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--json" });
         Assert.Equal("json", format);
     }
 
     [Fact]
     public void DoctorCli_Parse_PlanFlag_SetsPlanFormat()
     {
-        var (_, format, _, _) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--plan" });
+        var (_, format, _, _, _, _) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--plan" });
         Assert.Equal("plan", format);
     }
 
@@ -1408,7 +1408,7 @@ public class DoctorToolTests
     [Fact]
     public void DoctorCli_Parse_NoFormatFlag_DefaultsToMarkdown()
     {
-        var (path, format, _, full) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", "." });
+        var (path, format, _, full, _, _) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", "." });
         Assert.Equal(".", path);
         Assert.Equal("markdown", format);
         Assert.False(full);
@@ -1418,7 +1418,7 @@ public class DoctorToolTests
     public void DoctorCli_Parse_FlagBeforePath_StillCapturesPath()
     {
         // The `--` guard means a flag preceding the path isn't mistaken for it.
-        var (path, format, _, full) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", "--all", "--json", "myrepo" });
+        var (path, format, _, full, _, _) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", "--all", "--json", "myrepo" });
         Assert.Equal("myrepo", path);
         Assert.Equal("json", format);
         Assert.True(full);
@@ -1427,9 +1427,42 @@ public class DoctorToolTests
     [Fact]
     public void DoctorCli_Parse_ExcludeIsRepeatable()
     {
-        var (_, _, excludes, _) = MafDoctor.Commands.DoctorCli.Parse(
+        var (_, _, excludes, _, _, _) = MafDoctor.Commands.DoctorCli.Parse(
             new[] { "doctor", ".", "--exclude", "samples/", "--exclude", "tests/" });
         Assert.Equal(new[] { "samples/", "tests/" }, excludes);
+    }
+
+    [Fact]
+    public void DoctorCli_Parse_UnknownFlag_ReturnsError()
+    {
+        var (_, _, _, _, _, error) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--nope" });
+        Assert.NotNull(error);
+        Assert.Contains("--nope", error);
+    }
+
+    [Fact]
+    public void DoctorCli_Parse_ExtraPositional_ReturnsError()
+    {
+        var (_, _, _, _, _, error) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", "a", "b" });
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void DoctorCli_Parse_ExcludeSwallowingFlag_ReturnsError()
+    {
+        // REP-05: `--exclude --json` must NOT eat --json; it errors loudly instead.
+        var (_, _, excludes, _, _, error) = MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--exclude", "--json" });
+        Assert.NotNull(error);
+        Assert.Empty(excludes);
+    }
+
+    [Fact]
+    public void DoctorCli_Parse_FailOn_ParsesGradeAndRejectsJunk()
+    {
+        Assert.Equal("C", MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--fail-on", "c" }).FailOn);
+        Assert.Null(MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--fail-on", "C" }).Error);
+        Assert.NotNull(MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--fail-on", "Z" }).Error);
+        Assert.NotNull(MafDoctor.Commands.DoctorCli.Parse(new[] { "doctor", ".", "--fail-on", "--json" }).Error);
     }
 
     [Fact]

--- a/src/maf-autopilot.Tests/NewCommandTests.cs
+++ b/src/maf-autopilot.Tests/NewCommandTests.cs
@@ -45,6 +45,39 @@ public sealed class NewCommandTests : IDisposable
         Assert.Equal("// USER-EDITED — must not be overwritten\n", File.ReadAllText(path));
     }
 
+    // ---- WM-05: the advertised `new executor <Name> [In] [Out]` positionals work ----
+
+    [Fact]
+    public void PositionalsAfter_SkipsFlagsAndTheirValues()
+    {
+        var pos = NewCommand.PositionalsAfter(
+            ["new", "executor", "Foo", "In", "--path", "/dir", "Out"],
+            startIndex: 3, "--path", "--input", "--output");
+        Assert.Equal(new[] { "In", "Out" }, pos);
+    }
+
+    [Fact]
+    public void Run_NewExecutor_PositionalTypes_AreHonored()
+    {
+        var exitCode = NewCommand.Run(["new", "executor", "FraudReviewer", "FraudCheck", "FraudReport", "--path", _tempDir]);
+        Assert.Equal(0, exitCode);
+        var file = Path.Combine(_tempDir, "Workflows", "FraudReviewerExecutor.cs"); // scaffolder appends "Executor"
+        Assert.True(File.Exists(file), file);
+        var content = File.ReadAllText(file);
+        Assert.Contains("FraudCheck", content);
+        Assert.Contains("FraudReport", content);
+    }
+
+    [Fact]
+    public void Run_NewExecutor_FlagsWinOverPositionals()
+    {
+        NewCommand.Run(["new", "executor", "Rev", "PosIn", "PosOut", "--input", "FlagIn", "--output", "FlagOut", "--path", _tempDir]);
+        var content = File.ReadAllText(Path.Combine(_tempDir, "Workflows", "RevExecutor.cs"));
+        Assert.Contains("FlagIn", content);
+        Assert.Contains("FlagOut", content);
+        Assert.DoesNotContain("PosIn", content);
+    }
+
     // -------------------------------------------------------------------------
     // F-03 — WriteFiles previously wrote through a symlinked Agents/Workflows
     // directory (or a symlinked target file) with plain File.WriteAllText, no

--- a/src/maf-autopilot.Tests/ProgramCliDispatchTests.cs
+++ b/src/maf-autopilot.Tests/ProgramCliDispatchTests.cs
@@ -85,4 +85,58 @@ public sealed class ProgramCliDispatchTests
         Assert.Equal(0, exitCode);
         Assert.False(string.IsNullOrWhiteSpace(stdout));
     }
+
+    // ---- Phase 2 ----
+
+    [Fact]
+    public void Doctor_UnknownFlag_ExitsUsageError() // WM-04
+    {
+        var (exitCode, _, stderr) = Run(TimeSpan.FromSeconds(30), "doctor", Path.GetTempPath(), "--bogus");
+        Assert.Equal(2, exitCode);
+        Assert.Contains("--bogus", stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Doctor_ExcludeSwallowingFlag_ExitsUsageError() // REP-05
+    {
+        var (exitCode, _, _) = Run(TimeSpan.FromSeconds(30), "doctor", Path.GetTempPath(), "--exclude", "--json");
+        Assert.Equal(2, exitCode);
+    }
+
+    [Fact]
+    public void Doctor_InvalidPath_HumanErrorGoesToStdErr_NotStdOut() // REP-08
+    {
+        var badPath = Path.Combine(Path.GetTempPath(), "maf-doctor-nope-" + Guid.NewGuid().ToString("N"));
+        var (exitCode, stdout, stderr) = Run(TimeSpan.FromSeconds(30), "doctor", badPath);
+        Assert.Equal(1, exitCode);
+        Assert.False(string.IsNullOrWhiteSpace(stderr)); // error on stderr...
+        Assert.True(string.IsNullOrWhiteSpace(stdout));   // ...not stdout
+    }
+
+    [Fact]
+    public void Doctor_FailOnA_GateAlwaysFails_ExitsThree() // REP-09 (fail path)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-failon-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var (exitCode, _, _) = Run(TimeSpan.FromSeconds(30), "doctor", dir, "--fail-on", "A");
+            Assert.Equal(3, exitCode); // any grade is at-or-below A → gate fails
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    [Fact]
+    public void Doctor_FailOnF_CleanRepo_GatePasses_ExitsZero() // REP-09 (pass path)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-doctor-failonf-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Clean.cs"), "public class Clean { public int X => 1; }");
+            var (exitCode, _, _) = Run(TimeSpan.FromSeconds(30), "doctor", dir, "--fail-on", "F");
+            Assert.Equal(0, exitCode); // a clean repo grades above F → gate passes
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
 }

--- a/src/maf-autopilot/Commands/DoctorCli.cs
+++ b/src/maf-autopilot/Commands/DoctorCli.cs
@@ -20,25 +20,54 @@ namespace MafDoctor.Commands;
 /// </summary>
 internal static class DoctorCli
 {
-    public static (string? Path, string Format, List<string> Excludes, bool Full) Parse(string[] args)
+    public static (string? Path, string Format, List<string> Excludes, bool Full, string? FailOn, string? Error) Parse(string[] args)
     {
         var excludes = new List<string>();
         string? path = null;
         var full = false;
         var json = false;
         var plan = false;
+        string? failOn = null;
+        var unknown = new List<string>();
+        string? error = null;
 
         // args[0] is "doctor"; options start at index 1.
         for (int i = 1; i < args.Length; i++)
         {
-            if (args[i] == "--exclude" && i + 1 < args.Length) { excludes.Add(args[++i]); continue; }
-            if (args[i] is "--all" or "--full") { full = true; continue; }
-            if (args[i] is "--json") { json = true; continue; }
-            if (args[i] is "--plan") { plan = true; continue; }
-            // First non-flag token is the path. The `--` guard means a flag that
-            // appears before the path (e.g. `doctor --json .`) is never mistaken
-            // for the path.
-            if (path is null && !args[i].StartsWith("--", StringComparison.Ordinal)) path = args[i];
+            var a = args[i];
+            // REP-05: `--exclude` requires a value and must never swallow a following
+            // flag (`doctor --exclude --json` used to silently disable --json).
+            if (a == "--exclude")
+            {
+                if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal)) excludes.Add(args[++i]);
+                else error ??= "--exclude requires a value (e.g. `--exclude tests`)";
+                continue;
+            }
+            // REP-09: opt-in CI gate — exit 3 when the grade is at-or-below <grade>.
+            if (a == "--fail-on")
+            {
+                if (i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal)) failOn = args[++i];
+                else error ??= "--fail-on requires a grade (A|B|C|F)";
+                continue;
+            }
+            if (a is "--all" or "--full") { full = true; continue; }
+            if (a is "--json") { json = true; continue; }
+            if (a is "--plan") { plan = true; continue; }
+            // WM-04: reject unknown flags and extra positionals loudly (exit 2 in
+            // Program.cs) instead of silently ignoring them.
+            if (a.StartsWith("--", StringComparison.Ordinal)) { unknown.Add(a); continue; }
+            if (path is null) { path = a; continue; }
+            unknown.Add(a); // a second positional is not expected
+        }
+
+        if (error is null && unknown.Count > 0)
+            error = "unknown option(s) / extra argument(s): " + string.Join(", ", unknown);
+
+        if (error is null && failOn is not null)
+        {
+            failOn = failOn.ToUpperInvariant();
+            if (failOn is not ("A" or "B" or "C" or "F"))
+                error = $"--fail-on must be one of A, B, C, F (got '{failOn}')";
         }
 
         // `--plan --json` (either order) = the machine-readable remediation MANIFEST
@@ -52,6 +81,6 @@ internal static class DoctorCli
             _ => "markdown",
         };
 
-        return (path, format, excludes, full);
+        return (path, format, excludes, full, failOn, error);
     }
 }

--- a/src/maf-autopilot/InitCommand.cs
+++ b/src/maf-autopilot/InitCommand.cs
@@ -365,7 +365,9 @@ internal static class InitCommand
         }
         else
         {
-            var stored = env[rootsKey]?.GetValue<string>() ?? string.Empty;
+            // Defensive: a hand-edited config could store a non-string here — extract
+            // safely (a bare GetValue<string>() would throw on a number/array/object).
+            var stored = env[rootsKey] is JsonValue jv && jv.TryGetValue<string>(out var sv) ? sv : string.Empty;
             var covered = stored
                 .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Any(root => PathCovers(root, targetDir));

--- a/src/maf-autopilot/InitCommand.cs
+++ b/src/maf-autopilot/InitCommand.cs
@@ -96,22 +96,32 @@ internal static class InitCommand
         if (withCursor) Console.WriteLine("  --with-cursor: .cursor/rules/maf-doctor.mdc will also be dropped");
         Console.WriteLine();
 
-        await WriteMcpJsonAsync(targetDir);
-        await WriteClaudeMcpJsonAsync(targetDir);
+        try
+        {
+            await WriteMcpJsonAsync(targetDir);
+            await WriteClaudeMcpJsonAsync(targetDir);
 
-        // Steering — overwrite-on-reinit sidecars in each tool's auto-loaded
-        // convention dir. We never merge into the user's own copilot-instructions.md
-        // / CLAUDE.md, and re-running init refreshes the guidance (no duplicates).
-        await WriteSidecarAsync(targetDir, "steering/copilot-instructions.md",
-            ".github/instructions/maf-doctor.instructions.md",
-            "---\napplyTo: '**'\n---\n\n" + ManagedSidecarNote(".github/copilot-instructions.md"));
-        await WriteClaudeSteeringAsync(targetDir);
-        await UpsertManagedBlockAsync(targetDir, "steering/agents.md", "AGENTS.md");
-        if (withCursor)
-            await WriteSidecarAsync(targetDir, "steering/cursor-rules.md",
-                ".cursor/rules/maf-doctor.mdc",
-                "---\ndescription: MAF Doctor — use the MCP tools for Microsoft Agent Framework code\nalwaysApply: true\n---\n\n"
-                    + ManagedSidecarNote("a separate .cursor/rules/*.mdc file"));
+            // Steering — overwrite-on-reinit sidecars in each tool's auto-loaded
+            // convention dir. We never merge into the user's own copilot-instructions.md
+            // / CLAUDE.md, and re-running init refreshes the guidance (no duplicates).
+            await WriteSidecarAsync(targetDir, "steering/copilot-instructions.md",
+                ".github/instructions/maf-doctor.instructions.md",
+                "---\napplyTo: '**'\n---\n\n" + ManagedSidecarNote(".github/copilot-instructions.md"));
+            await WriteClaudeSteeringAsync(targetDir);
+            await UpsertManagedBlockAsync(targetDir, "steering/agents.md", "AGENTS.md");
+            if (withCursor)
+                await WriteSidecarAsync(targetDir, "steering/cursor-rules.md",
+                    ".cursor/rules/maf-doctor.mdc",
+                    "---\ndescription: MAF Doctor — use the MCP tools for Microsoft Agent Framework code\nalwaysApply: true\n---\n\n"
+                        + ManagedSidecarNote("a separate .cursor/rules/*.mdc file"));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException)
+        {
+            // WM-10: an unexpected I/O error (or a containment refusal that propagated)
+            // fails init gracefully with a message + non-zero exit, not a raw stack trace.
+            Console.Error.WriteLine($"init failed: {ex.Message}");
+            return 1;
+        }
 
         Console.WriteLine();
         Console.WriteLine("Done. ⚡ Try these three commands first:");
@@ -339,17 +349,52 @@ internal static class InitCommand
 
         changed |= SetString(env, InitVersionEnvName, CurrentVersion);
 
-        // F-04 — first-time-only: scope newly-initialized workspaces to
-        // themselves by default. Deliberately does NOT overwrite an existing
-        // value on re-init — a user may have broadened this to cover multiple
-        // repositories, and re-running `init` must not silently narrow it back.
-        if (!env.ContainsKey(WorkspacePolicy.WorkspaceRootsEnvName))
+        // F-04 — first-time-only default: scope a newly-initialized workspace to
+        // itself. Deliberately does NOT overwrite an existing value on re-init — a
+        // user may have broadened this to cover multiple repositories.
+        // WM-01 — but if a stored value exists and does NOT cover this directory
+        // (the repo was moved/renamed, or init is re-run in a new location), APPEND
+        // this directory so re-running `init` SELF-HEALS the lockout instead of being
+        // a no-op that leaves every MCP tool blocked. Append-only never narrows a
+        // user's deliberately-broadened list.
+        var rootsKey = WorkspacePolicy.WorkspaceRootsEnvName;
+        if (!env.ContainsKey(rootsKey))
         {
-            env[WorkspacePolicy.WorkspaceRootsEnvName] = targetDir;
+            env[rootsKey] = targetDir;
             changed = true;
+        }
+        else
+        {
+            var stored = env[rootsKey]?.GetValue<string>() ?? string.Empty;
+            var covered = stored
+                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Any(root => PathCovers(root, targetDir));
+            if (!covered)
+            {
+                env[rootsKey] = string.IsNullOrWhiteSpace(stored) ? targetDir : stored + ";" + targetDir;
+                changed = true;
+                Console.WriteLine($"  ↺ MAF_DOCTOR_WORKSPACE_ROOTS did not cover this directory — appended it so tools work here again.");
+            }
         }
 
         return changed;
+    }
+
+    /// <summary>
+    /// True when <paramref name="target"/> is <paramref name="root"/> itself or a
+    /// directory beneath it. Case-insensitive on Windows. Used by WM-01 to decide
+    /// whether a stored workspace-root already covers the current directory.
+    /// </summary>
+    private static bool PathCovers(string root, string target)
+    {
+        try
+        {
+            var r = Path.TrimEndingDirectorySeparator(Path.GetFullPath(root));
+            var t = Path.TrimEndingDirectorySeparator(Path.GetFullPath(target));
+            var cmp = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+            return t.Equals(r, cmp) || t.StartsWith(r + Path.DirectorySeparatorChar, cmp);
+        }
+        catch { return false; } // an unresolvable stored root simply doesn't count as coverage
     }
 
     internal static InitStatus GetWorkspaceInitStatus(string targetDir)
@@ -649,11 +694,27 @@ internal static class InitCommand
             var ei = existing.IndexOf(end, StringComparison.Ordinal);
             if (bi >= 0 && ei > bi)
             {
+                // Well-formed managed block — replace it in place.
                 finalContent = existing[..bi] + block + existing[(ei + end.Length)..];
                 verb = "refreshed managed maf-doctor block";
             }
+            else if (bi >= 0)
+            {
+                // WM-27: a BEGIN marker with NO matching END after it (missing END, or an
+                // END that precedes BEGIN from a hand-edit). The old code fell through to
+                // the append branch and DUPLICATED the block. Instead replace from the
+                // BEGIN marker to end-of-file (dropping any orphaned END before it), so the
+                // never-duplicates invariant holds even under damaged markers.
+                Console.Error.WriteLine("  ⚠ AGENTS.md — a BEGIN marker without a matching END; replacing from the marker to end-of-file.");
+                var prefix = existing[..bi];
+                var strayEnd = prefix.IndexOf(end, StringComparison.Ordinal);
+                if (strayEnd >= 0) prefix = prefix.Remove(strayEnd, end.Length);
+                finalContent = prefix + block + "\n";
+                verb = "repaired managed maf-doctor block";
+            }
             else
             {
+                // No BEGIN marker at all — first-time add (append cleanly).
                 var sep = existing.Length == 0 || existing.EndsWith("\n", StringComparison.Ordinal) ? string.Empty : "\n";
                 finalContent = existing + $"{sep}\n{block}\n";
                 verb = "added managed maf-doctor block";

--- a/src/maf-autopilot/NewCommand.cs
+++ b/src/maf-autopilot/NewCommand.cs
@@ -59,19 +59,26 @@ internal static class NewCommand
         var instructions = ExtractFlag(args, "--instructions");
         var ns = NewAgentTool.DetectNamespace(path, fallback: "MyApp.Agents");
         var files = AgentScaffolder.ScaffoldAgent(name, ns, instructions);
-        WriteFiles(path, files);
-        PrintNextStepsForAgent();
+        var created = WriteFiles(path, files);
+        if (created < 0) return 3; // WM-06: whole scaffold refused — do NOT print "Next steps".
+        if (created > 0) PrintNextStepsForAgent();
+        else Console.Error.WriteLine("  (all target files already existed — nothing scaffolded)");
         return 0;
     }
 
     private static int GenerateExecutor(string path, string name, string[] args)
     {
-        var inputType = ExtractFlag(args, "--input") ?? "string";
-        var outputType = ExtractFlag(args, "--output") ?? "string";
+        // WM-05: the help advertises `new executor <Name> [In] [Out]` positionals —
+        // honor them as a fallback to the --input/--output flags (flags win when both given).
+        var positional = PositionalsAfter(args, startIndex: 3, "--path", "--input", "--output", "--instructions");
+        var inputType = ExtractFlag(args, "--input") ?? positional.ElementAtOrDefault(0) ?? "string";
+        var outputType = ExtractFlag(args, "--output") ?? positional.ElementAtOrDefault(1) ?? "string";
         var ns = NewAgentTool.DetectNamespace(path, fallback: "MyApp.Workflows");
         var files = AgentScaffolder.ScaffoldExecutor(name, ns, inputType, outputType);
-        WriteFiles(path, files);
-        PrintNextStepsForExecutor();
+        var created = WriteFiles(path, files);
+        if (created < 0) return 3; // WM-06
+        if (created > 0) PrintNextStepsForExecutor();
+        else Console.Error.WriteLine("  (all target files already existed — nothing scaffolded)");
         return 0;
     }
 
@@ -105,7 +112,14 @@ internal static class NewCommand
         Console.WriteLine("  3. Optional: run `maf-doctor doctor .` to confirm fan-out-safe.");
     }
 
-    private static void WriteFiles(string baseDir, IReadOnlyList<AgentScaffolder.ScaffoldedFile> files)
+    /// <summary>
+    /// Writes the scaffold. Returns the number of files actually created, or
+    /// <c>-1</c> if the WHOLE scaffold was refused by the pre-flight containment
+    /// check. WM-06: the caller uses this to avoid printing "Next steps" (and to
+    /// exit non-zero) when nothing was scaffolded. Refusal/skip warnings go to
+    /// stderr so stdout carries only the created-file list.
+    /// </summary>
+    private static int WriteFiles(string baseDir, IReadOnlyList<AgentScaffolder.ScaffoldedFile> files)
     {
         // F-03 — this CLI path bypasses NewAgentTool entirely, so it needs its own
         // containment + symlink guard (SafeWorkspaceWriter.TryCreateNew rejects a
@@ -128,34 +142,60 @@ internal static class NewCommand
             }
             catch (ArgumentException ex)
             {
-                Console.WriteLine($"  ⚠ {file.RelativePath} — refused: {ex.Message}");
-                Console.WriteLine("  No files were written — refusing the whole scaffold rather than leaving a partially-generated result.");
-                return;
+                Console.Error.WriteLine($"  ⚠ {file.RelativePath} — refused: {ex.Message}");
+                Console.Error.WriteLine("  No files were written — refusing the whole scaffold rather than leaving a partially-generated result.");
+                return -1;
             }
         }
 
+        var created = 0;
         foreach (var file in files)
         {
             var absolute = Path.Combine(root, file.RelativePath);
-            bool created;
+            bool ok;
             try
             {
-                created = SafeWorkspaceWriter.TryCreateNew(root, absolute, file.Content);
+                ok = SafeWorkspaceWriter.TryCreateNew(root, absolute, file.Content);
             }
             catch (ArgumentException ex)
             {
-                Console.WriteLine($"  ⚠ {file.RelativePath} — refused: {ex.Message}");
+                Console.Error.WriteLine($"  ⚠ {file.RelativePath} — refused: {ex.Message}");
                 continue;
             }
 
-            if (!created)
+            if (!ok)
             {
-                Console.WriteLine($"  ⚠ {file.RelativePath} exists — skipped");
+                Console.Error.WriteLine($"  ⚠ {file.RelativePath} exists — skipped");
                 continue;
             }
             var lineCount = file.Content.Split('\n').Length;
             Console.WriteLine($"  ✓ {file.RelativePath} ({lineCount} lines)");
+            created++;
         }
+        return created;
+    }
+
+    /// <summary>
+    /// Collects the non-flag positional tokens at or after <paramref name="startIndex"/>,
+    /// skipping any value-taking flag together with its consumed value. Used by WM-05 to
+    /// read the advertised `new executor &lt;Name&gt; [In] [Out]` positionals.
+    /// </summary>
+    internal static List<string> PositionalsAfter(string[] args, int startIndex, params string[] valueFlags)
+    {
+        var result = new List<string>();
+        var valueFlagSet = new HashSet<string>(valueFlags, StringComparer.OrdinalIgnoreCase);
+        for (var i = startIndex; i < args.Length; i++)
+        {
+            var a = args[i];
+            if (a.StartsWith("--", StringComparison.Ordinal))
+            {
+                if (valueFlagSet.Contains(a) && i + 1 < args.Length && !args[i + 1].StartsWith("--", StringComparison.Ordinal))
+                    i++; // skip the flag's value too
+                continue;
+            }
+            result.Add(a);
+        }
+        return result;
     }
 
     private static int UnknownKind(string kind)
@@ -168,10 +208,12 @@ internal static class NewCommand
     private static string Usage() => """
         Usage:
           maf-doctor new agent <Name> [--path <dir>] [--instructions "<prompt>"]
-          maf-doctor new executor <Name> [--path <dir>] [--input <type>] [--output <type>]
+          maf-doctor new executor <Name> [In] [Out] [--path <dir>] [--input <type>] [--output <type>]
+            (In/Out may be given positionally OR via --input/--output; flags win when both are present.)
 
         Examples:
           maf-doctor new agent ChatBot
+          maf-doctor new executor FraudReviewer FraudCheck FraudReport
           maf-doctor new executor FraudReviewer --input FraudCheck --output FraudReport
         """;
 

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -28,7 +28,9 @@ System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globaliz
 // MCP stdio mode (no args) is left untouched — the MCP SDK owns its stream encoding.
 if (args.Length > 0)
 {
-    try { Console.OutputEncoding = System.Text.Encoding.UTF8; }
+    // UTF8Encoding(false): NO BOM — `Encoding.UTF8` emits a BOM that some Windows
+    // consoles prepend to redirected stdout, which would corrupt `--json` output.
+    try { Console.OutputEncoding = new System.Text.UTF8Encoding(encoderShouldEmitUTF8Identifier: false); }
     catch (IOException) { /* output redirected / no console — ignore */ }
     catch (System.Security.SecurityException) { /* restricted host — ignore */ }
 }

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -17,6 +17,22 @@ using ModelContextProtocol.Server;
 // --version / --help — short-circuit before anything else (and before the
 // no-subcommand fall-through to MCP-server mode, which would otherwise hang
 // waiting on stdio when a user runs `maf-doctor --version`).
+// WM-26: pin invariant culture for BOTH CLI and MCP modes (and every tool/thread,
+// including the update-notice Task.Run) so dates use the Gregorian calendar and
+// numbers use '.'-decimals regardless of the host locale — matching the docs/examples.
+System.Globalization.CultureInfo.DefaultThreadCurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+System.Globalization.CultureInfo.DefaultThreadCurrentUICulture = System.Globalization.CultureInfo.InvariantCulture;
+
+// REP-06: emoji + typographic punctuation mojibake to '?' on cmd / Windows PowerShell
+// 5.1 and in redirected files unless the console is UTF-8. CLI mode only (args present);
+// MCP stdio mode (no args) is left untouched — the MCP SDK owns its stream encoding.
+if (args.Length > 0)
+{
+    try { Console.OutputEncoding = System.Text.Encoding.UTF8; }
+    catch (IOException) { /* output redirected / no console — ignore */ }
+    catch (System.Security.SecurityException) { /* restricted host — ignore */ }
+}
+
 if (args.Length > 0 && (args[0] is "--version" or "-v" or "version"))
 {
     var raw = Assembly.GetExecutingAssembly()
@@ -42,11 +58,12 @@ if (args.Length > 0 && (args[0] is "--help" or "-h" or "help"))
         Commands:
           init [--with-cursor]              Wire the MCP server + steering into the current repo
                                             (.vscode/mcp.json, .mcp.json, instructions, agents).
-          doctor [path] [--exclude <s>] [--all|--full] [--json] [--plan]
+          doctor [path] [--exclude <s>] [--all|--full] [--json] [--plan] [--fail-on A|B|C|F]
                                             A/B/C/F health report. --all = every finding (grouped),
                                             not just the top 3; --json = machine-readable findings;
                                             --plan = ordered, checkboxed remediation plan;
-                                            --plan --json = structured remediation manifest (for an automated fix loop).
+                                            --plan --json = structured remediation manifest (for an automated fix loop);
+                                            --fail-on = exit 3 if the grade is at/below the given letter (CI gate).
           autofix-all [path] [--apply] [--json]
                                             Deterministic Roslyn fixes. Preview only by default
                                             (no writes); --apply = actually write the changes;
@@ -61,6 +78,9 @@ if (args.Length > 0 && (args[0] is "--help" or "-h" or "help"))
           registry-extract                  Extract registry entries (CI helper).
           --version, -v                     Print the installed version.
           --help, -h                        Show this help.
+
+        Exit codes: 0 success · 1 invalid path / failed run · 2 usage error (bad flag or value)
+                    · 3 doctor --fail-on gate not met (grade too low or scan incomplete).
 
         Docs: https://github.com/joslat/maf-doctor
         """);
@@ -93,6 +113,15 @@ if (args.Length >= 1 && args[0] == "new")
 static string ResolveCliPath(string? parsedPath)
     => Path.GetFullPath(parsedPath ?? Directory.GetCurrentDirectory());
 
+// REP-09: `doctor --fail-on <grade>` — fail (exit 3) when the graded result is at or
+// below the threshold, or when the scan was incomplete. Grade ranking A(best) → F(worst).
+static bool GradeFailsGate(char grade, bool scanIncomplete, string failOn)
+{
+    if (scanIncomplete) return true; // a partial scan cannot be trusted to pass a gate
+    static int Rank(char g) => char.ToUpperInvariant(g) switch { 'A' => 0, 'B' => 1, 'C' => 2, _ => 3 };
+    return Rank(grade) >= Rank(failOn[0]);
+}
+
 if (args.Length >= 1 && args[0] == "doctor")
 {
     // Usage: maf-doctor doctor [path] [--exclude <substr>]... [--all|--full] [--json]
@@ -100,17 +129,32 @@ if (args.Length >= 1 && args[0] == "doctor")
     // process spawn). `--exclude` skips files by repo-relative substring (drift
     // detector scopes to product code); `--all`/`--full` lists every finding
     // (grouped); `--json` emits machine-readable output.
-    var (parsedPath, format, excludes, full) = MafDoctor.Commands.DoctorCli.Parse(args);
+    var (parsedPath, format, excludes, full, failOn, parseError) = MafDoctor.Commands.DoctorCli.Parse(args);
+    if (parseError is { } dpe)
+    {
+        // WM-04 / REP-05: unknown flag, extra positional, or a bad --exclude/--fail-on value.
+        Console.Error.WriteLine($"doctor: {dpe}");
+        Console.Error.WriteLine("Run 'maf-doctor --help' for usage.");
+        Environment.Exit(2);
+        return;
+    }
     var path = ResolveCliPath(parsedPath);
-    var report = new MafDoctor.Tools.DoctorTool().Run(path, format, excludes, full);
-    Console.WriteLine(report);
-    // Round-4 review fixup — confirmed via real execution: this unconditionally
-    // exited 0 even when `report` was DoctorTool's own "Error: ..." text (e.g.
-    // a nonexistent path), so a CI/script exit-code check couldn't tell success
-    // from failure. DoctorTool.Run's sole failure source is PathGuard.ValidateRepoPath
-    // (checked internally); re-checking it here doesn't change what's printed,
-    // only which exit code is chosen.
-    Environment.Exit(PathGuard.ValidateRepoPath(path) is null ? 0 : 1);
+    var report = new MafDoctor.Tools.DoctorTool().Run(path, format, excludes, full, out var summary);
+    // `summary` is null ONLY when PathGuard rejected the path (no scan ran).
+    var pathValid = summary is not null;
+    if (pathValid || format is "json" or "plan-json")
+        Console.WriteLine(report);        // success, or JSON error → stdout (machine channel)
+    else
+        Console.Error.WriteLine(report);  // REP-08: human-format error → stderr
+    // REP-09: opt-in CI gate — exit 3 when the grade is at-or-below the threshold, or
+    // when the scan was incomplete (a partial scan must not silently pass a gate).
+    if (pathValid && failOn is not null && GradeFailsGate(summary!.Grade, summary.ScanIncomplete, failOn))
+    {
+        Console.Error.WriteLine($"doctor: grade {summary.Grade}{(summary.ScanIncomplete ? " (scan incomplete)" : "")} does not pass --fail-on {failOn}");
+        Environment.Exit(3);
+        return;
+    }
+    Environment.Exit(pathValid ? 0 : 1);
     return;
 }
 if (args.Length >= 1 && args[0] == "badge")
@@ -153,12 +197,11 @@ if (args.Length >= 1 && args[0] == "autofix-all")
     var report = tool.RunAll(path, specificFile: null, dryRun: dryRun, out var error);
     if (report is null)
     {
-        // On the error path RunAll returned null fast (bad path/specificFile);
-        // re-running MafAutoFixAll here just re-fails the same way and yields the
-        // structured { "error": ... } JSON — cheap, and only on this branch.
-        Console.WriteLine(json
-            ? tool.MafAutoFixAll(path, dryRun: dryRun)
-            : $"❌ {error}");
+        // REP-08: JSON error → stdout (parsers read the machine channel); human error
+        // → stderr. On the error path RunAll returned null fast (bad path/specificFile);
+        // re-running MafAutoFixAll for --json re-fails the same way, cheaply.
+        if (json) Console.WriteLine(tool.MafAutoFixAll(path, dryRun: dryRun));
+        else Console.Error.WriteLine($"❌ {error}");
         Environment.Exit(1);
         return;
     }
@@ -189,10 +232,13 @@ if (args.Length >= 1 && args[0] == "migrate-scan")
         return;
     }
     var fmt = json ? "json" : "markdown";
-    Console.WriteLine(new MafDoctor.Tools.SemanticKernelDetectorTool().MafDetectSourceFramework(path, fmt));
-    // Round-4 review fixup — same exit-code gap as `doctor`/`badge` above.
-    // MafDetectSourceFramework's sole failure source is the same PathGuard check.
-    Environment.Exit(PathGuard.ValidateRepoPath(path) is null ? 0 : 1);
+    var mReport = new MafDoctor.Tools.SemanticKernelDetectorTool().MafDetectSourceFramework(path, fmt);
+    var mValid = PathGuard.ValidateRepoPath(path) is null;
+    // REP-08: markdown (human) errors → stderr, matching doctor/autofix-all; the JSON
+    // shape stays on stdout for parsers. (Its sole failure source is the same PathGuard check.)
+    if (mValid || fmt == "json") Console.WriteLine(mReport);
+    else Console.Error.WriteLine(mReport);
+    Environment.Exit(mValid ? 0 : 1);
     return;
 }
 if (args.Length >= 1 && args[0] == "verify-registry")

--- a/src/maf-autopilot/RegistryExtractCommand.cs
+++ b/src/maf-autopilot/RegistryExtractCommand.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using MafDoctor.Data;
@@ -45,13 +46,25 @@ internal static class RegistryExtractCommand
         }
 
         var (exitCode, output) = ProcessRunner.RunDotnetInspectDiff(packageId, oldVersion, newVersion);
-        if (exitCode != 0)
-        {
-            Console.Error.WriteLine($"⚠️ dotnet-inspect exited with code {exitCode}. Output may be partial.");
-        }
 
         var parsed = DiffPackageTool.ParseDiffOutput(output);
         var entries = ExtractDraftEntries(parsed, packageId, newVersion);
+
+        // WM-09: a non-zero exit WITH no parseable entries is a TOOL FAILURE, not a
+        // clean diff — surface it distinctly (stderr + a poisoned stdout marker + exit 3)
+        // so neither the release-watcher nor a human ever mistakes a dotnet-inspect crash
+        // for "no breaking changes".
+        if (exitCode != 0 && entries.Count == 0)
+        {
+            Console.Error.WriteLine($"❌ dotnet-inspect failed (exit {exitCode}) and produced no parseable diff — extraction FAILED, not a clean diff.");
+            Console.WriteLine("# EXTRACTION FAILED — dotnet-inspect error; do not treat as a clean diff.");
+            return 3;
+        }
+        if (exitCode != 0)
+        {
+            // Partial output: some entries parsed despite the non-zero exit — proceed but warn.
+            Console.Error.WriteLine($"⚠️ dotnet-inspect exited with code {exitCode}; output may be partial.");
+        }
 
         if (entries.Count == 0)
         {
@@ -59,7 +72,9 @@ internal static class RegistryExtractCommand
             return 0;
         }
 
-        Console.WriteLine($"# Draft registry entries — auto-generated 2026-05-12 from {packageId} {oldVersion} → {newVersion}");
+        // WM-25: stamp the ACTUAL generation date (invariant so the Gregorian date
+        // survives a non-default-calendar host), not a hard-coded literal.
+        Console.WriteLine($"# Draft registry entries — auto-generated {DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)} from {packageId} {oldVersion} → {newVersion}");
         Console.WriteLine($"# {entries.Count} candidate(s). Review each before merging — TODO fields require human input.");
         Console.WriteLine();
         foreach (var entry in entries)

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -51,7 +51,7 @@ public sealed class DoctorTool
         string format = "markdown",
         [Description("When true, list EVERY finding (grouped by rule, ordered by impact) instead of only the top 3 fixes. Use for full triage / CI.")]
         bool full = false)
-        => RunCore(repoPath, format, excludes: null, full: full);
+        => RunCore(repoPath, format, excludes: null, full: full, out _);
 
     /// <summary>
     /// CLI entry point. Identical to <see cref="MafDoctor"/> but accepts
@@ -62,10 +62,21 @@ public sealed class DoctorTool
     /// preserves the stable MafDoctor schema for clients.
     /// </summary>
     internal string Run(string repoPath, string format, IReadOnlyList<string>? excludes, bool full = false)
-        => RunCore(repoPath, format, excludes, full);
+        => RunCore(repoPath, format, excludes, full, out _);
 
-    private string RunCore(string repoPath, string format, IReadOnlyList<string>? excludes, bool full = false)
+    /// <summary>
+    /// Run and also expose the graded <see cref="DoctorSummary"/> (grade + scan
+    /// completeness) so a CLI gate (<c>doctor --fail-on</c>, REP-09) can act on the
+    /// real grade without re-scanning or scraping the headline. <paramref name="summary"/>
+    /// is <see langword="null"/> when the path was invalid (no scan ran).
+    /// </summary>
+    internal string Run(string repoPath, string format, IReadOnlyList<string>? excludes, bool full, out DoctorSummary? summary)
+        => RunCore(repoPath, format, excludes, full, out summary);
+
+    private string RunCore(string repoPath, string format, IReadOnlyList<string>? excludes, bool full, out DoctorSummary? summary)
     {
+        summary = null;
+
         // Render a validation failure in the REQUESTED format — a machine consumer
         // asking for --json must get JSON back, not a plain-text string that
         // breaks their parser.
@@ -81,11 +92,12 @@ public sealed class DoctorTool
             return err;
         }
 
-        var summary = AnalyzeRepo(repoPath, excludes);
+        var s = AnalyzeRepo(repoPath, excludes);
+        summary = s;
 
         if (format.Equals("json", StringComparison.OrdinalIgnoreCase))
         {
-            var result = BuildJsonResult(repoPath, summary, full);
+            var result = BuildJsonResult(repoPath, s, full);
             return JsonSerializer.Serialize(result, DoctorJsonContext.Default.DoctorJsonResult);
         }
 
@@ -94,12 +106,12 @@ public sealed class DoctorTool
         // iterate it with per-finding confidence instead of parsing markdown.
         if (format.Equals("plan-json", StringComparison.OrdinalIgnoreCase))
             return JsonSerializer.Serialize(
-                BuildPlanJson(repoPath, summary), DoctorJsonContext.Default.DoctorPlanJson);
+                BuildPlanJson(repoPath, s), DoctorJsonContext.Default.DoctorPlanJson);
 
         if (format.Equals("plan", StringComparison.OrdinalIgnoreCase))
-            return FormatPlan(repoPath, summary); // always covers every finding
+            return FormatPlan(repoPath, s); // always covers every finding
 
-        return FormatReport(repoPath, summary, full);
+        return FormatReport(repoPath, s, full);
     }
 
     // -------------------------------------------------------------------------

--- a/src/maf-autopilot/Tools/StatusTool.cs
+++ b/src/maf-autopilot/Tools/StatusTool.cs
@@ -19,18 +19,25 @@ public sealed class StatusTool
         they only need to rerun `maf-doctor init` for this workspace.
 
         Input:
-          - repoPath: repository/workspace root to inspect. Defaults to the MCP
-            server current directory.
+          - repoPath: repository/workspace root to inspect. Defaults to the
+            configured workspace root (falling back to the server current directory).
 
         Returns markdown with exact update/init commands when action is needed.
         """)]
     public async Task<string> MafDoctorStatus(
-        [Description("Repository/workspace root to inspect. Defaults to the MCP server current directory.")]
+        [Description("Repository/workspace root to inspect. Defaults to the configured workspace root (falling back to the server current directory).")]
         string? repoPath = null)
     {
-        var rawPath = string.IsNullOrWhiteSpace(repoPath)
-            ? Directory.GetCurrentDirectory()
-            : repoPath;
+        // WM-08: the documented default was the server cwd — but in MCP mode the host
+        // spawns with cwd = the user's HOME, which the workspace policy rejects, so the
+        // no-arg call always errored. Prefer cwd ONLY when it passes policy; otherwise
+        // fall back to the first configured workspace root that exists on disk.
+        var cwd = Directory.GetCurrentDirectory();
+        var rawPath = !string.IsNullOrWhiteSpace(repoPath)
+            ? repoPath
+            : WorkspacePolicy.Validate(cwd) is null
+                ? cwd
+                : WorkspacePolicy.ConfiguredRoots.FirstOrDefault(Directory.Exists) ?? cwd;
 
         if (PathGuard.ValidateRepoPath(rawPath) is { } error)
             return error;

--- a/src/maf-autopilot/UpdateAdvisor.cs
+++ b/src/maf-autopilot/UpdateAdvisor.cs
@@ -22,8 +22,18 @@ internal sealed class UpdateNoticeHostedService(ILogger<UpdateNoticeHostedServic
                 timeout: TimeSpan.FromSeconds(3),
                 ignoreCache: false,
                 cancellationToken: cancellationToken);
-            var workspaceRoot = InitCommand.FindInitializedWorkspaceRoot(Directory.GetCurrentDirectory());
-            var init = InitCommand.GetWorkspaceInitStatus(workspaceRoot);
+            // WM-07: resolve the REAL workspace, not the server's cwd — MCP hosts spawn
+            // stdio servers with cwd = the user's home directory, so deriving staleness
+            // from cwd produced a false "init is stale" nag on every startup. Prefer a
+            // configured workspace root that exists; else walk up from cwd. If the
+            // resolved directory is not actually an initialized workspace (no .mcp.json /
+            // .vscode/mcp.json), skip the init-staleness half of the notice entirely.
+            var cwd = Directory.GetCurrentDirectory();
+            var root = WorkspacePolicy.ConfiguredRoots.FirstOrDefault(Directory.Exists)
+                       ?? InitCommand.FindInitializedWorkspaceRoot(cwd);
+            var initialized = File.Exists(Path.Combine(root, ".mcp.json"))
+                              || File.Exists(Path.Combine(root, ".vscode", "mcp.json"));
+            var init = initialized ? InitCommand.GetWorkspaceInitStatus(root) : (InitCommand.InitStatus?)null;
             var notice = UpdateAdvisor.BuildStartupNotice(update, init);
             if (!string.IsNullOrWhiteSpace(notice))
                 logger.LogWarning("{Notice}", notice);
@@ -152,7 +162,10 @@ internal static class UpdateAdvisor
         return sb.ToString();
     }
 
-    public static string? BuildStartupNotice(UpdateStatus update, InitCommand.InitStatus init)
+    // WM-07: `init` is nullable — a null value means "the workspace couldn't be
+    // resolved / isn't initialized", so the init-staleness half is skipped entirely
+    // (the update-available half still fires).
+    public static string? BuildStartupNotice(UpdateStatus update, InitCommand.InitStatus? init)
     {
         var lines = new List<string>();
         if (update.State == UpdateState.UpdateAvailable && update.LatestVersion is not null)
@@ -163,7 +176,7 @@ internal static class UpdateAdvisor
             lines.Add("Reload the editor or MCP host so it starts the new binary.");
         }
 
-        if (update.State != UpdateState.UpdateAvailable && init.NeedsRefresh)
+        if (update.State != UpdateState.UpdateAvailable && init is { NeedsRefresh: true })
         {
             lines.Add("maf-doctor is running, but this workspace's MCP/steering init is stale or incomplete.");
             lines.Add("Refresh it with: maf-doctor init");


### PR DESCRIPTION
Phase 2 of the Fable 5 remediation plan (`private/fable5review/PLAN.md`) — CLI & MCP server lifecycle, all 15 findings.

## Findings

**Entry conventions:** WM-26 (invariant culture, CLI+MCP), REP-06 (UTF-8 console in CLI mode, no BOM).

**Args & exit codes:** WM-04 (`doctor` rejects unknown flags/extra positionals → exit 2), REP-05 (`--exclude` requires a value, no longer swallows a following flag), WM-05 (`new executor <Name> [In] [Out]` positionals honored, flags win), WM-06 (`new` scaffold exits 3 + no "Next steps" on full refusal), WM-09 (`registry-extract` distinguishes a dotnet-inspect failure → exit 3 from a clean diff), WM-10 (`init` fails gracefully on I/O error, not a raw stack trace), REP-09 (exit codes documented; new opt-in `doctor --fail-on A|B|C|F` CI gate → exit 3, keyed on the real graded summary threaded out of `DoctorTool.Run`).

**Stream discipline:** REP-08 (human-format errors for doctor/autofix-all/migrate-scan → stderr; JSON stays on stdout for parsers).

**Workspace resolution:** WM-01 (High — `init` self-heals a stale `MAF_DOCTOR_WORKSPACE_ROOTS` after a repo move by appending the current dir, append-only), WM-07 (startup notice resolves the real workspace, not server cwd — no false "init is stale" nag), WM-08 (`MafDoctorStatus` no-arg default uses a policy-valid path).

**Misc:** WM-25 (registry-extract stamps the actual date), WM-27 (AGENTS.md upsert repairs a BEGIN-without-END marker instead of duplicating).

## Review

Self-audited the diff (single agent). Found + fixed 2 real issues: REP-06 was using BOM-emitting `Encoding.UTF8` (BOM could corrupt redirected `--json`); WM-01's stored-value parse could throw on a malformed non-string config value. Both fixed in `e3e955b`.

## Tests

DoctorCli strict-parse unit tests + CLI-dispatch integration tests (exit 2 / exit 3 / stderr routing) + NewCommand executor-positionals. Full suite green on **net8.0 and net9.0 (1152/1152 each)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)