### PR TITLE
Ignore fenced evidence in scaffold guide parsing

### DIFF
--- a/.github/scripts/tests/test_verify_ai_fill_delta.py
+++ b/.github/scripts/tests/test_verify_ai_fill_delta.py
@@ -203,6 +203,74 @@ def test_additive_scaffold_can_record_zero_generated_registry_entries(tmp_path: 
     assert verify_obligations(doc, tmp_path, raw) == []
 
 
+def test_scaffold_ignores_guide_headings_inside_fenced_package_evidence(tmp_path: Path):
+    fenced = """<<<BEGIN_USER_DATA_0123456789abcdef0123456789abcdef_UPSTREAM-MAF-DIFF-CORE>>>
+## Package API Evidence
+## Release Notes Extract
+## Breaking Changes
+<<<END_USER_DATA_0123456789abcdef0123456789abcdef_UPSTREAM-MAF-DIFF-CORE>>>"""
+    _write(
+        tmp_path,
+        "guides/maf-1.14.0-migration-guide.md",
+        TARGET_GUIDE.replace("```text\n- [Removed] Agent.RunAsync()\n```", fenced),
+    )
+    _write(tmp_path, ".maf-version", "1.14.0\n")
+    _write(
+        tmp_path,
+        ".github/skills/maf-obsolete-api-registry/registry.yaml",
+        yaml.safe_dump(_registry(), sort_keys=False),
+    )
+    _write(tmp_path, "guides/maf-1.13.0-migration-guide.md", "historical guide\n")
+    _write(
+        tmp_path,
+        "docs/compatibility-matrix.md",
+        "matrix prefix\n| **1.14.0** | target TODO |\n| **1.13.0** | historical |\ntracking 1.14.0\n",
+    )
+    _write(tmp_path, "src/maf-autopilot/Tools/CompatibilityTool.cs", TOOL)
+
+    document = build_obligations(
+        tmp_path,
+        old_version="1.13.0",
+        target_version="1.14.0",
+        base_commit="a" * 40,
+        target_branch="release-watcher/maf-1.14.0",
+    )
+    assert document["target_guide"]["evidence_sha256"]
+
+
+def test_scaffold_rejects_unterminated_upstream_data_fence(tmp_path: Path):
+    _write(
+        tmp_path,
+        "guides/maf-1.14.0-migration-guide.md",
+        TARGET_GUIDE.replace(
+            "```text\n- [Removed] Agent.RunAsync()\n```",
+            "<<<BEGIN_USER_DATA_0123456789abcdef0123456789abcdef_UPSTREAM-MAF-DIFF-CORE>>>\n## Breaking Changes",
+        ),
+    )
+    _write(tmp_path, ".maf-version", "1.14.0\n")
+    _write(
+        tmp_path,
+        ".github/skills/maf-obsolete-api-registry/registry.yaml",
+        yaml.safe_dump(_registry(), sort_keys=False),
+    )
+    _write(tmp_path, "guides/maf-1.13.0-migration-guide.md", "historical guide\n")
+    _write(
+        tmp_path,
+        "docs/compatibility-matrix.md",
+        "matrix prefix\n| **1.14.0** | target TODO |\n| **1.13.0** | historical |\ntracking 1.14.0\n",
+    )
+    _write(tmp_path, "src/maf-autopilot/Tools/CompatibilityTool.cs", TOOL)
+
+    with pytest.raises(ValueError, match="unterminated upstream-data fence"):
+        build_obligations(
+            tmp_path,
+            old_version="1.13.0",
+            target_version="1.14.0",
+            base_commit="a" * 40,
+            target_branch="release-watcher/maf-1.14.0",
+        )
+
+
 @pytest.mark.parametrize(
     ("relative", "old", "new", "message"),
     [

--- a/.github/scripts/verify_ai_fill_delta.py
+++ b/.github/scripts/verify_ai_fill_delta.py
@@ -32,6 +32,9 @@ AUTO_END = "<!-- AUTO-GENERATED END -->"
 BREAKING_RE = re.compile(
     r"^## Breaking Changes(?: \(requires human verification\))?\r?$", re.MULTILINE
 )
+FENCE_BEGIN_RE = re.compile(
+    r"^<<<BEGIN_(USER_DATA_[0-9a-f]{32}_[A-Z0-9._-]{1,64})>>>$"
+)
 
 
 def _contract_rel(version: str) -> str:
@@ -111,21 +114,42 @@ def _historical_registry_hash(doc: dict[str, Any], target: str) -> str:
     return _canonical_hash(historical)
 
 
+def _structural_markdown(text: str, label: str) -> str:
+    """Mask fenced upstream data while preserving source offsets and newlines."""
+    visible: list[str] = []
+    expected_end: str | None = None
+    for line in text.splitlines(keepends=True):
+        bare = line.rstrip("\r\n")
+        if expected_end is None:
+            begin = FENCE_BEGIN_RE.fullmatch(bare)
+            if begin is None:
+                visible.append(line)
+                continue
+            expected_end = f"<<<END_{begin.group(1)}>>>"
+        elif bare == expected_end:
+            expected_end = None
+        visible.append("".join(ch if ch in "\r\n" else " " for ch in line))
+    if expected_end is not None:
+        raise ValueError(f"{label} guide contains an unterminated upstream-data fence")
+    return "".join(visible)
+
+
 def _guide_regions(text: str, label: str) -> tuple[str, str, str]:
     if text.count(AUTO_START) != 1 or text.count(AUTO_END) != 1:
         raise ValueError(f"{label} guide must contain exactly one AUTO marker pair")
     auto_start, auto_end = text.index(AUTO_START), text.index(AUTO_END)
     if auto_start >= auto_end:
         raise ValueError(f"{label} guide AUTO markers are out of order")
-    breaks = [m for m in BREAKING_RE.finditer(text) if auto_start < m.start() < auto_end]
+    structural = _structural_markdown(text, label)
+    breaks = [m for m in BREAKING_RE.finditer(structural) if auto_start < m.start() < auto_end]
     packages = [
         m
-        for m in re.finditer(r"^## Package API Evidence\r?$", text, re.MULTILINE)
+        for m in re.finditer(r"^## Package API Evidence\r?$", structural, re.MULTILINE)
         if auto_start < m.start() < auto_end
     ]
     notes = [
         m
-        for m in re.finditer(r"^## Release Notes Extract\r?$", text, re.MULTILINE)
+        for m in re.finditer(r"^## Release Notes Extract\r?$", structural, re.MULTILINE)
         if auto_start < m.start() < auto_end
     ]
     if len(breaks) != 1 or len(packages) != 1 or len(notes) != 1:


### PR DESCRIPTION
## What changed

- Ignore headings inside `llm_fencing` upstream-data blocks when locating protected migration-guide sections.
- Fail closed on unterminated upstream-data fences.
- Add positive and malformed-fence regression tests.

## Root cause

The corrected 1.14 watcher generated valid evidence for ten package surfaces. The immutable-obligations builder then counted each fenced `## Breaking Changes` API-diff heading as an editable guide heading and rejected its own scaffold.

## Validation

- Exact generated guide from watcher run `32059070056` passes the patched parser.
- Focused obligations suite: 20 passed.
- Full workflow-helper suite: 292 passed.
- Independent read-only security review: no blocker.
