### PR TITLE
fix(reporting): Phase 4b — SARIF fidelity + data-correctness

### DIFF
--- a/src/maf-autopilot.Tests/Phase4bSarifTests.cs
+++ b/src/maf-autopilot.Tests/Phase4bSarifTests.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using MafDoctor;
+using MafDoctor.Tools;
+using Xunit;
+
+namespace MafDoctor.Tests;
+
+/// <summary>
+/// Regression tests for the Phase 4b (SARIF fidelity + data-correctness) findings:
+/// REP-20 (real SARIF version), REP-11 (help Why/Fix), REP-12 (partialFingerprints),
+/// REP-01 (version ladder from the maintained Matrix + drift lock), REP-02 (dotnet-inspect
+/// failure surfaced), REP-03 (FanOut relative paths).
+/// </summary>
+public sealed class Phase4bSarifTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-phase4b-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static JsonDocument AntiPatternSarif()
+    {
+        var findings = AntiPatternScannerTool.ScanFile(
+            "public class Prod { void M() { var c = new DefaultAzureCredential(); } }", "Prod.cs");
+        return JsonDocument.Parse(SarifExportTool.EmitAntiPatternsSarif(findings));
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-20 — SARIF driver.version tracks the real installed version
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Sarif_DriverVersion_IsRealToolVersion_NotFrozenAlpha()
+    {
+        using var doc = AntiPatternSarif();
+        var version = doc.RootElement.GetProperty("runs")[0]
+            .GetProperty("tool").GetProperty("driver").GetProperty("version").GetString();
+
+        Assert.Equal(ToolVersionInfo.Current, version);
+        Assert.NotEqual("1.3.0-alpha-3", version);
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-11 — SARIF rules carry the CLI's Why/Fix guidance in help.markdown
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Sarif_Rules_CarryWhyAndFixHelp()
+    {
+        using var doc = AntiPatternSarif();
+        var rule = doc.RootElement.GetProperty("runs")[0].GetProperty("tool")
+            .GetProperty("driver").GetProperty("rules").EnumerateArray()
+            .First(r => r.GetProperty("id").GetString() == "MAF-AP-SEC-001");
+
+        var helpMd = rule.GetProperty("help").GetProperty("markdown").GetString();
+        Assert.Contains("**Why:**", helpMd);
+        Assert.Contains("**Fix:**", helpMd);
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-12 — SARIF results carry a stable partialFingerprint
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Sarif_Results_CarryStablePartialFingerprint()
+    {
+        using var doc = AntiPatternSarif();
+        var result = doc.RootElement.GetProperty("runs")[0].GetProperty("results")[0];
+        var fp = result.GetProperty("partialFingerprints").GetProperty("mafDoctorFingerprint/v1").GetString();
+        Assert.False(string.IsNullOrEmpty(fp));
+
+        // Deterministic: the same finding hashes to the same fingerprint every run.
+        using var doc2 = AntiPatternSarif();
+        var fp2 = doc2.RootElement.GetProperty("runs")[0].GetProperty("results")[0]
+            .GetProperty("partialFingerprints").GetProperty("mafDoctorFingerprint/v1").GetString();
+        Assert.Equal(fp, fp2);
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-01 — the version ladder is derived from the maintained Matrix (drift-locked)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void KnownVersions_EqualsCompatibilityMatrixKeys()
+    {
+        Assert.True(new HashSet<string>(RegressionPlanTool.KnownVersions)
+            .SetEquals(CompatibilityTool.Matrix.Keys));
+        // And it now reaches the current release, not the frozen 1.5.0 ceiling.
+        Assert.Contains("1.13.0", RegressionPlanTool.KnownVersions);
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-02 — a dotnet-inspect failure is surfaced, never parsed as "0 changes"
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void DescribeInspectFailure_NotInstalled_IsVerbatim_OtherOutput_IsFenced()
+    {
+        var notInstalled = "dotnet tool install --global dotnet-inspect --version 0.7.8 to enable this.";
+        var failVerbatim = DiffPackageTool.DescribeInspectFailure(1, notInstalled);
+        Assert.Contains("Error: dotnet-inspect failed", failVerbatim);
+        Assert.Contains(notInstalled, failVerbatim);
+        Assert.DoesNotContain("BEGIN_USER_DATA", failVerbatim); // not fenced — it's tool text
+
+        var realStderr = "Unhandled exception: System.Exception at Package.Load()";
+        var fenced = DiffPackageTool.DescribeInspectFailure(1, realStderr);
+        Assert.Contains("BEGIN_USER_DATA", fenced); // attacker-influenceable stdout is fenced
+
+        var unrecognized = DiffPackageTool.DescribeInspectFailure(0, "weird output", unrecognized: true);
+        Assert.Contains("unrecognized", unrecognized);
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-03 — MafValidateFanOut emits repo-relative paths, not absolute host paths
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void ValidateFanOut_EmitsRelativePaths_NotAbsoluteHostPaths()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "Wf.cs"), """
+                using System.Threading.Tasks;
+                public partial class Inv : Executor
+                {
+                    [MessageHandler]
+                    public ValueTask AlphaAsync(string m) => default;
+                }
+                """);
+            var md = new FanOutValidatorTool().MafValidateFanOut(dir);
+            Assert.Contains("Wf.cs", md);
+            Assert.DoesNotContain(dir, md); // the absolute host path must not leak
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/src/maf-autopilot/InitCommand.cs
+++ b/src/maf-autopilot/InitCommand.cs
@@ -73,18 +73,8 @@ internal static class InitCommand
             $"Check that the directory is writable.");
     }
 
-    internal static string CurrentVersion
-    {
-        get
-        {
-            var raw = Assembly.GetExecutingAssembly()
-                .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-                ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
-                ?? "unknown";
-            var plus = raw.IndexOf('+');
-            return plus >= 0 ? raw[..plus] : raw;
-        }
-    }
+    // REP-20: single source of truth for the version (see ToolVersionInfo).
+    internal static string CurrentVersion => ToolVersionInfo.Current;
 
     public static async Task<int> RunAsync(string[]? args = null)
     {

--- a/src/maf-autopilot/Program.cs
+++ b/src/maf-autopilot/Program.cs
@@ -37,13 +37,8 @@ if (args.Length > 0)
 
 if (args.Length > 0 && (args[0] is "--version" or "-v" or "version"))
 {
-    var raw = Assembly.GetExecutingAssembly()
-        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-        ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
-        ?? "unknown";
-    // InformationalVersion can carry build metadata (e.g. "1.2.7+abc123") — trim it.
-    var plus = raw.IndexOf('+');
-    Console.WriteLine($"maf-doctor {(plus >= 0 ? raw[..plus] : raw)}");
+    // REP-20: single source of truth for the version (build metadata already trimmed).
+    Console.WriteLine($"maf-doctor {MafDoctor.ToolVersionInfo.Current}");
     Environment.Exit(0);
     return;
 }
@@ -302,15 +297,11 @@ builder.Services
         // Advertise the server's identity + icon (MCP 2025-11 `icons` on the
         // Implementation). Clients that support it render the icon; older clients
         // ignore it. Source points at the asset on `main` so it tracks the brand.
-        var v = Assembly.GetExecutingAssembly()
-            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "1.0.0";
-        var plus = v.IndexOf('+');
-        if (plus >= 0) v = v[..plus];
         options.ServerInfo = new Implementation
         {
             Name = "maf-doctor",
             Title = "MAF Doctor",
-            Version = v,
+            Version = MafDoctor.ToolVersionInfo.Current, // REP-20: single source of truth
             WebsiteUrl = "https://github.com/joslat/maf-doctor",
             Icons =
             [

--- a/src/maf-autopilot/ToolVersionInfo.cs
+++ b/src/maf-autopilot/ToolVersionInfo.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+
+namespace MafDoctor;
+
+/// <summary>
+/// REP-20: the single source of truth for the installed tool version — computed once
+/// from the assembly's <see cref="AssemblyInformationalVersionAttribute"/> (build
+/// metadata after '+' trimmed). Shared by <c>--version</c>, the MCP
+/// <c>ServerInfo.Version</c>, <c>InitCommand.CurrentVersion</c>, and the SARIF
+/// <c>tool.driver.version</c>, so every surface reports the same real version on every
+/// release automatically instead of a per-surface hard-coded string (the SARIF version
+/// was previously frozen at the retired "1.3.0-alpha-3").
+/// </summary>
+internal static class ToolVersionInfo
+{
+    /// <summary>The tool version, e.g. "1.13.0". "0.0.0" only when no version attribute is present.</summary>
+    public static string Current { get; } = Compute();
+
+    private static string Compute()
+    {
+        var raw = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+            ?? "0.0.0";
+        var plus = raw.IndexOf('+');
+        return plus >= 0 ? raw[..plus] : raw;
+    }
+}

--- a/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
+++ b/src/maf-autopilot/Tools/AntiPatternScannerTool.cs
@@ -880,7 +880,11 @@ public sealed class AntiPatternScannerTool
             // The Match column echoes the matched source — redact it if it looks
             // like a secret (e.g. the SEC-002 key literal), and neutralize backticks
             // so the value can't break the markdown code span / table cell.
-            var match = LooksLikeSecret(f.Match) ? "(redacted)" : f.Match.Replace('`', '\'').Replace('|', '\\');
+            // SEC-21: flatten newlines FIRST — a multi-line match (e.g. SEC-003's
+            // `assign.ToString()`) would otherwise break the table row and inject the
+            // remaining source lines as raw markdown. Secret check runs on the original.
+            var flat = f.Match.Replace("\r", string.Empty).Replace('\n', ' ');
+            var match = LooksLikeSecret(f.Match) ? "(redacted)" : flat.Replace('`', '\'').Replace('|', '\\');
             sb.AppendLine($"| `{f.RuleId}` — {f.RuleName} | `{f.File.Replace('`', '\'')}` | {f.Line} | `{match}` |");
         }
         sb.AppendLine();

--- a/src/maf-autopilot/Tools/DiffPackageTool.cs
+++ b/src/maf-autopilot/Tools/DiffPackageTool.cs
@@ -61,8 +61,41 @@ public sealed class DiffPackageTool
             return $"Error: oldVersion and newVersion must be valid SemVer-ish strings; got '{oldVersion}', '{newVersion}'.";
 
         var (exitCode, output) = ProcessRunner.RunDotnetInspectDiff(packageId, oldVersion, newVersion);
+
+        // REP-02: a non-zero exit (missing dotnet-inspect, timeout, or a real failure)
+        // was previously parsed as if it were diff output — yielding a misleading
+        // "0 breaking changes" clean report. Surface the failure as a visible error.
+        if (exitCode != 0)
+            return DescribeInspectFailure(exitCode, output);
+
         var parsed = ParseDiffOutput(output);
+
+        // REP-02: guard the success path too — if the parser found nothing AND the tool
+        // didn't explicitly report "no changes", the output format drifted; fail loud
+        // instead of rendering empty tables that read as a clean diff.
+        if (parsed.Breaking.Count == 0 && parsed.Additive.Count == 0 && !parsed.NoChangesDetected)
+            return DescribeInspectFailure(exitCode, output, unrecognized: true);
+
         return FormatReport(packageId, oldVersion, newVersion, exitCode, parsed, _registry);
+    }
+
+    /// <summary>
+    /// REP-02: render a dotnet-inspect failure (or unrecognized output) as a visible error
+    /// with the underlying output. A MISSING dotnet-inspect renders the tool's own install
+    /// instructions — safe to surface verbatim; any other output is real process stdout
+    /// (attacker-influenceable via package metadata), so it is data-fenced. Shared with
+    /// <see cref="PreUpgradeDryRunTool"/>.
+    /// </summary>
+    internal static string DescribeInspectFailure(int exitCode, string output, bool unrecognized = false)
+    {
+        var header = unrecognized
+            ? "Error: dotnet-inspect diff output was unrecognized (format drift or partial output) — refusing to report a possibly-incomplete diff as a clean result."
+            : $"Error: dotnet-inspect failed (exit {exitCode}).";
+        var isNotInstalled = output.Contains("dotnet tool install --global dotnet-inspect", StringComparison.OrdinalIgnoreCase);
+        var body = isNotInstalled
+            ? output
+            : LlmFencing.Fence("dotnet-inspect-output", output, maxBytes: 16 * 1024);
+        return $"{header}\n\n{body}";
     }
 
     // -------------------------------------------------------------------------

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -389,7 +389,7 @@ public sealed class DoctorTool
     };
 
     /// <summary>One-line actionable fix description per anti-pattern rule ID.</summary>
-    private static string GetAntiPatternFix(string ruleId) => ruleId switch
+    internal static string GetAntiPatternFix(string ruleId) => ruleId switch // internal: shared with SARIF help (REP-11)
     {
         "MAF-AP-SEC-001" => "Replace `DefaultAzureCredential` with `ManagedIdentityCredential` in production code.",
         "MAF-AP-SEC-002" => "Remove the hard-coded key; load it from configuration / Key Vault and rotate the leaked value.",

--- a/src/maf-autopilot/Tools/FanOutValidatorTool.cs
+++ b/src/maf-autopilot/Tools/FanOutValidatorTool.cs
@@ -61,6 +61,17 @@ public sealed class FanOutValidatorTool
         if (path.Replace('\\', '/').Split('/').Any(s => s == ".."))
             return "Error: path must not contain '..' segments (path traversal).";
 
+        // SEC-03: confine to the configured workspace. The other scanners route through
+        // PathGuard.ValidateRepoPath (directories only); FanOut also accepts a single file,
+        // so validate the CONTAINING directory (the path itself if it is a dir, else the
+        // file's parent). With no MAF_WORKSPACE_ROOTS set this is a no-op except for
+        // filesystem-root / home rejection — it only bites in a scoped MCP deployment.
+        var fullPath = Path.GetFullPath(path);
+        var isDir = Directory.Exists(fullPath);
+        var root = isDir ? fullPath : (Path.GetDirectoryName(fullPath) ?? fullPath);
+        if (WorkspacePolicy.Validate(root) is { } policyErr)
+            return policyErr;
+
         var budget = new SourceFileWalker.ScanBudget();
         var files = ResolveFiles(path, budget);
         if (files.Count == 0)
@@ -70,20 +81,33 @@ public sealed class FanOutValidatorTool
         var skippedUnreadable = 0;
         foreach (var file in files)
         {
-            string source;
+            string source, rel;
             try
             {
+                // SEC-03: bound the read to the same 10 MB per-file ceiling as the walk
+                // (the directory branch is already size-filtered; this covers the single
+                // -file branch, which ResolveFiles returns unbounded).
+                if (new FileInfo(file).Length > budget.MaxFileBytes)
+                {
+                    budget.RecordOversizedSkip();
+                    continue;
+                }
                 // WM-18: a locked/raced/unreadable file must not abort the whole scan.
                 source = File.ReadAllText(file);
+                // REP-03: emit repo-relative paths like every other surface (SARIF resolves
+                // in GitHub code-scanning; markdown tables are shorter; host layout isn't
+                // leaked). For a single-file target this yields just the file name.
+                rel = SourceFileWalker.MakeRelative(root, file);
             }
             catch (Exception ex) when (ex is IOException
                                         or UnauthorizedAccessException
-                                        or System.Security.SecurityException)
+                                        or System.Security.SecurityException
+                                        or InvalidOperationException)
             {
                 skippedUnreadable++;
                 continue;
             }
-            allFindings.AddRange(AnalyzeSource(source, file));
+            allFindings.AddRange(AnalyzeSource(source, rel));
         }
 
         return format.Equals("sarif", StringComparison.OrdinalIgnoreCase)

--- a/src/maf-autopilot/Tools/PreUpgradeDryRunTool.cs
+++ b/src/maf-autopilot/Tools/PreUpgradeDryRunTool.cs
@@ -68,7 +68,15 @@ public sealed class PreUpgradeDryRunTool
             return "Error: currentVersion and targetVersion must be valid SemVer-ish strings.";
 
         var (exitCode, output) = ProcessRunner.RunDotnetInspectDiff(packageId, currentVersion, targetVersion);
+
+        // REP-02: surface a dotnet-inspect failure (or drifted/partial output) as a visible
+        // error instead of assessing empty diff output as "nothing breaks". Shared helper.
+        if (exitCode != 0)
+            return DiffPackageTool.DescribeInspectFailure(exitCode, output);
+
         var parsed = DiffPackageTool.ParseDiffOutput(output);
+        if (parsed.Breaking.Count == 0 && parsed.Additive.Count == 0 && !parsed.NoChangesDetected)
+            return DiffPackageTool.DescribeInspectFailure(exitCode, output, unrecognized: true);
 
         var sources = LoadSources(repoPath);
         var assessment = AssessImpact(parsed, sources, _registry);

--- a/src/maf-autopilot/Tools/RegressionPlanTool.cs
+++ b/src/maf-autopilot/Tools/RegressionPlanTool.cs
@@ -26,16 +26,18 @@ namespace MafDoctor.Tools;
 public sealed class RegressionPlanTool
 {
     /// <summary>
-    /// Hard-coded version ladder. Source of truth is
-    /// `docs/compatibility-matrix.md` — when a new MAF version ships,
-    /// add it here AND to <see cref="CompatibilityTool.Matrix"/>.
-    /// (The drift-test in CompatibilityToolTests pins the matrix doc;
-    /// this list cross-references it.)
+    /// The version ladder, derived from the single maintained source
+    /// (<see cref="CompatibilityTool.Matrix"/>) instead of a second hard-coded list.
+    /// REP-01: the old frozen list stopped at 1.5.0 while MAF is at 1.13.0, so roadmaps
+    /// silently omitted every released version above 1.5.0 (including the 1.6.1 / 1.11.1
+    /// patch steps). The Matrix keys are exactly the released versions the release-watcher
+    /// keeps current; a drift test pins the two together. Sorted by real version order.
     /// </summary>
-    internal static readonly string[] KnownVersions =
-    {
-        "1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0"
-    };
+    internal static string[] KnownVersions =>
+        CompatibilityTool.Matrix.Keys.OrderBy(v => Version.Parse(v)).ToArray();
+
+    /// <summary>Per-step migration guides exist from this version on; below it, no guide file ships.</summary>
+    private static readonly Version FirstGuidedVersion = new(1, 3, 0);
 
     private readonly RegistryService _registry;
 
@@ -126,7 +128,11 @@ public sealed class RegressionPlanTool
             var ids = entriesAtStep.Count > 0
                 ? string.Join(", ", entriesAtStep.Select(e => $"`{e.Id}`"))
                 : "_(none — minor release or polish)_";
-            sb.AppendLine($"| {steps.IndexOf(step) + 1} | **{step}** | {ids} | [maf-{step}-migration-guide.md](../guides/maf-{step}-migration-guide.md) |");
+            // REP-01: guides ship only from 1.3.0 on; below that, emit no dead link.
+            var guide = Version.TryParse(step, out var sv) && sv >= FirstGuidedVersion
+                ? $"[maf-{step}-migration-guide.md](../guides/maf-{step}-migration-guide.md)"
+                : "_(no per-step guide)_";
+            sb.AppendLine($"| {steps.IndexOf(step) + 1} | **{step}** | {ids} | {guide} |");
         }
         sb.AppendLine();
 

--- a/src/maf-autopilot/Tools/SarifEmitter.cs
+++ b/src/maf-autopilot/Tools/SarifEmitter.cs
@@ -91,6 +91,14 @@ internal static class SarifEmitter
             };
             if (!string.IsNullOrWhiteSpace(r.HelpUri))
                 node["helpUri"] = r.HelpUri;
+            // REP-11: GitHub renders help.markdown in the alert detail pane (help.text
+            // is the plain-text fallback). Carries the same Why/Fix guidance the CLI prints.
+            if (!string.IsNullOrWhiteSpace(r.HelpMarkdown))
+                node["help"] = new JsonObject
+                {
+                    ["text"] = r.HelpMarkdown,
+                    ["markdown"] = r.HelpMarkdown,
+                };
             arr.Add(node);
         }
         return arr;
@@ -120,9 +128,28 @@ internal static class SarifEmitter
                         },
                     },
                 }),
+                // REP-12: a stable per-result identity so code-scanning alerts don't churn
+                // when line numbers shift. Keyed by a custom versioned name (non-GitHub SARIF
+                // consumers can dedup on it too); the hash covers ruleId + file + the trimmed
+                // match/line text, so a line MOVE keeps the fingerprint while a content edit
+                // changes it. Falls back to the line number when no text is available.
+                ["partialFingerprints"] = new JsonObject
+                {
+                    ["mafDoctorFingerprint/v1"] = Fingerprint(f),
+                },
             });
         }
         return arr;
+    }
+
+    private static string Fingerprint(SarifFinding f)
+    {
+        var tail = string.IsNullOrWhiteSpace(f.LineText)
+            ? f.Line.ToString(System.Globalization.CultureInfo.InvariantCulture)
+            : string.Join(' ', f.LineText.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+        var hash = System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes($"{f.RuleId}|{NormaliseUri(f.File)}|{tail}"));
+        return Convert.ToHexString(hash, 0, 8).ToLowerInvariant(); // 16 hex chars
     }
 
     private static string LevelFromSeverity(SarifSeverity severity) => severity switch
@@ -147,11 +174,16 @@ internal sealed record SarifFinding(
     SarifSeverity Severity,
     string Message,
     string File,
-    int Line);
+    int Line,
+    // REP-12: the offending source/match text, used to compute a drift-stable
+    // partialFingerprint. Null → the fingerprint falls back to ruleId+file+line.
+    string? LineText = null);
 
 internal sealed record SarifRule(
     string Id,
     string Name,
     SarifSeverity Severity,
     string? FullDescription = null,
-    string? HelpUri = null);
+    string? HelpUri = null,
+    // REP-11: markdown Why/Fix guidance rendered in the code-scanning alert detail pane.
+    string? HelpMarkdown = null);

--- a/src/maf-autopilot/Tools/SarifExportTool.cs
+++ b/src/maf-autopilot/Tools/SarifExportTool.cs
@@ -11,7 +11,9 @@ namespace MafDoctor.Tools;
 /// </summary>
 internal static class SarifExportTool
 {
-    private const string ToolVersion = "1.3.0-alpha-3";
+    // REP-20: SARIF provenance now tracks the real installed version (was frozen at the
+    // retired "1.3.0-alpha-3", a per-release manual-update trap). Single source: ToolVersionInfo.
+    private static string ToolVersion => ToolVersionInfo.Current;
 
     /// <summary>
     /// Builds a SARIF v2.1.0 document from a list of anti-pattern findings.
@@ -25,7 +27,10 @@ internal static class SarifExportTool
             // SARIF surface matches the markdown surface's no-secret-leak posture.
             Message: f.RuleName + " — " + (AntiPatternScannerTool.LooksLikeSecret(f.Match) ? "(redacted)" : f.Match),
             File: f.File,
-            Line: f.Line));
+            Line: f.Line,
+            // REP-12: fingerprint basis. Uses the raw match (one-way hash, never emitted)
+            // so the identity is drift-stable across line moves.
+            LineText: f.Match));
 
         return SarifEmitter.Emit(ToolVersion, sarifFindings, BuildAntiPatternRuleCatalog());
     }
@@ -76,22 +81,30 @@ internal static class SarifExportTool
         const string skillUri = "https://github.com/joslat/maf-doctor/blob/main/.github/skills/maf-anti-pattern-scanner/SKILL.md";
         foreach (var rule in AntiPatternScannerTool.AllRules)
         {
+            // REP-11: surface the same Why/Fix guidance the CLI prints. fullDescription
+            // carries the Why (was a duplicate of the name); help.markdown carries both.
+            var why = DoctorTool.GetWhy(rule.Id);
+            var whyText = string.IsNullOrEmpty(why) ? rule.Name : why;
             yield return new SarifRule(
                 Id: rule.Id,
                 Name: rule.Name,
                 Severity: MapSeverity(rule.Severity),
-                FullDescription: rule.Name,
-                HelpUri: skillUri);
+                FullDescription: whyText,
+                HelpUri: skillUri,
+                HelpMarkdown: $"**Why:** {whyText}\n\n**Fix:** {DoctorTool.GetAntiPatternFix(rule.Id)}");
         }
     }
 
     private static IEnumerable<SarifRule> BuildFanOutRuleCatalog()
     {
+        const string full = "A [MessageHandler] method that returns void, Task, or ValueTask (non-generic) produces no downstream message and silently starves the fan-in barrier.";
         yield return new SarifRule(
             Id: "MAF001",
             Name: "Fan-out handler must return Task<T> or ValueTask<T>",
             Severity: SarifSeverity.Error,
-            FullDescription: "A [MessageHandler] method that returns void, Task, or ValueTask (non-generic) produces no downstream message and silently starves the fan-in barrier.",
-            HelpUri: "https://github.com/joslat/maf-doctor/blob/main/.github/skills/maf-fan-out-validator/SKILL.md");
+            FullDescription: full,
+            HelpUri: "https://github.com/joslat/maf-doctor/blob/main/.github/skills/maf-fan-out-validator/SKILL.md",
+            // REP-11: MAF001 already had a good fullDescription but no help pane content.
+            HelpMarkdown: $"**Why:** {full}\n\n**Fix:** Return `Task<T>` / `ValueTask<T>` / `IAsyncEnumerable<T>` (the value is sent automatically), OR emit explicitly with `await context.SendMessageAsync(...)`.");
     }
 }


### PR DESCRIPTION
## Phase 4b — SARIF fidelity + data-correctness (Fable 5 remediation)

PR-4b of the Phase 4 split (depends on PR-4a #157). 8 findings — completes Phase 4.

### SARIF fidelity
- **REP-20** — `tool.driver.version` tracks the real installed version via a shared `ToolVersionInfo` (was frozen at the retired `1.3.0-alpha-3`). Consolidates the version computation duplicated across `--version`, `ServerInfo`, and `InitCommand`.
- **REP-11** — SARIF rules carry the CLI's Why/Fix guidance (`fullDescription` = Why + `help.text`/`help.markdown` pane) for the anti-pattern rules and the MAF001 fan-out rule.
- **REP-12** — each result carries a stable `partialFingerprints` (`mafDoctorFingerprint/v1` = SHA-256 of ruleId+file+trimmed match) so code-scanning alerts survive line shifts.

### Path / injection hygiene
- **REP-03** — `MafValidateFanOut` emits repo-relative paths (SARIF + markdown) instead of absolute host paths — SARIF resolves in GitHub code-scanning, no host-layout leak.
- **SEC-03** — `MafValidateFanOut` enforces `WorkspacePolicy` on the containing directory and caps the single-file read at the same 10 MB ceiling as the walk.
- **SEC-21** — the anti-pattern report flattens a multi-line `Match` before escaping so it can't break the table row / inject raw markdown.

### Data-correctness
- **REP-01** — the regression-plan version ladder derives from `CompatibilityTool.Matrix.Keys` (maintained source) instead of a second hard-coded list frozen at 1.5.0 — now covers every release through 1.13.0. A **drift test** pins `KnownVersions` ↔ `Matrix.Keys`; guide links guarded to 1.3.0+.
- **REP-02** — `MafDiffPackage` / `MafPreUpgradeDryRun` surface a dotnet-inspect failure (or drifted/partial output) as a visible error instead of a misleading "0 breaking changes". Missing-tool install instructions shown verbatim; other output data-fenced.

### Verification
- New `Phase4bSarifTests` (SARIF version/help/fingerprint, KnownVersions↔Matrix drift lock, `DescribeInspectFailure` verbatim-vs-fenced, FanOut relative paths).
- **1193 tests pass net8.** The one local failure — `ProgramCliDispatchTests.Doctor_ValidPath_ExitsZero` — is a **30s timeout from a polluted local `%TEMP%` (4509 stray `.cs` files); the test scans `Path.GetTempPath()`**. Not a code regression: the doctor CLI exits 0 on a clean dir, and CI runs on a clean temp — so the net8/9/10 CI job is the authoritative validation for that test.

_No GitHub Copilot review requested (per project instruction)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)