### PR TITLE
fix(reporting): Phase 5 — PR-audit accuracy, draft-issue quality, fork-text neutralization

### DIFF
--- a/src/maf-autopilot.Tests/DraftIssueToolTests.cs
+++ b/src/maf-autopilot.Tests/DraftIssueToolTests.cs
@@ -232,7 +232,8 @@ public sealed class DraftIssueToolTests
             actual: "NullReferenceException at MAF.Workflows.WorkflowBuilder.AddFanInBarrierEdge");
 
         // Assert — every section header is present.
-        Assert.Contains("## Title:", body);
+        Assert.Contains("Suggested title", body); // REP-15: title split out of the body
+        Assert.Contains("----- ISSUE BODY BELOW THIS LINE -----", body);
         Assert.Contains("### Symptom", body);
         Assert.Contains("### Environment", body);
         Assert.Contains("### Steps to reproduce", body);

--- a/src/maf-autopilot.Tests/Phase5ReportSurfacesTests.cs
+++ b/src/maf-autopilot.Tests/Phase5ReportSurfacesTests.cs
@@ -1,0 +1,117 @@
+using MafDoctor.Data;
+using MafDoctor.Tools;
+using Xunit;
+
+namespace MafDoctor.Tests;
+
+/// <summary>
+/// Regression tests for the Phase 5 (human report surfaces) findings:
+/// REP-14 (deletion-only PR verdict), REP-23 (cost scanner in PR audit),
+/// REP-40 (starvation own bucket + canonical MAF001 fix), REP-15 (draft-issue
+/// title/body split), REP-33 (single-line title from a multi-line symptom).
+/// </summary>
+public sealed class Phase5ReportSurfacesTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "maf-phase5-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-14 — a deletion-only PR reports the deletions, not "0 of N + Ship it"
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void DeletionOnlyPr_ReportsDeletions_NotShipIt()
+    {
+        var repo = NewTempDir();
+        try
+        {
+            // Files in the diff that don't exist on disk = deletions.
+            var report = PullRequestAuditTool.BuildReport(repo, "main", new[] { "Gone.cs", "Also.cs" });
+            Assert.Contains("only deletes", report);
+            Assert.Contains("were deleted in this diff", report);
+            Assert.DoesNotContain("Ship it", report);
+        }
+        finally { Directory.Delete(repo, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-23 — the PR audit includes the cost scanner (COST-001)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void PrAudit_IncludesCostScanner()
+    {
+        var repo = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(repo, "Svc.cs"),
+                "public class Svc { async System.Threading.Tasks.Task M(dynamic agent) { await agent.RunAsync(\"hi\"); } }");
+            var report = PullRequestAuditTool.BuildReport(repo, "main", new[] { "Svc.cs" });
+            Assert.Contains("COST-001", report);
+            Assert.Contains("🟠 Cost", report); // the new summary-table column
+        }
+        finally { Directory.Delete(repo, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-40 — silent-starvation gets its own bucket + the canonical MAF001 fix
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void PrAudit_StarvationHasOwnBucket_AndCanonicalFix()
+    {
+        var repo = NewTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(repo, "Wf.cs"),
+                "using System.Threading.Tasks; public partial class Inv : Executor { [MessageHandler] public void H(string m) {} }");
+            var report = PullRequestAuditTool.BuildReport(repo, "main", new[] { "Wf.cs" });
+            Assert.Contains("🔴 Starvation risk", report);           // own label, not "❌ Error"
+            Assert.Contains("SendMessageAsync doesn't broadcast", report); // DoctorTool.Maf001Fix canonical text
+            Assert.Contains(DoctorTool.Maf001Fix, report);
+        }
+        finally { Directory.Delete(repo, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-15 — the draft issue splits the title out of the body
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void DraftIssue_SplitsTitleFromBody_ReviewerNoteAboveSentinel()
+    {
+        var repo = NewTempDir();
+        try
+        {
+            var body = new DraftIssueTool(new RegistryService()).MafDraftIssue(repo, "AddFanInBarrierEdge throws NRE at runtime");
+            const string sentinel = "----- ISSUE BODY BELOW THIS LINE -----";
+            Assert.Contains("Suggested title", body);
+            Assert.Contains(sentinel, body);
+            Assert.DoesNotContain("## Title:", body);
+
+            var sentinelIdx = body.IndexOf(sentinel, StringComparison.Ordinal);
+            // The reviewer note is ABOVE the sentinel (never lands in the posted body);
+            // the first body section is BELOW it.
+            Assert.True(body.IndexOf("Review before posting", StringComparison.Ordinal) < sentinelIdx);
+            Assert.True(body.IndexOf("### Symptom", StringComparison.Ordinal) > sentinelIdx);
+        }
+        finally { Directory.Delete(repo, recursive: true); }
+    }
+
+    // -------------------------------------------------------------------------
+    // REP-33 — a multi-line symptom yields a single-line title
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void SuggestTitle_CollapsesMultilineAndTabWhitespace()
+    {
+        var title = DraftIssueTool.SuggestTitle("line one\n   line two\t\tline three.");
+        Assert.DoesNotContain("\n", title);
+        Assert.DoesNotContain("\t", title);
+        Assert.Equal("line one line two line three", title);
+    }
+}

--- a/src/maf-autopilot/Tools/BeforeAfterTool.cs
+++ b/src/maf-autopilot/Tools/BeforeAfterTool.cs
@@ -90,7 +90,7 @@ public sealed class BeforeAfterTool
 
                 changedInThisRule++;
                 totalFiles++;
-                sb.AppendLine($"### File: `{SourceFileWalker.MakeRelative(repoPath, file)}`");
+                sb.AppendLine($"### File: `{LlmFencing.MdInline(SourceFileWalker.MakeRelative(repoPath, file))}`"); // SEC-02
                 sb.AppendLine();
                 sb.AppendLine("```diff");
                 sb.Append(RenderUnifiedDiff(orig, rewritten, contextLines: 2));
@@ -151,7 +151,16 @@ public sealed class BeforeAfterTool
         // so the rendered diff doesn't echo a hard-coded key sitting near a change.
         static string Safe(string line)
         {
-            try { return AntiPatternScannerTool.LooksLikeSecret(line) ? "(redacted — may contain a secret)" : line; }
+            // SEC-05: a source line of ``` (or context lines with a leading space) is a
+            // valid CommonMark closing fence that would break out of the enclosing ```diff
+            // block. NeutralizeFences inserts a zero-width space so it can't close the fence
+            // (invisible to humans). Secret check runs first (redact-on-doubt).
+            try
+            {
+                return AntiPatternScannerTool.LooksLikeSecret(line)
+                    ? "(redacted — may contain a secret)"
+                    : MafDoctor.Data.RegistryService.NeutralizeFences(line);
+            }
             catch { return "(redacted — may contain a secret)"; }
         }
 

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -195,7 +195,7 @@ public sealed class DoctorTool
                 File: h.File,
                 Line: h.Line,
                 Issue: $"`{h.MethodName}` returns `{h.ReturnType}` — fan-out handler must return Task<T>",
-                FixDescription: "Return Task<T> / ValueTask<T> / IAsyncEnumerable<T> (the value is sent automatically), OR emit explicitly with `await context.SendMessageAsync(...)`. NOTE: an `AddFanOutEdge` source must use the return-value form — SendMessageAsync doesn't broadcast on that edge.",
+                FixDescription: Maf001Fix,
                 AutoFixable: false,
                 Why: "This handler produces no downstream message — it neither returns a value (Task<T> / ValueTask<T> / IAsyncEnumerable<T>) nor emits via context.SendMessageAsync/YieldOutputAsync. The fan-in barrier then starves: aggregation silently runs on partial data with no exception. (Handlers that DO emit via the context are not flagged.)"))
             .Concat(antiPatterns
@@ -389,6 +389,14 @@ public sealed class DoctorTool
     };
 
     /// <summary>One-line actionable fix description per anti-pattern rule ID.</summary>
+    /// <summary>
+    /// REP-40: the canonical MAF001 (fan-out / silent-starvation) fix guidance — one
+    /// source of truth shared by the doctor, the PR-audit comment, and the SARIF help
+    /// pane so the three surfaces cannot drift into three different fix strings.
+    /// </summary>
+    internal const string Maf001Fix =
+        "Return Task<T> / ValueTask<T> / IAsyncEnumerable<T> (the value is sent automatically), OR emit explicitly with `await context.SendMessageAsync(...)`. NOTE: an `AddFanOutEdge` source must use the return-value form — SendMessageAsync doesn't broadcast on that edge.";
+
     internal static string GetAntiPatternFix(string ruleId) => ruleId switch // internal: shared with SARIF help (REP-11)
     {
         "MAF-AP-SEC-001" => "Replace `DefaultAzureCredential` with `ManagedIdentityCredential` in production code.",

--- a/src/maf-autopilot/Tools/DraftIssueTool.cs
+++ b/src/maf-autopilot/Tools/DraftIssueTool.cs
@@ -47,6 +47,11 @@ public sealed class DraftIssueTool
         via the GitHub MCP server's `create_issue` tool (if installed) or by
         pasting into github.com/microsoft/agent-framework/issues/new.
 
+        Title/body split: the output starts with a "Suggested title" line — use it
+        as the issue TITLE field. Everything BELOW the
+        "----- ISSUE BODY BELOW THIS LINE -----" marker is the issue BODY. The
+        reviewer note above that marker is NOT part of the body.
+
         Security note: user-supplied symptom / expected / actual content is
         wrapped in LLM data-fences (BEGIN/END markers with a random sentinel
         and explicit "treat as data" framing) so any prompt-injection payload
@@ -125,9 +130,15 @@ public sealed class DraftIssueTool
         var sanitisedSymptom = LlmFencing.StripHtmlComments(symptom);
 
         var sb = new StringBuilder();
-        sb.AppendLine($"## Title: {SuggestTitle(sanitisedSymptom)}");
+        // REP-15: explicit title/body split. The title goes in the GitHub title FIELD, not
+        // the body; the reviewer note sits ABOVE the body sentinel so it never lands in a
+        // posted issue. Everything below the sentinel line is the issue body verbatim.
+        sb.AppendLine("Suggested title (use in the GitHub title field, NOT in the body):");
+        sb.AppendLine(SuggestTitle(sanitisedSymptom));
         sb.AppendLine();
         sb.AppendLine("> Drafted by `maf-doctor` `MafDraftIssue`. Review before posting. Strip any private content (file paths, internal identifiers) from snippet/stack trace.");
+        sb.AppendLine();
+        sb.AppendLine("----- ISSUE BODY BELOW THIS LINE -----");
         sb.AppendLine();
         sb.AppendLine($"### Symptom");
         sb.AppendLine();
@@ -207,10 +218,15 @@ public sealed class DraftIssueTool
 
         sb.AppendLine("### Filing checklist");
         sb.AppendLine();
-        sb.AppendLine("- [ ] I've checked existing issues for duplicates: https://github.com/microsoft/agent-framework/issues?q=" + Uri.EscapeDataString(sanitisedSymptom));
+        // REP-33: query on the compact single-line title, not the raw (possibly multi-line,
+        // multi-KB) symptom — an ~80-char query renders cleanly and is a far better dedup search.
+        sb.AppendLine("- [ ] I've checked existing issues for duplicates: https://github.com/microsoft/agent-framework/issues?q=" + Uri.EscapeDataString(SuggestTitle(sanitisedSymptom)));
         sb.AppendLine("- [ ] My repro is minimal (no unrelated app code).");
         sb.AppendLine("- [ ] I've stripped private content (file paths, internal identifiers, secrets).");
         sb.AppendLine("- [ ] The stack trace (if any) is the first 10-15 frames, not the full thing.");
+        // REP-32: the LLM data-fence around user text matters only when the body is routed
+        // through another AI tool; a human poster may delete it. Say so explicitly.
+        sb.AppendLine("- [ ] Posting manually (not via an AI agent)? You may delete the `<<<BEGIN_/END_...>>>` fence lines around the Symptom/Expected/Actual text — they only matter when the body passes through another AI tool.");
         sb.AppendLine();
 
         sb.AppendLine("### How to post this");
@@ -337,10 +353,16 @@ public sealed class DraftIssueTool
     /// </summary>
     internal static string SuggestTitle(string symptom)
     {
-        var trimmed = symptom.Trim().TrimEnd('.', '!', '?');
+        // REP-33: collapse ALL whitespace runs (incl. newlines/tabs) FIRST so a multi-line
+        // symptom produces a single-line title heading and a short, useful dedup query —
+        // not a broken multi-line heading and a multi-kilobyte search URL.
+        var trimmed = WhitespaceRegex.Replace(symptom, " ").Trim().TrimEnd('.', '!', '?');
         if (trimmed.Length > 80) trimmed = trimmed[..77] + "...";
         return trimmed;
     }
+
+    private static readonly Regex WhitespaceRegex = new(
+        @"\s+", RegexOptions.Compiled | RegexOptions.NonBacktracking, TimeSpan.FromSeconds(2));
 
     public sealed record EnvironmentInfo(
         string TrackedMafVersion,

--- a/src/maf-autopilot/Tools/PullRequestAuditTool.cs
+++ b/src/maf-autopilot/Tools/PullRequestAuditTool.cs
@@ -30,7 +30,8 @@ public sealed class PullRequestAuditTool
           - baseBranch: the branch to diff against (default: `main`).
 
         Returns a markdown report grouped by changed file, with anti-pattern,
-        fan-out, and prompt-lint findings. Files with zero findings are omitted.
+        fan-out (silent-starvation), prompt-lint, and cost findings. Files with
+        zero findings are omitted.
         """)]
     public string MafAuditPullRequest(
         [Description("Absolute path to the repository root.")] string repoPath,
@@ -135,6 +136,7 @@ public sealed class PullRequestAuditTool
 
         long aggregateBytes = 0;
         var actuallyScanned = 0;
+        var deleted = 0; // REP-14: deletion-only PRs must not read as "0 of N + Ship it"
         foreach (var relPath in filesToScan)
         {
             // F-07 — previously combined repoPath + relPath with plain Path.Combine
@@ -149,17 +151,17 @@ public sealed class PullRequestAuditTool
             catch (ArgumentException ex)
             {
                 scanComplete = false;
-                skipped.Add($"`{relPath}` — refused: {ex.Message}");
+                skipped.Add($"`{LlmFencing.MdInline(relPath)}` — refused: {ex.Message}"); // SEC-02: fork-supplied path
                 continue;
             }
 
-            if (!File.Exists(absPath)) continue;     // file deleted in the diff
+            if (!File.Exists(absPath)) { deleted++; continue; }  // REP-14: file deleted in the diff
 
             var length = new FileInfo(absPath).Length;
             if (length > MaxFileBytes)
             {
                 scanComplete = false;
-                skipped.Add($"`{relPath}` — {length / (1024 * 1024)} MB exceeds the {MaxFileBytes / (1024 * 1024)} MB per-file cap, skipped.");
+                skipped.Add($"`{LlmFencing.MdInline(relPath)}` — {length / (1024 * 1024)} MB exceeds the {MaxFileBytes / (1024 * 1024)} MB per-file cap, skipped.");
                 continue;
             }
             if (aggregateBytes + length > MaxAggregateBytes)
@@ -178,26 +180,37 @@ public sealed class PullRequestAuditTool
                 .Where(f => f.Verdict is FanOutVerdict.SilentStarvationRisk or FanOutVerdict.LikelyInvalid)
                 .ToList();
             var prompt = PromptLintTool.LintSource(source, relPath);
+            // REP-23: include the cost scanner — the tool description claims "every MAF
+            // scanner", but COST-001 (surfaced on every other surface) was missing here.
+            var cost = EstimateCostTool.AnalyzeSource(source, relPath).Where(c => c.HasCapWarning).ToList();
 
-            if (anti.Count == 0 && fanOut.Count == 0 && prompt.Count == 0) continue;
+            if (anti.Count == 0 && fanOut.Count == 0 && prompt.Count == 0 && cost.Count == 0) continue;
 
             var lines = new List<string>();
             foreach (var f in anti)
             {
-                lines.Add($"- **{Severity(f.Severity)}** `{f.RuleId}` line {f.Line}: {f.RuleName}");
+                lines.Add($"- **{Severity(f.Severity)}** `{f.RuleId}` line {f.Line}: {LlmFencing.MdInline(f.RuleName)}");
                 Bump(totals, f.Severity);
             }
             foreach (var f in fanOut)
             {
-                lines.Add($"- **❌ Error** `MAF001` line {f.Line}: `{f.MethodName}` returns `{f.ReturnType}` — fan-out handler must return `Task<T>`");
-                totals.Errors++;
+                // REP-40: silent-starvation gets its OWN severity bucket (not folded into
+                // Errors) and the doctor's canonical MAF001 fix — one source of truth so the
+                // three surfaces (doctor / SARIF / PR comment) can't drift.
+                lines.Add($"- **🔴 Starvation risk** `MAF001` line {f.Line}: `{f.MethodName}` returns `{f.ReturnType}` — {DoctorTool.Maf001Fix}");
+                totals.Starvation++;
             }
             foreach (var f in prompt)
             {
                 var sev = f.Severity == PromptSeverity.Error ? "❌ Error" : "⚠️ Warning";
-                lines.Add($"- **{sev}** `{f.RuleId}` line {f.Line}: {f.Message}");
+                lines.Add($"- **{sev}** `{f.RuleId}` line {f.Line}: {LlmFencing.MdInline(f.Message)}");
                 if (f.Severity == PromptSeverity.Error) totals.Errors++;
                 else totals.Warnings++;
+            }
+            foreach (var f in cost)
+            {
+                lines.Add($"- **🟠 Cost** `COST-001` line {f.Line}: Unbounded `{f.CallSite}` — set MaxOutputTokens on the nearest ChatOptions");
+                totals.Costs++;
             }
 
             perFileFindings.Add((relPath, lines));
@@ -214,6 +227,9 @@ public sealed class PullRequestAuditTool
         sb.AppendLine(actuallyScanned == changedFiles.Count
             ? $"**Files scanned:** {actuallyScanned} changed `.cs` file(s)."
             : $"**Files scanned:** {actuallyScanned} of {changedFiles.Count} changed `.cs` file(s).");
+        // REP-14: always explain the N-of-M gap for deletions so the count reads honestly.
+        if (deleted > 0)
+            sb.AppendLine($"_({deleted} changed file(s) were deleted in this diff — nothing to scan for them.)_");
         if (!scanComplete)
         {
             sb.AppendLine();
@@ -221,16 +237,22 @@ public sealed class PullRequestAuditTool
             foreach (var reason in skipped) sb.AppendLine($"- {reason}");
         }
         sb.AppendLine();
-        sb.AppendLine($"| ❌ Errors | ⚠️ Warnings | ℹ️ Info |");
-        sb.AppendLine($"|---:|---:|---:|");
-        sb.AppendLine($"| {totals.Errors} | {totals.Warnings} | {totals.Infos} |");
+        sb.AppendLine($"| ❌ Errors | 🔴 Starvation | ⚠️ Warnings | 🟠 Cost | ℹ️ Info |");
+        sb.AppendLine($"|---:|---:|---:|---:|---:|");
+        sb.AppendLine($"| {totals.Errors} | {totals.Starvation} | {totals.Warnings} | {totals.Costs} | {totals.Infos} |");
         sb.AppendLine();
 
         if (perFileFindings.Count == 0)
         {
-            sb.AppendLine(scanComplete
-                ? "✅ All changed files are clean against the configured scanner rules. Ship it."
-                : "⚠️ No findings in the file(s) that were scanned — but the scan above was incomplete. This is NOT a clean bill of health.");
+            string verdict;
+            if (!scanComplete)
+                verdict = "⚠️ No findings in the file(s) that were scanned — but the scan above was incomplete. This is NOT a clean bill of health.";
+            else if (actuallyScanned == 0 && deleted == changedFiles.Count && changedFiles.Count > 0)
+                // REP-14: a deletion-only PR gets an accurate verdict, not "Ship it" over "0 scanned".
+                verdict = "✅ This branch only deletes `.cs` files — nothing to scan.";
+            else
+                verdict = "✅ All changed files are clean against the configured scanner rules. Ship it.";
+            sb.AppendLine(verdict);
             return sb.ToString();
         }
 
@@ -238,7 +260,9 @@ public sealed class PullRequestAuditTool
         sb.AppendLine();
         foreach (var (file, lines) in perFileFindings.OrderByDescending(f => f.Lines.Count))
         {
-            sb.AppendLine($"#### `{file}`");
+            // SEC-02: the changed-file path is fork-supplied — neutralize it so a crafted
+            // filename can't escape the code span / inject markdown into the PR comment.
+            sb.AppendLine($"#### `{LlmFencing.MdInline(file)}`");
             foreach (var line in lines) sb.AppendLine(line);
             sb.AppendLine();
         }
@@ -290,5 +314,7 @@ public sealed class PullRequestAuditTool
         public int Errors;
         public int Warnings;
         public int Infos;
+        public int Starvation; // REP-40: own bucket, no longer folded into Errors
+        public int Costs;      // REP-23: cost scanner now included
     }
 }

--- a/src/maf-autopilot/Tools/SarifExportTool.cs
+++ b/src/maf-autopilot/Tools/SarifExportTool.cs
@@ -105,6 +105,7 @@ internal static class SarifExportTool
             FullDescription: full,
             HelpUri: "https://github.com/joslat/maf-doctor/blob/main/.github/skills/maf-fan-out-validator/SKILL.md",
             // REP-11: MAF001 already had a good fullDescription but no help pane content.
-            HelpMarkdown: $"**Why:** {full}\n\n**Fix:** Return `Task<T>` / `ValueTask<T>` / `IAsyncEnumerable<T>` (the value is sent automatically), OR emit explicitly with `await context.SendMessageAsync(...)`.");
+            // REP-40: reuse the doctor's canonical fix so doctor / SARIF / PR-audit agree.
+            HelpMarkdown: $"**Why:** {full}\n\n**Fix:** {DoctorTool.Maf001Fix}");
     }
 }


### PR DESCRIPTION
## Phase 5 — Human report surfaces (Fable 5 remediation)

7 findings across the GitHub-facing report tools + completing SEC-02 path-neutralization for the PR-audit / BeforeAfter echo sites (DoctorTool sites were Phase 4). Unblocked by Phase 4 (reuses `MdInline`, the unified model).

### PullRequestAuditTool
- **REP-14** — deletion-only PRs report the deletions + get an accurate verdict ("only deletes `.cs` — nothing to scan") instead of "0 of N" + "Ship it".
- **REP-23** — the cost scanner (COST-001) is now included (the description claimed "every MAF scanner"; COST-001 was the one gap). New 🟠 Cost column.
- **REP-40** — silent-starvation gets its own 🔴 Starvation column/label instead of folding into Errors, and uses the doctor's canonical MAF001 fix.
- **SEC-02** — fork-supplied changed-file paths (file header + skipped-file names) routed through `LlmFencing.MdInline`.

### DraftIssueTool
- **REP-15** — explicit title/body split: a "Suggested title" line + a `----- ISSUE BODY BELOW THIS LINE -----` sentinel, with the reviewer note moved ABOVE the sentinel so it never lands in a posted issue.
- **REP-33** — `SuggestTitle` collapses whitespace runs first → single-line title + a short dedup-search URL (query on the compact title, not the raw multi-KB symptom).
- **REP-32** — a Filing-checklist item tells human posters they may delete the LLM fence lines. _(The shared `LlmFencing.Fence` framing/sentinel is left unchanged — shrinking it would touch every caller + the Python parity helper + their tests for a Low-severity cosmetic gain.)_

### BeforeAfterTool
- **SEC-05** — the unified-diff `Safe()` neutralizes triple-backtick runs so a source line of ``` can't close the enclosing ` ```diff ` fence.
- **SEC-02** — the per-file diff header path routed through `MdInline`.

### Shared
- `DoctorTool.Maf001Fix` — one canonical MAF001 fix string consumed by the doctor, the SARIF help pane, and the PR-audit comment so the three can't drift.

### Verification
- New `Phase5ReportSurfacesTests` (deletion-only verdict, cost scanner, starvation bucket + canonical fix, title/body split, multi-line title collapse).
- **1198 tests green net8** (net9/net10 via CI). The one excluded test — `ProgramCliDispatchTests.Doctor_ValidPath_ExitsZero` — fails only on a polluted local `%TEMP%` (it scans `Path.GetTempPath()`); it passes on the clean CI runner.

_No GitHub Copilot review requested (per project instruction)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)