### PR TITLE
fix(doctor): make the scored report scannable — space + rule off findings

### DIFF
--- a/src/maf-autopilot.Tests/DoctorToolTests.cs
+++ b/src/maf-autopilot.Tests/DoctorToolTests.cs
@@ -363,6 +363,43 @@ public class DoctorToolTests
         finally { Directory.Delete(tempDir, recursive: true); }
     }
 
+    // -------------------------------------------------------------------------
+    // Report readability — the default "Top fixes" list must space findings out
+    // and rule them off from one another so the report is scannable. Locks the
+    // shape against a silent regression to the old back-to-back rendering.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void DefaultReport_SeparatesFindings_WithBlankLineAndRule()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), "maf-doctor-readability-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            // Two findings (same rule, two files) → two entries in the default top-fixes list.
+            foreach (var name in new[] { "A.cs", "B.cs" })
+                File.WriteAllText(Path.Combine(tempDir, name), $$"""
+                    using Azure.Identity;
+                    public class {{name[..1]}}x
+                    {
+                        public {{name[..1]}}x() { var c = new DefaultAzureCredential(); }
+                    }
+                    """);
+
+            var output = new DoctorTool().MafDoctor(tempDir); // default (top-fixes) markdown
+            var norm = output.Replace("\r\n", "\n");
+
+            // Bold-number headers (literal text, NOT a `1.`/`2.` ordered-list item, so the
+            // rule between findings can't break list numbering).
+            Assert.Contains("**1. [", norm, StringComparison.Ordinal);
+            Assert.Contains("**2. [", norm, StringComparison.Ordinal);
+            // A horizontal rule sits between the two findings, blank-line padded on both
+            // sides (the leading blank line is what keeps `---` an <hr>, not a setext <h2>).
+            Assert.Contains("\n\n---\n\n", norm, StringComparison.Ordinal);
+        }
+        finally { Directory.Delete(tempDir, recursive: true); }
+    }
+
     [Fact]
     public void Json_Finding_CarriesWhy()
     {

--- a/src/maf-autopilot/Tools/DoctorTool.cs
+++ b/src/maf-autopilot/Tools/DoctorTool.cs
@@ -690,17 +690,33 @@ public sealed class DoctorTool
         var i = 1;
         foreach (var fix in s.TopFixes)
         {
+            // Readability: space each finding out and rule it off from the previous one
+            // so the list is scannable (report-readability follow-up). Two markdown traps
+            // dictate the exact shape:
+            //   1. The header is bold *literal* text ("**N. [Source]** …"), not a real
+            //      "N." ordered-list item, so the `---` rule between findings can't reset
+            //      or terminate list numbering the way an <hr> does inside an <ol>.
+            //   2. A `---` on the line directly under text is a setext-heading underline
+            //      (it would promote that line to an <h2>). The blank line before every
+            //      `---` keeps it an <hr>.
+            if (i > 1)
+            {
+                sb.AppendLine();
+                sb.AppendLine("---");
+                sb.AppendLine();
+            }
             // SEC-02: the untrusted file path inside Description is neutralized at its
             // construction in Grade() (so tool-authored markdown here — backticks around
             // method/type names — is preserved). The code-span echo below is neutralized too.
-            sb.AppendLine($"{i}. **[{fix.Source}]** {fix.Description} · _{FixTag(fix)}_");
-            if (!string.IsNullOrEmpty(fix.Why)) sb.AppendLine($"   - **Why:** {fix.Why}");
-            if (!string.IsNullOrEmpty(fix.FixDescription)) sb.AppendLine($"   - **Fix:** {fix.FixDescription}");
+            sb.AppendLine($"**{i}. [{fix.Source}]** {fix.Description} · _{FixTag(fix)}_");
+            sb.AppendLine();
+            if (!string.IsNullOrEmpty(fix.Why)) sb.AppendLine($"- **Why:** {fix.Why}");
+            if (!string.IsNullOrEmpty(fix.FixDescription)) sb.AppendLine($"- **Fix:** {fix.FixDescription}");
             var (src, redacted) = TryReadSourceLine(repoPath, fix.File, fix.Line, lineCache);
             if (redacted)
-                sb.AppendLine($"   - `{LlmFencing.MdInline(fix.File)}:{fix.Line}` → _(source line redacted — may contain a secret)_");
+                sb.AppendLine($"- `{LlmFencing.MdInline(fix.File)}:{fix.Line}` → _(source line redacted — may contain a secret)_");
             else if (src is not null)
-                sb.AppendLine($"   - `{LlmFencing.MdInline(fix.File)}:{fix.Line}` → `{src}`");
+                sb.AppendLine($"- `{LlmFencing.MdInline(fix.File)}:{fix.Line}` → `{src}`");
             i++;
         }
         sb.AppendLine();
@@ -722,11 +738,21 @@ public sealed class DoctorTool
         sb.AppendLine($"### All findings ({fixes.Count} across {groups.Count} rule(s), grouped + ordered by impact)");
         sb.AppendLine();
 
+        var firstGroup = true;
         foreach (var g in groups)
         {
             var rep = g.Rep;
             var tag = FixTag(rep);
             var count = g.Items.Count > 1 ? $" ×{g.Items.Count}" : "";
+            // Rule each group off from the previous one, matching the default report's
+            // rhythm. Each group already ends with a blank line, so the `---` here is
+            // always preceded by one (no setext-heading promotion of the line above).
+            if (!firstGroup)
+            {
+                sb.AppendLine("---");
+                sb.AppendLine();
+            }
+            firstGroup = false;
             // Use a rule-generic title (not the representative's per-instance Issue),
             // so a group of distinct fan-out methods / cost sites isn't mislabeled
             // with one member's specifics under a ×N count.


### PR DESCRIPTION
## What

User feedback: scoring an app with `maf-doctor doctor` produced results that were **hard to read** — findings, their Why/Fix, and source lines ran together with no vertical spacing and no separator between issues. A few blank lines and dashed rules between findings "would make a world of difference."

This makes the default report scannable.

## Root cause

`AppendTopFixes` (the default "Top fixes" renderer) appended each finding's header + Why + Fix + source line **back-to-back**; the only blank line landed *after* the whole loop. The earlier reporting work (Fable-5 phases 4a/4b/5/6 + the doctor-suggestion tiers) improved the *content* of each finding — never the whitespace *between* them — so this was an untouched gap, not a regression.

## Change

**Human markdown report only.** `--json`, `--plan`, `--plan-json`, and SARIF are schema contracts and are **byte-for-byte unchanged**.

- **Top-fixes list:** a blank line after each finding's bold header, and a `---` rule (blank-line padded) between findings.
- **`--all` grouped view:** the same `---` rule between rule-groups, matching the default report's rhythm.

### Rendered before → after (default report)

```
BEFORE
1. **[MafScanAntiPatterns]** MAF-AP-SEC-001 at AuthorAgent.cs:4 … · _auto-fixable_
   - **Why:** …
   - **Fix:** …
   - `AuthorAgent.cs:4` → `…`
2. **[MafScanAntiPatterns]** MAF-AP-SEC-001 at BloggerAgent.cs:4 … · _auto-fixable_
   - **Why:** …

AFTER
**1. [MafScanAntiPatterns]** MAF-AP-SEC-001 at AuthorAgent.cs:4 … · _auto-fixable_

- **Why:** …
- **Fix:** …
- `AuthorAgent.cs:4` → `…`

---

**2. [MafScanAntiPatterns]** MAF-AP-SEC-001 at BloggerAgent.cs:4 … · _auto-fixable_

- **Why:** …
```

## Two markdown traps handled deliberately

1. Finding headers are now bold **literal** text (`**N. [Source]** …`) instead of real `N.` ordered-list items, so an `<hr>` between them can't reset/terminate list numbering the way it does inside an `<ol>`. Sub-items become a plain top-level bullet list.
2. A blank line precedes **every** `---`, so it renders as an `<hr>` and never as a setext-heading underline that would promote the line above it to an `<h2>`.

## Tests

- Existing `DoctorToolTests` are content-based and stay green (**85 pass on net8**).
- Added `DefaultReport_SeparatesFindings_WithBlankLineAndRule` — locks the new rhythm (bold-number headers + a blank-line-padded `---` between findings) against a silent regression.
- Manually rendered the real report on a 2-finding and a multi-rule sample to eyeball spacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
