### PR TITLE
Fail fast on watcher credential errors

### DIFF
--- a/.github/workflows/maf-release-watcher.yml
+++ b/.github/workflows/maf-release-watcher.yml
@@ -29,7 +29,7 @@ permissions:
 
 jobs:
   # Phase 3.1 — validate workflow_dispatch input BEFORE any privileged step
-  # runs. The watcher has COPILOT_ASSIGN_PAT in scope on the main job; a
+  # runs. The watcher uses COPILOT_ASSIGN_PAT for its final push; a
   # malformed `maf_version` would otherwise template into shell-interpreted
   # contexts downstream.
   validate-inputs:
@@ -200,29 +200,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          # Use the maintainer's PAT, not the workflow's GITHUB_TOKEN. Round-3
-          # review fixup: this comment used to justify the PAT as needed to
-          # bypass branch protection on a direct push to main — stale since
-          # the 2026-06-28 "C" refactor (see "Commit to a release-watcher
-          # branch and open a PR" below), which pushes to a per-version
-          # branch and opens a PR instead. The PAT is still required, for a
-          # different reason: GitHub does not trigger `on: pull_request`
-          # workflows (build-test.yml, maf-pr-audit.yml, mcp-scanner.yml —
-          # all required checks) for a PR opened with the default
-          # GITHUB_TOKEN. Without a PAT, the scaffold PR this job opens would
-          # sit with none of its required checks ever running.
-          #
-          # Commit identity is still github-actions[bot] (set explicitly via
-          # `git config` below). The PAT is only used for the push auth header.
-          #
-          # COPILOT_ASSIGN_PAT is a SHARED fine-grained PAT (this repo only). Its
-          # FULL required scope — Issues + Contents + Pull requests + Actions R/W
-          # — is documented in maf-ai-fill-todos.yml (which also uses it to assign
-          # the Coding Agent). The watcher only exercises the Contents R/W portion
-          # here (the push). Provision the full union, NOT Contents-only, or the
-          # fill workflow's assignment breaks. Falls back to GITHUB_TOKEN if unset,
-          # which will fail the push (loud, not silent). [task 3.5]
-          token: ${{ secrets.COPILOT_ASSIGN_PAT || secrets.GITHUB_TOKEN }}
+          # Checkout is read-only and must not depend on a long-lived maintainer
+          # PAT. An expired COPILOT_ASSIGN_PAT previously prevented even this
+          # public-repository fetch, before the workflow could explain the fault.
+          token: ${{ secrets.GITHUB_TOKEN }}
           # F-06 (2026-07-19 security assessment) — persist-credentials defaults
           # to true, which embeds this PAT into .git/config for the ENTIRE job:
           # every later step (dotnet-inspect diff, python helpers, dotnet build)
@@ -231,6 +212,21 @@ jobs:
           # before the single `git push` call in "Commit to a release-watcher
           # branch and open a PR".
           persist-credentials: false
+
+      - name: Validate maintainer PAT before analysis
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::COPILOT_ASSIGN_PAT is missing. Add a repository-scoped fine-grained PAT before running the watcher."
+            exit 1
+          fi
+          if ! gh api user --silent || ! gh api "repos/$GH_REPO" --silent; then
+            echo "::error::COPILOT_ASSIGN_PAT is expired, revoked, or cannot read $GH_REPO. Rotate the repository secret before rerunning."
+            exit 1
+          fi
+          echo "Maintainer PAT is valid and can access $GH_REPO."
 
       - name: Setup .NET
         # Round-4 review fixup — continue-on-error, matching this same file's
@@ -498,7 +494,10 @@ jobs:
           OLD_VERSION: ${{ needs.check-for-new-maf-release.outputs.old_version }}
           IS_MAJOR: ${{ needs.check-for-new-maf-release.outputs.is_major }}
           VERDICT: ${{ steps.classify.outputs.verdict }}
-          GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT || secrets.GITHUB_TOKEN }}
+          # A human token is intentional here: GitHub suppresses pull_request
+          # workflow events for branches/PRs created with GITHUB_TOKEN. Never
+          # fall back silently, or the scaffold PR opens without its CI checks.
+          GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
           PUSH_TARGET: ${{ inputs.push_target }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}  # REP-34
         run: |
@@ -657,6 +656,7 @@ jobs:
       - name: Open or update a failure tracking issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           WORKFLOW: ${{ github.workflow }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Semantic review restored after GitHub Models retirement.** The workflow now
   uses GitHub Copilot CLI with the short-lived `GITHUB_TOKEN`, an exact-pinned
   CLI, and no enabled Copilot tools.
+- **Watcher credentials fail early and clearly.** Read-only checkout now uses
+  `GITHUB_TOKEN`; the maintainer token is validated before analysis and reserved
+  for the CI-triggering push. Failure notification now identifies the repository
+  explicitly instead of requiring a nonexistent checkout.
 - **Release backlogs no longer skip intermediate stable MAF versions.** The watcher selects the oldest untracked stable release and permits only one scaffold PR in flight, preserving per-version compatibility rows and migration guides when Microsoft ships more than once between weekly runs.
 - **Cost audit false positives removed.** CLI command entry points and the built MCP/host `RunAsync()` loop are no longer mistaken for uncapped agent inference calls.
 - **MCP scanner cache made runner-writable.** pipx now installs and caches under the workspace instead of `/opt`, eliminating tar permission failures and perpetual cache misses on hosted runners.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -194,6 +194,12 @@ owner's Copilot seat. Copilot tools are not enabled in that workflow.
 2. Add each secret by its exact name.
 3. Scope `NUGET_API_KEY` to package push. Scope `COPILOT_ASSIGN_PAT` to Metadata R plus Issues, Contents, and Pull requests R/W on this repository only.
 
+The watcher uses `GITHUB_TOKEN` for its read-only checkout, validates
+`COPILOT_ASSIGN_PAT` before doing expensive analysis, and reserves that token
+for the final branch push/PR operation. It deliberately does not fall back to
+`GITHUB_TOKEN` for the push: GitHub suppresses downstream `pull_request` events
+for changes made by that token, which would create a scaffold PR with no CI.
+
 > The `GITHUB_TOKEN` secret is automatically provided by GitHub Actions — no setup needed.
 
 ---


### PR DESCRIPTION
## What changed

- Use the short-lived `GITHUB_TOKEN` for the watcher's read-only checkout.
- Validate `COPILOT_ASSIGN_PAT` before expensive MAF diff/build work.
- Remove the silent `GITHUB_TOKEN` fallback from the final push because it would suppress downstream pull-request CI.
- Set `GH_REPO` in the no-checkout failure notifier so `gh` does not try to infer a repository from a missing `.git` directory.

## Root cause

The configured maintainer token is non-empty but rejected by GitHub, so `actions/checkout` failed before analysis. The notifier then failed independently because it runs without checkout and had no explicit repository.

## Impact

Expired/revoked automation credentials now produce an immediate, actionable error and a working tracking issue. Read-only source checkout no longer depends on the long-lived credential.

## Validation

- All 12 workflow YAML files parsed locally.
- `python -m pytest .github/scripts/tests -q`: 106 passed.
- `git diff --check`: passed.
- Failure reproduced in watcher run 32047010617.