### PR TITLE
Resolve the current trusted PR base for AI-fill verification

### DIFF
--- a/.github/scripts/tests/test_ai_fill_verify_workflow.py
+++ b/.github/scripts/tests/test_ai_fill_verify_workflow.py
@@ -1,4 +1,6 @@
-"""Static trust-boundary contracts for the required AI-fill verifier."""
+"""Trust-boundary contract and behavior tests for the AI-fill verifier."""
+import shlex
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -14,6 +16,28 @@ def _steps() -> list[dict]:
     return document["jobs"]["verify"]["steps"]
 
 
+def _resolver_command() -> list[str]:
+    resolver = next(step for step in _steps() if step.get("id") == "trusted_base")
+    assignment = next(
+        line.strip()
+        for line in resolver["run"].splitlines()
+        if line.strip().startswith("BASE_SHA=$(")
+    )
+    assert assignment.endswith(")")
+    return shlex.split(assignment[len("BASE_SHA=$("):-1])
+
+
+def _git(cwd: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
 def test_pr_data_and_trusted_verifier_use_separate_checkouts():
     checkouts = [
         step
@@ -23,9 +47,80 @@ def test_pr_data_and_trusted_verifier_use_separate_checkouts():
     assert len(checkouts) == 2
     assert checkouts[0]["with"]["ref"] == "${{ github.event.pull_request.head.sha }}"
     assert checkouts[0]["with"]["path"] == "pr"
-    assert checkouts[1]["with"]["ref"] == "${{ github.event.pull_request.base.sha }}"
+    assert checkouts[1]["with"]["ref"] == "${{ github.base_ref }}"
     assert checkouts[1]["with"]["path"] == "trusted"
     assert all(step["with"]["persist-credentials"] is False for step in checkouts)
+
+
+def test_current_trusted_base_sha_drives_scope_and_delta_verification():
+    steps = _steps()
+    resolver = next(step for step in steps if step.get("id") == "trusted_base")
+    scope = next(step for step in steps if step.get("id") == "scope")
+    delta = next(step for step in steps if step.get("id") == "delta")
+    resolved_sha = "${{ steps.trusted_base.outputs.sha }}"
+
+    assert resolver.get("continue-on-error") is not True
+    assert resolver["shell"] == "bash"
+    assert resolver["env"]["BASE_REF"] == "${{ github.base_ref }}"
+    assert "set -euo pipefail" in resolver["run"]
+    assert '[ -z "$BASE_REF" ]' in resolver["run"]
+    assert 'git -C trusted rev-parse --verify "HEAD^{commit}"' in resolver["run"]
+    assert "^([0-9a-f]{40}|[0-9a-f]{64})$" in resolver["run"]
+    assert 'git -C trusted cat-file -e "${BASE_SHA}^{commit}"' in resolver["run"]
+    assert 'echo "sha=$BASE_SHA" >> "$GITHUB_OUTPUT"' in resolver["run"]
+
+    assert scope["env"]["BASE_SHA"] == resolved_sha
+    assert delta["env"]["BASE_SHA"] == resolved_sha
+    assert 'git -C pr fetch --no-tags origin "$BASE_SHA"' in scope["run"]
+    assert 'git -C pr diff --name-only "$BASE_SHA" "$HEAD_SHA"' in scope["run"]
+    assert '--base-sha "$BASE_SHA"' in delta["run"]
+
+
+def test_stale_event_base_sha_cannot_select_or_verify_trusted_code():
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "github.event.pull_request.base.sha" not in workflow
+    assert workflow.count("${{ steps.trusted_base.outputs.sha }}") == 2
+
+
+def test_resolver_command_uses_checked_out_tip_not_an_older_sha(tmp_path):
+    trusted = tmp_path / "trusted"
+    _git(tmp_path, "init", str(trusted))
+    _git(tmp_path, "-C", "trusted", "config", "user.name", "MAF CI Test")
+    _git(tmp_path, "-C", "trusted", "config", "user.email", "ci@example.invalid")
+
+    marker = trusted / "marker.txt"
+    marker.write_text("stale\n", encoding="utf-8")
+    _git(tmp_path, "-C", "trusted", "add", "marker.txt")
+    _git(tmp_path, "-C", "trusted", "commit", "-m", "stale base")
+    stale_event_sha = _git(tmp_path, "-C", "trusted", "rev-parse", "HEAD")
+
+    marker.write_text("current\n", encoding="utf-8")
+    _git(tmp_path, "-C", "trusted", "commit", "-am", "current base")
+    current_tip = _git(tmp_path, "-C", "trusted", "rev-parse", "HEAD")
+
+    resolved = subprocess.run(
+        _resolver_command(),
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    assert stale_event_sha != current_tip
+    assert resolved == current_tip
+
+
+def test_resolver_command_fails_when_trusted_checkout_is_missing(tmp_path):
+    result = subprocess.run(
+        _resolver_command(),
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode != 0
 
 
 def test_scope_discovery_and_verifiers_fail_closed_from_trusted_base():

--- a/.github/workflows/maf-ai-fill-verify.yml
+++ b/.github/workflows/maf-ai-fill-verify.yml
@@ -59,18 +59,42 @@ jobs:
           persist-credentials: false
           path: pr
 
-      - name: Checkout trusted PR base verifier
+      # `pull_request.base.sha` is the base captured when the PR event was
+      # created and can remain stale while a long-running release PR is open.
+      # Resolve the current base branch tip from this separate trusted checkout
+      # and pin every later comparison/verifier invocation to that exact commit.
+      - name: Checkout current trusted PR base verifier
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.base_ref }}
           fetch-depth: 1
           persist-credentials: false
           path: trusted
 
+      - name: Resolve current trusted base SHA
+        id: trusted_base
+        shell: bash
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [ -z "$BASE_REF" ]; then
+            echo "::error::Pull request base ref is empty; refusing to select trusted verifier code."
+            exit 1
+          fi
+          BASE_SHA=$(git -C trusted rev-parse --verify "HEAD^{commit}")
+          if [[ ! "$BASE_SHA" =~ ^([0-9a-f]{40}|[0-9a-f]{64})$ ]]; then
+            echo "::error::Trusted base checkout did not resolve to one exact commit SHA."
+            exit 1
+          fi
+          git -C trusted cat-file -e "${BASE_SHA}^{commit}"
+          echo "sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          echo "Resolved current trusted base $BASE_REF to $BASE_SHA"
+
       - name: Decide whether this PR is in scope
         id: scope
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ steps.trusted_base.outputs.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Task 4.6 — in scope iff the PR DIFF touches a watcher-managed file
@@ -80,8 +104,9 @@ jobs:
           # let a fill PR that forgot the label (or used an unexpected branch
           # prefix) silently report success while verifying NOTHING. Any edit to
           # these files deserves the structural verification.
-          # Scope discovery is fail-closed. Both event SHAs must be reachable and
-          # `git diff` must succeed; an empty list is trusted only after that proof.
+          # Scope discovery is fail-closed. The resolved current base commit and
+          # event HEAD must be reachable and `git diff` must succeed; an empty
+          # list is trusted only after that proof.
           # Full ancestry is required to prove where the immutable obligations
           # blob first appeared; a shallow base fetch makes merge-base ambiguous.
           git -C pr fetch --no-tags origin "$BASE_SHA"
@@ -238,7 +263,7 @@ jobs:
         if: steps.scope.outputs.in_scope == 'true'
         continue-on-error: true
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_SHA: ${{ steps.trusted_base.outputs.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BASE_REF: ${{ github.base_ref }}
           HEAD_REF: ${{ github.head_ref }}


### PR DESCRIPTION
## Why

A pull request event keeps the base SHA captured when the PR event was created. After a verifier fix merges into main, rerunning an older AI-fill PR can therefore execute stale trusted verifier code.

## What changed

- check out the current trusted base branch using github.base_ref
- resolve and validate the exact checked-out commit SHA, failing closed on missing or invalid state
- use that resolved SHA consistently for scope fetch/diff and verify_ai_fill_delta
- retain verify_ai_fill_delta merge-base and linear obligation semantics
- add static data-flow assertions and behavioral Git tests covering stale event SHAs and missing trusted checkouts

## Validation

- python -m pytest .github/scripts/tests/test_ai_fill_verify_workflow.py -q (8 passed)
- python -m pytest .github/scripts/tests -q (300 passed)
- python -m compileall -q .github/scripts
- git diff --check