### PR TITLE
ci(pr): Phase 8 — mcp-scanner gate integrity, required-check semantics, comment hygiene

### DIFF
--- a/.github/instructions/maf-deployment.instructions.md
+++ b/.github/instructions/maf-deployment.instructions.md
@@ -156,7 +156,7 @@ Optional gates (recommended):
 - `MafLintAgentPrompt(repoPath)` with no PROMPT-004 errors (prompt injection).
 - `MafEstimateCost(repoPath)` with zero unbounded sites.
 
-The PR-comment integration via `MafAuditPullRequest` posts a sticky summary to the PR — no greenfield work should land without that summary being clean.
+The CI sticky PR comment is the **product-scoped `doctor`** report (whole-repo, `samples/`/`.Tests/`/`find-the-bug/` excluded) run by `maf-pr-audit.yml` — no greenfield work should land without that summary being clean. (`MafAuditPullRequest` remains the on-demand MCP tool for a **diff-scoped** audit of just the changed files.)
 
 ## Anti-patterns we've already paid for
 

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -16,6 +16,13 @@ on:
     branches: [main]
   pull_request:
 
+# WM-35: cancel superseded PR runs so rapid pushes don't queue redundant full builds.
+# Push-to-main runs are NOT cancelled (main's history stays fully tested); only an
+# already-superseded PR head is cancelled the moment a newer head arrives.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci-invariants.yml
+++ b/.github/workflows/ci-invariants.yml
@@ -253,6 +253,12 @@ jobs:
               r'|github\.event\.inputs\.'
               r'|needs\.[^.]+\.outputs\.'
               r'|steps\.[^.]+\.outputs\.'
+              # WM-14: the classic free-text event-field injection lanes (PR/issue/
+              # comment/review titles + bodies, commit messages). Allowlist the
+              # structurally-safe numeric/sha leaves via a negative lookahead so
+              # `pull_request.number` / `.base.sha` / `.head.sha` stay usable in run: blocks.
+              r'|github\.event\.pull_request\.(?!number\b|base\.sha\b|head\.sha\b)'
+              r'|github\.event\.(?:issue|comment|review|head_commit|commits)\b'
               r')'
           )
           # Self-exclude ci-invariants.yml — this meta-workflow names the
@@ -276,6 +282,12 @@ jobs:
                           if m:
                               in_run = True
                               run_indent = len(m.group(1))
+                              continue
+                          # WM-14: a SINGLE-LINE `run: <cmd>` (no |/> block scalar) — the
+                          # command is on the same line, so check its remainder directly.
+                          m1 = re.match(r'^\s*run\s*:\s*(?![|>])(\S.*)$', stripped)
+                          if m1 and tpl.search(m1.group(1)):
+                              violations.append(f"{path}:{i}: {stripped.strip()}")
                               continue
                           # End of run: block when indentation drops to or below run_indent and line isn't blank
                           if in_run and stripped.strip() != '':

--- a/.github/workflows/maf-ai-fill-verify.yml
+++ b/.github/workflows/maf-ai-fill-verify.yml
@@ -28,9 +28,17 @@ on:
     # get blocked by "missing required check"). The job filters internally:
     # if registry.yaml isn't in the diff, it reports success trivially.
 
+# SEC-11: this job checks out + builds PR-supplied (possibly fork) code, so it must
+# NOT hold write scope. It uploads its comment body + PR number as an artifact; the
+# workflow_run companion (maf-pr-audit-comment.yml) posts the sticky comment from the
+# base-repo context without ever touching fork code.
 permissions:
   contents: read
-  pull-requests: write
+
+# WM-35: cancel superseded PR runs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   verify:
@@ -207,66 +215,65 @@ jobs:
           } >> $GITHUB_OUTPUT
           exit $EXIT
 
-      - name: Build failure comment
-        if: |
-          steps.scope.outputs.in_scope == 'true' &&
-          (steps.verify.outputs.exit_code != '0' ||
-           steps.crossfile.outputs.exit_code != '0')
+      # SEC-11: build the sticky-comment body (failure detail OR a passed message) and
+      # upload it as an artifact instead of posting it here — this job checks out + built
+      # PR-supplied code, so it must not hold write scope. The workflow_run companion
+      # (maf-pr-audit-comment.yml) posts it from the base-repo context. Task 4.8: still a
+      # single sticky comment (header maf-ai-fill-verify), updated per PR.
+      - name: Build verify comment body
+        if: steps.scope.outputs.in_scope == 'true'
         env:
           VERIFY_OUTPUT: ${{ steps.verify.outputs.output }}
           CROSSFILE_OUTPUT: ${{ steps.crossfile.outputs.output }}
           VERIFY_EXIT: ${{ steps.verify.outputs.exit_code }}
           CROSSFILE_EXIT: ${{ steps.crossfile.outputs.exit_code }}
         run: |
-          {
-            echo "## ❌ AI-fill verification failed"
-            echo ""
-            if [ "$VERIFY_EXIT" != "0" ]; then
-              echo "### Registry entry checks (rung-1 mechanical)"
+          if [ "$VERIFY_EXIT" = "0" ] && [ "$CROSSFILE_EXIT" = "0" ]; then
+            echo "✅ AI-fill verification passed (registry + cross-file checks)." > ai-fill-verify-comment.md
+          else
+            {
+              echo "## ❌ AI-fill verification failed"
               echo ""
-              echo '```'
-              echo "$VERIFY_OUTPUT"
-              echo '```'
-              echo ""
-            fi
-            if [ "$CROSSFILE_EXIT" != "0" ]; then
-              echo "### Cross-file consistency checks"
-              echo ""
-              echo '```'
-              echo "$CROSSFILE_OUTPUT"
-              echo '```'
-              echo ""
-            fi
-            echo "**Common fixes:**"
-            echo "- example_before == example_after -> these must differ."
-            echo "- fix_description too short -> write a real sentence, no TODO/TBD."
-            echo "- unbalanced braces -> bot truncated a code block."
-            echo "- guide_section placeholder -> use 'N/A' literal."
-            echo "- duplicate version row -> UPDATE the watcher placeholder, do NOT add a row."
-            echo "- Version Tracking section stale -> bump 'Current tracked version' to match .maf-version."
-          } > /tmp/comment.md
+              if [ "$VERIFY_EXIT" != "0" ]; then
+                echo "### Registry entry checks (rung-1 mechanical)"
+                echo ""
+                echo '```'
+                echo "$VERIFY_OUTPUT"
+                echo '```'
+                echo ""
+              fi
+              if [ "$CROSSFILE_EXIT" != "0" ]; then
+                echo "### Cross-file consistency checks"
+                echo ""
+                echo '```'
+                echo "$CROSSFILE_OUTPUT"
+                echo '```'
+                echo ""
+              fi
+              echo "**Common fixes:**"
+              echo "- example_before == example_after -> these must differ."
+              echo "- fix_description too short -> write a real sentence, no TODO/TBD."
+              echo "- unbalanced braces -> bot truncated a code block."
+              echo "- guide_section placeholder -> use 'N/A' literal."
+              echo "- duplicate version row -> UPDATE the watcher placeholder, do NOT add a row."
+              echo "- Version Tracking section stale -> bump 'Current tracked version' to match .maf-version."
+            } > ai-fill-verify-comment.md
+          fi
 
-      # Task 4.8 — sticky comment (one comment updated by header) instead of
-      # `gh pr comment`, which stacked a NEW duplicate on every push/label event.
-      - name: Post sticky failure comment
-        if: |
-          steps.scope.outputs.in_scope == 'true' &&
-          (steps.verify.outputs.exit_code != '0' ||
-           steps.crossfile.outputs.exit_code != '0')
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v2.9.2
-        with:
-          header: maf-ai-fill-verify
-          path: /tmp/comment.md
+      - name: Write PR number for the comment companion
+        if: steps.scope.outputs.in_scope == 'true'
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
 
-      - name: Clear sticky comment on success
-        if: |
-          steps.scope.outputs.in_scope == 'true' &&
-          steps.verify.outputs.exit_code == '0' &&
-          steps.crossfile.outputs.exit_code == '0'
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v2.9.2
+      - name: Upload verify result for the comment companion (SEC-11)
+        if: steps.scope.outputs.in_scope == 'true'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          header: maf-ai-fill-verify
-          message: "✅ AI-fill verification passed (registry + cross-file checks)."
+          name: maf-ai-fill-verify-result
+          path: |
+            ai-fill-verify-comment.md
+            pr-number.txt
 
       - name: Final status (fail if any check failed)
         if: |

--- a/.github/workflows/maf-pr-audit-comment.yml
+++ b/.github/workflows/maf-pr-audit-comment.yml
@@ -15,8 +15,15 @@ name: MAF PR Audit Comment
 # that still has to process fork-supplied content.
 
 on:
+  # SEC-11: the single sticky-comment poster for every PR-time producer whose scan
+  # job runs untrusted PR code and therefore can't safely hold `pull-requests: write`.
+  # Each producer uploads its comment body + pr-number.txt as an artifact; this
+  # base-repo-context companion posts it without ever touching fork code.
   workflow_run:
-    workflows: ["MAF PR Audit"]
+    workflows:
+      - "MAF PR Audit"
+      - "MCP server security scan (Cisco mcp-scanner)"
+      - "MAF AI-Fill PR Verify"
     types: [completed]
 
 # `actions: read` is required for actions/download-artifact to fetch an
@@ -46,17 +53,59 @@ jobs:
     if: (github.event.workflow_run.conclusion == 'success' || github.event.workflow_run.conclusion == 'failure') && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      # maf-pr-audit.yml now ALWAYS uploads this artifact on a successful run
+      # SEC-11: map the upstream workflow name → its uploaded artifact name, comment
+      # body file, and sticky-comment header. One companion, several producers.
+      - name: Resolve producer
+        id: producer
+        env:
+          WF_NAME: ${{ github.event.workflow_run.name }}
+        run: |
+          case "$WF_NAME" in
+            "MAF PR Audit")
+              echo "artifact=pr-audit-result" >> "$GITHUB_OUTPUT"
+              echo "body_file=pr-audit-full.md" >> "$GITHUB_OUTPUT"
+              echo "header=maf-autopilot-audit" >> "$GITHUB_OUTPUT" ;;
+            "MCP server security scan (Cisco mcp-scanner)")
+              echo "artifact=mcp-scanner-result" >> "$GITHUB_OUTPUT"
+              echo "body_file=pr-comment.md" >> "$GITHUB_OUTPUT"
+              echo "header=mcp-scanner-result" >> "$GITHUB_OUTPUT" ;;
+            "MAF AI-Fill PR Verify")
+              echo "artifact=maf-ai-fill-verify-result" >> "$GITHUB_OUTPUT"
+              echo "body_file=ai-fill-verify-comment.md" >> "$GITHUB_OUTPUT"
+              echo "header=maf-ai-fill-verify" >> "$GITHUB_OUTPUT" ;;
+            *)
+              echo "::error::Unrecognized upstream workflow: $WF_NAME"; exit 1 ;;
+          esac
+
+      # The producer ALWAYS uploads this artifact on a completed run
       # (a placeholder message when the audit was intentionally skipped, the
       # real report otherwise) — so reaching this step with the artifact
       # missing is a genuine problem, not an expected case to swallow. No
       # continue-on-error: a failure here should be visible.
-      - name: Download audit result
+      - name: Download producer result
+        id: download
+        # continue-on-error: a producer that ran but was OUT OF SCOPE legitimately
+        # uploads no artifact (e.g. MAF AI-Fill PR Verify on a PR that doesn't touch
+        # registry.yaml). The next step turns a missing body into a clean no-op; the
+        # always-uploading producers (audit / mcp-scanner) still always have one.
+        continue-on-error: true
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
-          name: pr-audit-result
+          name: ${{ steps.producer.outputs.artifact }}
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check comment body present
+        id: check
+        env:
+          BODY_FILE: ${{ steps.producer.outputs.body_file }}
+        run: |
+          if [ -f "$BODY_FILE" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "No comment body from '${{ github.event.workflow_run.name }}' (producer out of scope / no artifact) — nothing to post."
+          fi
 
       # F-14 — pr-number.txt is attacker-influenced (it's written inside
       # maf-pr-audit.yml, which runs Roslyn analysis over fork-supplied source
@@ -73,6 +122,7 @@ jobs:
       # chosen markdown to an arbitrary one.
       - name: Resolve and verify PR number
         id: pr
+        if: steps.check.outputs.present == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -93,6 +143,7 @@ jobs:
           echo "number=$RESOLVED" >> "$GITHUB_OUTPUT"
 
       - name: Cap comment size and stamp audited SHA
+        if: steps.check.outputs.present == 'true'
         # Defense in depth alongside PathGuard-style caps elsewhere in the
         # project — pr-audit-full.md's content ultimately derives from the
         # PR's own (possibly adversarial) source tree via `doctor`'s findings.
@@ -104,21 +155,30 @@ jobs:
         # PR's current head.
         env:
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          BODY_FILE: ${{ steps.producer.outputs.body_file }}
         run: |
           MAX_BYTES=60000
-          if [ "$(wc -c < pr-audit-full.md)" -gt "$MAX_BYTES" ]; then
-            head -c "$MAX_BYTES" pr-audit-full.md > pr-audit-full.trunc.md
-            printf '\n\n> ⚠️ **Report truncated** — exceeded %s bytes. See the full log in the workflow run.\n' "$MAX_BYTES" >> pr-audit-full.trunc.md
-            mv pr-audit-full.trunc.md pr-audit-full.md
+          if [ "$(wc -c < "$BODY_FILE")" -gt "$MAX_BYTES" ]; then
+            # REP-30: truncate at a LINE boundary (drop the possibly-split last line),
+            # strip any partial trailing UTF-8 byte, then RE-BALANCE code fences so the
+            # truncation notice can never land inside an unclosed ``` block. A raw
+            # byte cut previously split a UTF-8 char or an open fence.
+            head -c "$MAX_BYTES" "$BODY_FILE" | sed '$ d' | iconv -f utf-8 -t utf-8 -c > body.trunc
+            if [ $(( $(grep -c '^[[:space:]]*```' body.trunc) % 2 )) -eq 1 ]; then
+              printf '```\n' >> body.trunc
+            fi
+            printf '\n\n> ⚠️ **Report truncated** — exceeded %s bytes. See the full log in the workflow run.\n' "$MAX_BYTES" >> body.trunc
+            mv body.trunc "$BODY_FILE"
           fi
-          printf '\n\n_Audited commit: `%s`_\n' "$HEAD_SHA" >> pr-audit-full.md
+          printf '\n\n_Audited commit: `%s`_\n' "$HEAD_SHA" >> "$BODY_FILE"
 
       - name: Comment on PR
+        if: steps.check.outputs.present == 'true'
         # SHA-pinned per supply-chain hardening. Verify against tag with:
         #   gh api repos/marocchino/sticky-pull-request-comment/git/refs/tags/v2.9.2 --jq .object.sha
         # Update via Dependabot (.github/dependabot.yml).
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v2.9.2
         with:
-          header: maf-autopilot-audit
-          path: pr-audit-full.md
+          header: ${{ steps.producer.outputs.header }}
+          path: ${{ steps.producer.outputs.body_file }}
           number: ${{ steps.pr.outputs.number }}

--- a/.github/workflows/maf-pr-audit.yml
+++ b/.github/workflows/maf-pr-audit.yml
@@ -7,10 +7,12 @@ name: MAF PR Audit
 # The CI integration vector for plan #52. [task 4.10]
 
 on:
-  pull_request:
-    paths:
-      - '**.cs'
-      - '**.csproj'
+  # SEC-16: NO paths: filter. A required check with a paths filter deadlocks docs-only
+  # PRs (the check is "expected" but never runs) — or, if not required, the compiler-bomb
+  # red gate can't actually block a merge. Instead the check runs on EVERY PR and the
+  # in-job "Decide whether to audit" step below skips (green) when nothing product-code
+  # changed, so it reports success on every PR and is safely requireable.
+  pull_request: {}
 
 # #148 finding 3 — this job runs Roslyn analysis over the PR's own (possibly
 # untrusted, fork-supplied) source, so it must never hold write-scoped
@@ -24,6 +26,11 @@ on:
 # job produces below.
 permissions:
   contents: read
+
+# WM-35: cancel superseded PR runs (this audit is one of the heavier PR jobs).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   audit:
@@ -54,8 +61,15 @@ jobs:
           echo "$CHANGED_CODE" | sed 's/^/  /'
           if [ -z "$NON_SAMPLE" ]; then
             echo "skip=true" >> $GITHUB_OUTPUT
-            echo "skip_reason=samples-only" >> $GITHUB_OUTPUT
-            echo "::notice title=MAF audit skipped::Only samples/ files changed — they're intentionally buggy demo corpora, not real code to audit."
+            # SEC-16: distinguish "no product code changed at all" (docs-only PR — now
+            # reachable since the paths filter was removed) from "only samples/ changed".
+            if [ -z "$CHANGED_CODE" ]; then
+              echo "skip_reason=no-code" >> $GITHUB_OUTPUT
+              echo "::notice title=MAF audit skipped::No .cs/.csproj files changed — nothing to audit."
+            else
+              echo "skip_reason=samples-only" >> $GITHUB_OUTPUT
+              echo "::notice title=MAF audit skipped::Only samples/ files changed — they're intentionally buggy demo corpora, not real code to audit."
+            fi
             exit 0
           fi
 
@@ -149,7 +163,10 @@ jobs:
         if: steps.scope.outputs.skip != 'true'
         run: dotnet build src/maf-autopilot/maf-autopilot.csproj -c Release -f net8.0 --no-restore
 
-      - name: Run MCP server and call MafAuditPullRequest
+      - name: Run maf-doctor doctor (whole-repo, product-scoped)
+        # REP-41: this is the whole-repo, product-scoped `doctor` report (not the
+        # diff-scoped MafAuditPullRequest MCP tool) — the step name + steering docs
+        # now say so.
         if: steps.scope.outputs.skip != 'true'
         id: audit
         env:
@@ -170,12 +187,30 @@ jobs:
           else
             # Product-scoped (task 4.10 / 3.1): exclude samples/ + test fixtures so
             # the audit reflects product code, matching the drift detector.
-            # `|| true` keeps the job alive on any error so we still post a sticky
-            # comment with diagnostic content.
+            # REP-29: capture stdout (the markdown report) and stderr SEPARATELY so a
+            # stray runtime warning can't corrupt the sticky comment. `|| true` keeps
+            # the job alive so we still post diagnostic content.
+            rc=0
             dotnet "$MAF_DOCTOR" doctor "$GITHUB_WORKSPACE" \
               --exclude samples/ --exclude .Tests/ --exclude find-the-bug/ \
-              > pr-audit-full.md 2>&1 || true
+              > pr-audit-full.md 2> doctor-stderr.txt || rc=$?
+            # On failure / empty report, append the stderr as a COLLAPSED diagnostics
+            # block (delimited, not interleaved). On success it's only in the job log below.
+            if [ "$rc" -ne 0 ] || [ ! -s pr-audit-full.md ]; then
+              {
+                echo ''
+                echo '<details><summary>doctor diagnostics (stderr)</summary>'
+                echo ''
+                echo '```'
+                cat doctor-stderr.txt 2>/dev/null || echo '(none)'
+                echo '```'
+                echo ''
+                echo '</details>'
+              } >> pr-audit-full.md
+            fi
           fi
+
+          echo "--- doctor stderr ---"; cat doctor-stderr.txt 2>/dev/null || echo "(none)"
 
           # Defensive fallback: if the doctor invocation produced nothing
           # (empty file), write an explanatory message rather than letting the
@@ -208,6 +243,8 @@ jobs:
             cat > pr-audit-full.md <<EOF
           ⚠️ **MAF audit INCOMPLETE for this PR.** The Roslyn-heavy per-file audit was skipped: this PR changes $FILE_COUNT .cs files totaling $BYTES bytes, exceeding the 200-file / 5 MB compiler-bomb cap. The CI-side mcp-scanner still ran. A maintainer should manually review this PR's size and content before merging — the automated mechanical audit has NOT evaluated it.
           EOF
+          elif [ "$SKIP_REASON" = "no-code" ]; then
+            echo "ℹ️ **MAF audit skipped for this PR.** No .cs/.csproj files changed — nothing to audit." > pr-audit-full.md
           else
             echo "ℹ️ **MAF audit skipped for this PR.** Only samples/ files changed — they're intentionally buggy demo corpora, not real code to audit." > pr-audit-full.md
           fi

--- a/.github/workflows/mcp-scanner.yml
+++ b/.github/workflows/mcp-scanner.yml
@@ -21,9 +21,14 @@ name: MCP server security scan (Cisco mcp-scanner)
 on:
   pull_request:
     branches: [main]
+    # SEC-30: dropped the nonexistent `src/maf-autopilot.csproj` and added the CPM /
+    # build inputs, so a server DEPENDENCY bump (Directory.Packages.props) is scanned
+    # pre-merge instead of only at the weekly cron.
     paths:
       - 'src/maf-autopilot/**'
-      - 'src/maf-autopilot.csproj'
+      - 'Directory.Packages.props'
+      - 'Directory.Build.props'
+      - 'global.json'
       - '.github/workflows/mcp-scanner.yml'
   # Weekly cron as a backstop for findings introduced by upstream regex /
   # tooling drift even without code changes on our side.
@@ -32,7 +37,19 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+
+# SEC-12: the scan passes vacuously if the server enumerates no tools ("Total tools
+# scanned: 0" + "No results" both match the allowlist). Assert a floor so a partial
+# stdio handshake / enumeration regression fails the gate. The real count is 28
+# (docs/security.md); 26 leaves slack for a deliberately-removed tool.
+env:
+  MIN_TOOLS: 26
+
+# WM-35: cancel superseded PR runs (this scan is expensive: build + scan). Cron runs
+# never share a PR number, so github.ref keeps them uncancelled.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   scan:
@@ -169,19 +186,32 @@ jobs:
             --stdio-arg=net10.0 \
             --stdio-arg=--no-build \
             --stderr-file=/tmp/maf-server.log \
-            > scan-results.txt 2>&1 || true
+            > scan-results.txt 2> scanner-stderr.log || true
           echo "Scanner output:"
           cat scan-results.txt
+          echo ""
+          # WM-13: keep the scanner's OWN stderr OUT of the allowlisted results file.
+          # A benign stderr line (urllib/Python warning) previously merged into
+          # scan-results.txt via 2>&1 and permanently red-ed the allowlist gate. It's
+          # visible here in the log but can no longer forge or break the verdict.
+          echo "--- Scanner stderr ---"
+          cat scanner-stderr.log 2>/dev/null || echo "(empty)"
           echo ""
           echo "--- Server bootstrap log ---"
           cat /tmp/maf-server.log 2>/dev/null || echo "(empty)"
 
+      # SEC-11: this job stdio-launches and scans PR-supplied (possibly fork,
+      # untrusted) code, so it must NOT hold `pull-requests: write`. Instead of
+      # posting the comment here (which 403s on fork PRs and would need write
+      # scope during untrusted execution), build the comment body + PR number and
+      # upload them as an artifact; the workflow_run companion
+      # (maf-pr-audit-comment.yml) posts the sticky comment from the base-repo
+      # context with a write token but WITHOUT ever touching fork code.
       - name: Build PR comment body
         if: github.event_name == 'pull_request' && !cancelled()
         # !cancelled() (not always(), not the implicit success()-only default)
         # — runs whether the scan step above passed or failed the gate below,
-        # so the comment explaining WHY still posts, but not if the job was
-        # cancelled outright.
+        # so the comment explaining WHY still gets produced, unless cancelled.
         run: |
           {
             echo '### 🔍 Cisco mcp-scanner result'
@@ -189,6 +219,18 @@ jobs:
             echo '```'
             cat scan-results.txt 2>/dev/null || echo '(no output)'
             echo '```'
+            # WM-13: surface any scanner stderr in the comment so a maintainer can
+            # tell noise from findings without log-diving. Only when non-empty.
+            if [ -s scanner-stderr.log ]; then
+              echo ''
+              echo '<details><summary>Scanner stderr (noise, not findings)</summary>'
+              echo ''
+              echo '```'
+              cat scanner-stderr.log
+              echo '```'
+              echo ''
+              echo '</details>'
+            fi
             echo ''
             echo '<sub>Scan covers prompt-injection, tool-poisoning, credential-harvesting,'
             echo 'code-execution, parameter-injection, cross-origin-escalation, and rug-pull'
@@ -197,12 +239,20 @@ jobs:
             echo 'exact pass/fail evaluation.</sub>'
           } > pr-comment.md
 
-      - name: Post scan results as PR comment
+      - name: Write PR number for the comment companion
         if: github.event_name == 'pull_request' && !cancelled()
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0  # v2.9.2
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}   # numeric; env-redirect per templating discipline
+        run: echo "$PR_NUMBER" > pr-number.txt
+
+      - name: Upload scan result for the comment companion (SEC-11)
+        if: github.event_name == 'pull_request' && !cancelled()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          header: mcp-scanner-result
-          path: pr-comment.md
+          name: mcp-scanner-result
+          path: |
+            pr-comment.md
+            pr-number.txt
 
       - name: Evaluate scan result (hard-fail gate)
         # F-16 — the actual pass/fail decision, deliberately separated from
@@ -258,4 +308,43 @@ jobs:
             echo "::error::mcp-scanner reported findings (or produced an unexpected output shape) — see the 'Run mcp-scanner' step output above (and the PR comment, if this is a pull_request run)."
             exit 1
           fi
-          echo "Clean scan confirmed — no findings."
+          # SEC-12: a server that enumerates ZERO/too few tools passes the allowlist
+          # vacuously ("Total tools scanned: 0" + "No results" both match). Assert a floor
+          # so an enumeration regression / partial handshake fails closed.
+          N=$(printf '%s\n' "$NONBLANK" | grep -oE '^Total tools scanned: [0-9]+$' | grep -oE '[0-9]+$')
+          if [ "${N:-0}" -lt "${MIN_TOOLS}" ]; then
+            echo "::error::Only ${N:-0} tools scanned (expected >= ${MIN_TOOLS} — enumeration regressed or the stdio handshake was partial). Failing closed."
+            exit 1
+          fi
+          echo "Clean scan confirmed — no findings (${N} tools scanned)."
+
+  # WM-29: scheduled-scan failures were a silent red X — the same silent-failure class
+  # Phase 2.1 fixed for the watcher / drift detector. Scoped to the cron so PR failures
+  # (already loud via the required check) don't double-report; dedupes onto its OWN
+  # rolling issue (the title carries this workflow's distinct name).
+  notify-on-failure:
+    needs: [scan]
+    if: failure() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Open or update a failure tracking issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW: ${{ github.workflow }}
+        run: |
+          gh label create maf-release --color 0E8A16 \
+            --description "Auto-generated by maf-release-watcher / fill workflows" --force || true
+          TITLE="🔴 Self-update workflow failed: ${WORKFLOW}"
+          NUM=$(gh issue list --label maf-release --state open --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" | head -1)
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --body "Failed again: ${RUN_URL}"
+            echo "Commented on existing failure issue #${NUM}"
+          else
+            gh issue create --title "${TITLE}" --label maf-release \
+              --body "The scheduled **${WORKFLOW}** workflow failed. Most recent failed run: ${RUN_URL}. Updated (not duplicated) on subsequent failures; close once fixed."
+            echo "Opened new failure issue"
+          fi


### PR DESCRIPTION
## Phase 8 — CI: PR-time scanning & merge gates (Fable 5 remediation)

11 findings. Applies the Phase-7 stdout/stderr convention to the scanner + PR-audit, resolves the required-check-vs-paths-filter contradiction, and moves comment-posting out of jobs that execute untrusted PR code.

### mcp-scanner.yml
- **WM-13**: scanner stderr no longer merges into the allowlisted results file (was `2>&1`) — benign stderr can't red the gate.
- **SEC-12**: assert a `MIN_TOOLS` floor (26) so "Total tools scanned: 0" / a partial handshake fails **closed**.
- **SEC-30**: path filter drops the nonexistent csproj and adds the CPM/build inputs.
- **WM-29**: a cron-scoped `notify-on-failure` job (own rolling issue).

### SEC-11 — fork-safe commenting (mcp-scanner, maf-ai-fill-verify, companion)
Both scan/verify jobs run untrusted PR code, so they **no longer hold `pull-requests: write`**. Each uploads its comment body + PR number as an artifact; `maf-pr-audit-comment.yml` is **generalized** to post the sticky comment for all three producers (branching artifact/header/body on the upstream workflow name) from the base-repo context, without ever touching fork code. The companion tolerates an out-of-scope producer that uploads no artifact (clean no-op).

### maf-pr-audit.yml
- **SEC-16**: remove the `paths:` filter — runs on every PR, the in-job scope step skips (green) when no product code changed, so it's safely **requireable**.
- **REP-29**: capture doctor stdout/stderr separately; stderr appended as a collapsed block only on failure.
- **REP-41**: rename the step + correct the steering doc (CI comment is the product-scoped `doctor`, not the diff-scoped `MafAuditPullRequest`).

### Standalone
- **REP-30**: comment truncation at a line boundary + strip partial UTF-8 (`iconv -c`) + re-balance code fences.
- **WM-14**: ci-invariants templating discipline also covers single-line `run:` scalars + the `github.event.pull_request/issue/comment/review/commit` free-text injection lanes (safe number/sha leaves allowlisted). Tree clean under the widened gate.
- **WM-35**: cancel-in-progress concurrency on the PR-triggered workflows.

### Verification
All six edited workflow YAML files validate; the widened templating check is clean on the tree; **96 `.github/scripts` Python tests pass**. (Comment/gate behavior is exercised by CI's own runs — this PR's checks run through the modified gates.)

_No GitHub Copilot review requested (per project instruction)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)