### PR TITLE
Ignore fenced upstream evidence in guide consistency checks

### DIFF
--- a/.github/scripts/tests/test_verify_crossfile_consistency.py
+++ b/.github/scripts/tests/test_verify_crossfile_consistency.py
@@ -128,6 +128,20 @@ None detected in the validated public API diffs.
 None documented yet.
 """
 
+UPSTREAM_FENCE_START = (
+    "<<<BEGIN_USER_DATA_0123456789abcdef0123456789abcdef_"
+    "UPSTREAM-MAF-DIFF-CORE>>>"
+)
+UPSTREAM_FENCE_END = (
+    "<<<END_USER_DATA_0123456789abcdef0123456789abcdef_"
+    "UPSTREAM-MAF-DIFF-CORE>>>"
+)
+
+
+def _fenced_upstream(body: str, *, close: bool = True) -> str:
+    ending = f"\n{UPSTREAM_FENCE_END}" if close else ""
+    return f"{UPSTREAM_FENCE_START}\n{body}{ending}"
+
 
 def test_unresolved_generated_guide_is_flagged(tmp_path):
     guide = _write_current_guide(
@@ -144,6 +158,70 @@ def test_resolved_generated_guide_passes(tmp_path):
         COMPLETE_GUIDE_SECTIONS,
     )
     assert v.check_current_guide_contract(guide) == []
+
+
+def test_package_evidence_headings_and_todos_are_ignored(tmp_path):
+    evidence = _fenced_upstream(
+        """## Breaking Changes
+<!-- TODO: this is untrusted upstream text, not an analysis placeholder -->
+## New Patterns
+## Obsolete APIs Added
+## Known Misalignments"""
+    )
+    guide = _write_current_guide(
+        tmp_path,
+        f"## Package API Evidence\n\n{evidence}\n\n{COMPLETE_GUIDE_SECTIONS}",
+    )
+
+    assert v.check_current_guide_contract(guide) == []
+
+
+def test_fenced_headings_cannot_satisfy_required_analysis_sections(tmp_path):
+    evidence_only = _fenced_upstream(
+        """## Breaking Changes
+Upstream-controlled prose that looks substantive.
+## New Patterns
+Upstream-controlled prose that looks substantive.
+## Obsolete APIs Added
+Upstream-controlled prose that looks substantive.
+## Known Misalignments
+Upstream-controlled prose that looks substantive."""
+    )
+    findings = v.check_current_guide_contract(
+        _write_current_guide(tmp_path, evidence_only)
+    )
+
+    for section in (
+        "Breaking Changes",
+        "New Patterns",
+        "Obsolete APIs Added",
+        "Known Misalignments",
+    ):
+        assert any(f"exactly one '{section}'" in finding for finding in findings)
+
+
+def test_fenced_payload_cannot_make_analysis_section_substantive(tmp_path):
+    body = COMPLETE_GUIDE_SECTIONS.replace(
+        "- Continue using the supported agent construction pattern.",
+        _fenced_upstream("This upstream-controlled text is not reviewed analysis."),
+    )
+    findings = v.check_current_guide_contract(_write_current_guide(tmp_path, body))
+
+    assert any(
+        "New Patterns" in finding and "substantive" in finding
+        for finding in findings
+    )
+
+
+def test_unterminated_upstream_fence_is_flagged(tmp_path):
+    guide = _write_current_guide(
+        tmp_path,
+        _fenced_upstream("## Breaking Changes", close=False),
+    )
+
+    findings = v.check_current_guide_contract(guide)
+
+    assert any("unterminated upstream-data fence" in finding for finding in findings)
 
 
 def test_deleting_required_guide_sections_is_flagged(tmp_path):

--- a/.github/scripts/verify_crossfile_consistency.py
+++ b/.github/scripts/verify_crossfile_consistency.py
@@ -69,6 +69,9 @@ GUIDE_SECTION_HEADING_RE = re.compile(
     r'^##+\s+(\d+(?:\.\d+)*)\.', re.MULTILINE
 )
 GENERATED_TODO_RE = re.compile(r'<!--\s*TODO:', re.IGNORECASE)
+UPSTREAM_FENCE_BEGIN_RE = re.compile(
+    r"^<<<BEGIN_(USER_DATA_[0-9a-f]{32}_[A-Z0-9._-]{1,64})>>>$"
+)
 
 
 def find_duplicate_rows(text: str) -> list[str]:
@@ -290,6 +293,39 @@ def check_invented_guide_sections(
     return findings
 
 
+def _mask_upstream_fences(text: str) -> str:
+    """Hide fenced upstream data without changing offsets or line endings.
+
+    Package diffs and release notes are deliberately embedded inside randomized
+    ``USER_DATA`` fences. Their payload is evidence, not guide structure: a
+    heading or TODO-looking comment supplied by an upstream package must not be
+    counted as maintainer-authored analysis. Replacing every non-newline
+    character with a space keeps regex match offsets aligned with ``text``.
+
+    A recognized opening fence without its exact randomized closing marker is
+    rejected instead of masking the rest of the guide, so malformed evidence
+    cannot hide required sections.
+    """
+    masked: list[str] = []
+    expected_end: str | None = None
+    for line in text.splitlines(keepends=True):
+        bare = line.rstrip("\r\n")
+        if expected_end is None:
+            begin = UPSTREAM_FENCE_BEGIN_RE.fullmatch(bare)
+            if begin is None:
+                masked.append(line)
+                continue
+            expected_end = f"<<<END_{begin.group(1)}>>>"
+        elif bare == expected_end:
+            expected_end = None
+
+        masked.append("".join(ch if ch in "\r\n" else " " for ch in line))
+
+    if expected_end is not None:
+        raise ValueError("guide contains an unterminated upstream-data fence")
+    return "".join(masked)
+
+
 def check_current_guide_contract(guide_path: Path) -> list[str]:
     """Require a complete, substantive set of generated migration sections."""
     if not guide_path.is_file():
@@ -317,7 +353,13 @@ def check_current_guide_contract(guide_path: Path) -> list[str]:
         return findings
 
     generated = text[start + len(AUTO_START):end]
-    if GENERATED_TODO_RE.search(generated):
+    try:
+        structural = _mask_upstream_fences(generated)
+    except ValueError as exc:
+        findings.append(f"{guide_path}: {exc}")
+        return findings
+
+    if GENERATED_TODO_RE.search(structural):
         findings.append(
             f"{guide_path}: the AUTO-GENERATED block still contains one or more "
             "'<!-- TODO:' placeholders; replace every generated placeholder "
@@ -332,7 +374,7 @@ def check_current_guide_contract(guide_path: Path) -> list[str]:
     )
     matches: list[tuple[str, re.Match[str]]] = []
     for name, pattern in required:
-        found = list(re.finditer(pattern, generated, re.MULTILINE))
+        found = list(re.finditer(pattern, structural, re.MULTILINE))
         if len(found) != 1:
             findings.append(
                 f"{guide_path}: expected exactly one '{name}' section inside "
@@ -355,9 +397,9 @@ def check_current_guide_contract(guide_path: Path) -> list[str]:
         section_end = (
             ordered_matches[index + 1][1].start()
             if index + 1 < len(ordered_matches)
-            else len(generated)
+            else len(structural)
         )
-        body = generated[match.end():section_end]
+        body = structural[match.end():section_end]
         body = re.sub(r"<!--.*?-->", "", body, flags=re.DOTALL)
         meaningful_lines = [
             line.strip()


### PR DESCRIPTION
The cross-file guide gate currently treats headings and TODO-shaped text inside randomized upstream evidence fences as maintainer-authored guide structure. That makes a correctly generated MAF 1.14 guide fail closed before its human analysis can be accepted. This change masks recognized USER_DATA fence regions while preserving character offsets, rejects unterminated fences, and adds regression coverage proving fenced headings cannot satisfy or duplicate required analysis sections. Validation: 58 focused tests passed; 296 full helper-script tests passed; the updated cross-file validator passes on main.