### PR TITLE
Repair watcher branch reuse and registry metadata

### DIFF
--- a/.github/scripts/tests/test_release_watcher_workflow.py
+++ b/.github/scripts/tests/test_release_watcher_workflow.py
@@ -36,7 +36,32 @@ def test_watcher_commits_a_per_release_immutable_obligations_artifact():
     assert "build_scaffold_obligations.py" in text
     assert '.github/maf-scaffold-obligations/maf-${NEW_VERSION}.json' in text
     assert "--base-commit \"$BASE_COMMIT\"" in text
-    assert "--target-branch \"$BRANCH\"" in text
+    assert "--target-branch \"$TARGET_BRANCH\"" in text
+
+
+def test_retained_closed_branch_gets_a_fresh_target_reused_end_to_end():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "gh pr list --state open --json number,headRefName" in text
+    assert 'TARGET_BRANCH="${PUSH_TARGET:-release-watcher/maf-${LATEST}}"' in text
+    assert 'TARGET_BRANCH="${TARGET_BRANCH}-run-${RUN_ID}-${RUN_ATTEMPT}"' in text
+    assert "target_branch: ${{ steps.version-check.outputs.target_branch }}" in text
+    downstream = "${{ needs.check-for-new-maf-release.outputs.target_branch }}"
+    assert text.count(downstream) == 2
+    assert 'BRANCH="${PUSH_TARGET:-release-watcher/maf-${NEW_VERSION}}"' not in text
+    assert 'gh pr list --state open --head "$BRANCH"' in text
+    assert 'gh pr view "$BRANCH"' not in text
+    assert "git push --force-with-lease" not in text
+
+
+def test_registry_metadata_is_final_before_obligations_are_recorded():
+    text = WORKFLOW.read_text(encoding="utf-8")
+    evidence_gate = text.index("release_classification.py --require-complete-evidence")
+    version_update = text.index("- name: Update .maf-version")
+    metadata_update = text.index("update_registry_metadata.py")
+    obligations = text.index("build_scaffold_obligations.py")
+    assert evidence_gate < version_update < metadata_update < obligations
+    assert '--target-version "$NEW_VERSION"' in text[metadata_update:obligations]
+    assert '--last-updated "$LAST_UPDATED"' in text[metadata_update:obligations]
 
 
 def test_dedupe_collision_invalidates_extraction_ledger():

--- a/.github/scripts/tests/test_update_registry_metadata.py
+++ b/.github/scripts/tests/test_update_registry_metadata.py
@@ -1,0 +1,90 @@
+"""Tests for the registry root-metadata updater."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from update_registry_metadata import main, update_registry_metadata  # noqa: E402
+
+
+REGISTRY = """\
+# retained comment\r
+schema_version: "1.0"\r
+target_maf_version: "1.3.0"\r
+last_updated: "2026-05-12"\r
+\r
+entries:\r
+  - id: MAF130-EXISTING-001\r
+"""
+
+
+def test_updates_only_root_metadata_and_preserves_registry_formatting():
+    updated = update_registry_metadata(REGISTRY, "1.14.0", "2026-08-17")
+
+    assert updated == REGISTRY.replace(
+        'target_maf_version: "1.3.0"',
+        'target_maf_version: "1.14.0"',
+    ).replace(
+        'last_updated: "2026-05-12"',
+        'last_updated: "2026-08-17"',
+    )
+
+
+@pytest.mark.parametrize(
+    ("text", "message"),
+    [
+        (REGISTRY.replace('target_maf_version: "1.3.0"\r\n', ""), "target_maf_version"),
+        (
+            REGISTRY.replace(
+                'target_maf_version: "1.3.0"\r\n',
+                'target_maf_version: "1.3.0"\r\ntarget_maf_version: "1.4.0"\r\n',
+            ),
+            "target_maf_version",
+        ),
+        (REGISTRY.replace('last_updated: "2026-05-12"\r\n', ""), "last_updated"),
+    ],
+)
+def test_rejects_missing_or_duplicate_root_fields(text: str, message: str):
+    with pytest.raises(ValueError, match=message):
+        update_registry_metadata(text, "1.14.0", "2026-08-17")
+
+
+@pytest.mark.parametrize(
+    ("version", "date", "message"),
+    [
+        ("1.14.0-preview.1", "2026-08-17", "stable X.Y.Z"),
+        ("1.14.0", "2026-02-31", "valid ISO calendar date"),
+        ("1.14.0", "2026-8-17", "valid ISO calendar date"),
+    ],
+)
+def test_rejects_invalid_version_or_date(version: str, date: str, message: str):
+    with pytest.raises(ValueError, match=message):
+        update_registry_metadata(REGISTRY, version, date)
+
+
+def test_dry_run_prints_update_without_writing(tmp_path: Path, capfd):
+    registry = tmp_path / "registry.yaml"
+    registry.write_bytes(REGISTRY.encode("utf-8"))
+
+    result = main(
+        [
+            "--registry",
+            str(registry),
+            "--target-version",
+            "1.14.0",
+            "--last-updated",
+            "2026-08-17",
+            "--dry-run",
+        ]
+    )
+
+    stdout, stderr = capfd.readouterr()
+    assert result == 0
+    assert 'target_maf_version: "1.14.0"' in stdout
+    assert 'last_updated: "2026-08-17"' in stdout
+    assert stderr == ""
+    assert registry.read_bytes() == REGISTRY.encode("utf-8")

--- a/.github/scripts/tests/test_verify_ai_fill_delta.py
+++ b/.github/scripts/tests/test_verify_ai_fill_delta.py
@@ -28,6 +28,8 @@ def _write(root: Path, relative: str, text: str) -> None:
 def _registry() -> dict:
     return {
         "schema_version": 1,
+        "target_maf_version": "1.14.0",
+        "last_updated": "2026-08-17",
         "entries": [
             {
                 "id": "MAF113-HISTORY-001",
@@ -201,6 +203,36 @@ def test_additive_scaffold_can_record_zero_generated_registry_entries(tmp_path: 
     contract.write_bytes(raw)
     assert doc["registry"]["generated_target_entries"] == []
     assert verify_obligations(doc, tmp_path, raw) == []
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("target_maf_version", "1.13.0", "target_maf_version must match"),
+        ("last_updated", "2026-02-31", "valid ISO calendar date"),
+        ("last_updated", "2026-8-17", "valid ISO calendar date"),
+    ],
+)
+def test_scaffold_rejects_incorrect_registry_metadata(
+    tmp_path: Path,
+    field: str,
+    value: str,
+    message: str,
+):
+    _scaffold(tmp_path)
+    registry_path = tmp_path / ".github/skills/maf-obsolete-api-registry/registry.yaml"
+    registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    registry[field] = value
+    registry_path.write_text(yaml.safe_dump(registry, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        build_obligations(
+            tmp_path,
+            old_version="1.13.0",
+            target_version="1.14.0",
+            base_commit="a" * 40,
+            target_branch="release-watcher/maf-1.14.0",
+        )
 
 
 def test_scaffold_ignores_guide_headings_inside_fenced_package_evidence(tmp_path: Path):

--- a/.github/scripts/update_registry_metadata.py
+++ b/.github/scripts/update_registry_metadata.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Update the registry's release-level metadata without reformatting entries."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+
+
+DEFAULT_REGISTRY = Path(".github/skills/maf-obsolete-api-registry/registry.yaml")
+VERSION_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+
+
+def _replace_root_field(text: str, field: str, value: str) -> str:
+    pattern = re.compile(rf"^{re.escape(field)}:[^\r\n]*(\r?)$", re.MULTILINE)
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        raise ValueError(
+            f"registry must contain exactly one root {field} field; found {len(matches)}"
+        )
+    return pattern.sub(lambda match: f'{field}: "{value}"{match.group(1)}', text)
+
+
+def update_registry_metadata(text: str, target_version: str, last_updated: str) -> str:
+    """Return *text* with the two release-level registry fields updated."""
+    if not VERSION_RE.fullmatch(target_version):
+        raise ValueError(f"target version is not stable X.Y.Z: {target_version!r}")
+    try:
+        parsed_date = dt.date.fromisoformat(last_updated)
+    except ValueError as exc:
+        raise ValueError(f"last-updated is not a valid ISO calendar date: {last_updated!r}") from exc
+    if parsed_date.isoformat() != last_updated:
+        raise ValueError(f"last-updated must use canonical YYYY-MM-DD form: {last_updated!r}")
+
+    updated = _replace_root_field(text, "target_maf_version", target_version)
+    return _replace_root_field(updated, "last_updated", last_updated)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--target-version", required=True)
+    parser.add_argument("--last-updated", required=True)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        raw = args.registry.read_bytes()
+        text = raw.decode("utf-8")
+        updated = update_registry_metadata(
+            text,
+            target_version=args.target_version,
+            last_updated=args.last_updated,
+        )
+        rendered = updated.encode("utf-8")
+        if args.dry_run:
+            sys.stdout.buffer.write(rendered)
+            return 0
+        args.registry.write_bytes(rendered)
+    except (OSError, UnicodeError, ValueError) as exc:
+        print(f"Cannot update registry metadata: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Updated registry metadata to MAF {args.target_version} "
+        f"({args.last_updated})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/verify_ai_fill_delta.py
+++ b/.github/scripts/verify_ai_fill_delta.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import datetime as dt
 import hashlib
 import json
 import re
@@ -222,6 +223,24 @@ def build_obligations(
     if version_raw.decode("utf-8").strip() != target:
         raise ValueError(".maf-version does not match target version")
     registry = _registry(_safe_file(root, REGISTRY_REL, "registry"), "scaffold")
+    registry_target = registry.get("target_maf_version")
+    if registry_target != target:
+        raise ValueError(
+            f"registry target_maf_version must match target {target}; got {registry_target!r}"
+        )
+    last_updated = registry.get("last_updated")
+    if not isinstance(last_updated, str):
+        raise ValueError("registry last_updated must be a canonical YYYY-MM-DD string")
+    try:
+        parsed_last_updated = dt.date.fromisoformat(last_updated)
+    except ValueError as exc:
+        raise ValueError(
+            f"registry last_updated is not a valid ISO calendar date: {last_updated!r}"
+        ) from exc
+    if parsed_last_updated.isoformat() != last_updated:
+        raise ValueError(
+            f"registry last_updated must use canonical YYYY-MM-DD form: {last_updated!r}"
+        )
     generated: list[dict[str, Any]] = []
     seen: set[str] = set()
     for entry in _target_entries(registry, target):

--- a/.github/skills/maf-obsolete-api-registry/registry.yaml
+++ b/.github/skills/maf-obsolete-api-registry/registry.yaml
@@ -1,12 +1,12 @@
-# MAF 1.3.0 Obsolete API Registry
+# MAF Obsolete API Registry
 # Machine-readable source of truth for all known CS0618 warnings.
 # Update this file whenever a new CS0618 warning is encountered in any MAF migration.
 #
 # Format: see .github/skills/maf-obsolete-api-registry/SKILL.md
 
 schema_version: "1.0"
-target_maf_version: "1.3.0"
-last_updated: "2026-05-12"
+target_maf_version: "1.14.0"
+last_updated: "2026-08-17"
 
 entries:
   - id: MAF130-FAN-IN-001

--- a/.github/workflows/maf-release-watcher.yml
+++ b/.github/workflows/maf-release-watcher.yml
@@ -10,7 +10,7 @@ on:
         required: false
         default: ''
       push_target:
-        description: 'Override branch for watcher commits (dry-run). Leave blank for the default release-watcher/maf-<version> PR branch (the scaffold is opened as a PR, never pushed to main).'
+        description: 'Override branch for watcher commits (dry-run). Leave blank for the default release-watcher/maf-<version> PR branch; a retained historical branch gets a collision-safe run suffix (the scaffold is opened as a PR, never pushed to main).'
         required: false
         default: ''
 
@@ -75,6 +75,7 @@ jobs:
       old_version: ${{ steps.version-check.outputs.old_version }}
       has_update: ${{ steps.version-check.outputs.has_update }}
       is_major: ${{ steps.version-check.outputs.is_major }}
+      target_branch: ${{ steps.version-check.outputs.target_branch }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
@@ -85,6 +86,8 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.maf_version }}
           PUSH_TARGET: ${{ inputs.push_target }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}   # WM-12: gh pr list short-circuit
         run: |
           CURRENT=$(cat .maf-version | tr -d '[:space:]')
@@ -149,6 +152,22 @@ jobs:
             echo "is_major=false" >> $GITHUB_OUTPUT
             exit 0
           fi
+
+          # Resolve the target branch exactly once. Closed watcher PR branches are
+          # retained for audit history, so branch existence alone is not evidence
+          # that a PR is still open. Preserve an occupied canonical branch and use
+          # a run-unique successor; every downstream contract/push consumes this
+          # one output instead of independently recomputing a branch name.
+          TARGET_BRANCH="${PUSH_TARGET:-release-watcher/maf-${LATEST}}"
+          if [ -z "$PUSH_TARGET" ] && git ls-remote --exit-code --heads origin "$TARGET_BRANCH" >/dev/null 2>&1; then
+            TARGET_BRANCH="${TARGET_BRANCH}-run-${RUN_ID}-${RUN_ATTEMPT}"
+            if git ls-remote --exit-code --heads origin "$TARGET_BRANCH" >/dev/null 2>&1; then
+              echo "::error::Collision-safe watcher branch $TARGET_BRANCH already exists; refusing to overwrite retained history."
+              exit 1
+            fi
+            echo "ℹ️ Canonical watcher branch is retained history; using $TARGET_BRANCH."
+          fi
+          echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
 
           echo "old_version=$CURRENT" >> $GITHUB_OUTPUT
           echo "new_version=$LATEST" >> $GITHUB_OUTPUT
@@ -493,6 +512,15 @@ jobs:
           echo "$NEW" > .maf-version
           echo "Updated .maf-version to $NEW"
 
+      - name: Update registry release metadata
+        env:
+          NEW_VERSION: ${{ needs.check-for-new-maf-release.outputs.new_version }}
+        run: |
+          LAST_UPDATED=$(date -u +%F)
+          python3 .github/scripts/update_registry_metadata.py \
+            --target-version "$NEW_VERSION" \
+            --last-updated "$LAST_UPDATED"
+
       - name: Record immutable scaffold obligations
         # This data contract is generated only after every watcher-owned file is
         # final.  AI-fill verification recovers this exact blob from the first
@@ -501,14 +529,13 @@ jobs:
           OLD_VERSION: ${{ needs.check-for-new-maf-release.outputs.old_version }}
           NEW_VERSION: ${{ needs.check-for-new-maf-release.outputs.new_version }}
           BASE_COMMIT: ${{ github.sha }}
-          PUSH_TARGET: ${{ inputs.push_target }}
+          TARGET_BRANCH: ${{ needs.check-for-new-maf-release.outputs.target_branch }}
         run: |
-          BRANCH="${PUSH_TARGET:-release-watcher/maf-${NEW_VERSION}}"
           python3 .github/scripts/build_scaffold_obligations.py \
             --old-version "$OLD_VERSION" \
             --target-version "$NEW_VERSION" \
             --base-commit "$BASE_COMMIT" \
-            --target-branch "$BRANCH" \
+            --target-branch "$TARGET_BRANCH" \
             --output ".github/maf-scaffold-obligations/maf-${NEW_VERSION}.json"
 
       - name: Commit to a release-watcher branch and open a PR
@@ -531,7 +558,7 @@ jobs:
           # workflow events for branches/PRs created with GITHUB_TOKEN. Never
           # fall back silently, or the scaffold PR opens without its CI checks.
           GH_TOKEN: ${{ secrets.COPILOT_ASSIGN_PAT }}
-          PUSH_TARGET: ${{ inputs.push_target }}
+          BRANCH: ${{ needs.check-for-new-maf-release.outputs.target_branch }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}  # REP-34
         run: |
           git config user.name  "github-actions[bot]"
@@ -558,43 +585,40 @@ jobs:
           python3 .github/scripts/build_watcher_commit_message.py \
             > "$RUNNER_TEMP/commit-msg.txt"
 
-          # Push to a per-version branch (NOT main) so an unfilled scaffold can never red
-          # main. A manual dispatch may override the branch via push_target (dry-run).
-          BRANCH="${PUSH_TARGET:-release-watcher/maf-${NEW_VERSION}}"
+          # Push to the branch resolved by the read-only version-check job. Reusing
+          # that exact value keeps the immutable obligations topology truthful.
           # Hard guard: never operate on the default/protected branch. The whole point of C
           # is that the scaffold goes through a PR — a stray push_target=main must NOT push.
           if [ "$BRANCH" = "main" ] || [ "$BRANCH" = "master" ]; then
             echo "::error::push_target must not be a protected branch (got '$BRANCH'). The watcher opens a PR; it never pushes the scaffold to main."
             exit 1
           fi
-          # WM-12 (defense-in-depth for the check-for-new-maf-release short-circuit):
-          # if the scaffold branch already exists on the remote, a PR is in flight —
-          # leave it and its in-flight fill commits untouched instead of force-clobbering
-          # them (which the old --force-with-lease then failed on in a fresh clone, red-ing
-          # the whole job). Public repo → unauthenticated ls-remote works.
+          # Defense-in-depth against a branch appearing after target selection.
+          # Never overwrite it: it may be retained history or another actor's work.
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "ℹ️ Branch $BRANCH already exists on the remote — scaffold PR in flight; leaving it (and any fill commits) untouched. Delete the branch or dispatch with push_target to regenerate."
-            echo "committed=false" >> $GITHUB_OUTPUT
-            exit 0
+            echo "::error::Resolved branch $BRANCH appeared after selection; refusing to overwrite it. Rerun to select a fresh collision-safe branch."
+            exit 1
           fi
           git checkout -b "$BRANCH"
           git commit -F "$RUNNER_TEMP/commit-msg.txt"
           # SEC-27: pass the ephemeral auth header through Git's one-command
           # environment config, not `.git/config`, the remote URL, or argv.
-          # --force-with-lease (not -f) lets a deliberate regenerate update its
-          # own branch without clobbering someone else's work.
+          # The resolved branch is required to be new, so an ordinary push is
+          # sufficient and cannot rewrite a retained historical branch.
           AUTH_VALUE="AUTHORIZATION: basic $(printf 'x-access-token:%s' "$GH_TOKEN" | base64 -w0)"
           GIT_CONFIG_COUNT=1 \
           GIT_CONFIG_KEY_0=http.extraheader \
           GIT_CONFIG_VALUE_0="$AUTH_VALUE" \
-            git push --force-with-lease origin "HEAD:${BRANCH}"
+            git push origin "HEAD:${BRANCH}"
           unset AUTH_VALUE
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
           echo "committed=true" >> $GITHUB_OUTPUT
 
-          # Open a PR to main (idempotent).
-          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
-            echo "✅ Updated existing PR for branch $BRANCH."
+          # Only an OPEN PR with this exact head is current. A closed PR is
+          # historical evidence and must never suppress creation of a successor.
+          OPEN_PR=$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // empty')
+          if [ -n "$OPEN_PR" ]; then
+            echo "✅ Open PR #$OPEN_PR already targets branch $BRANCH."
           else
             # REP-34: build the body with printf + SINGLE-quoted lines (no command
             # substitution, so backticks + markdown bullets are safe — this is what

--- a/src/maf-autopilot.Tests/RegistryLookupToolTests.cs
+++ b/src/maf-autopilot.Tests/RegistryLookupToolTests.cs
@@ -6,7 +6,13 @@ namespace MafDoctor.Tests;
 
 public class RegistryLookupToolTests
 {
-    private readonly RegistryLookupTool _tool = new(new RegistryService());
+    private readonly RegistryService _registry = new();
+    private readonly RegistryLookupTool _tool;
+
+    public RegistryLookupToolTests()
+    {
+        _tool = new RegistryLookupTool(_registry);
+    }
 
     // -------------------------------------------------------------------------
     // MafRegistryLookup
@@ -50,7 +56,7 @@ public class RegistryLookupToolTests
     public void List_ReturnsMarkdownTableWithAllEntries()
     {
         var result = _tool.MafRegistryList();
-        Assert.Contains("MAF 1.3.0 Obsolete-API Registry", result, StringComparison.Ordinal);
+        Assert.Contains($"MAF {_registry.TargetVersion} Obsolete-API Registry", result, StringComparison.Ordinal);
         // Markdown table rows for known entries
         Assert.Contains("MAF130-FAN-IN-001", result, StringComparison.Ordinal);
         Assert.Contains("MAF130-THREAD-001", result, StringComparison.Ordinal);

--- a/src/maf-autopilot.Tests/RegistryServiceTests.cs
+++ b/src/maf-autopilot.Tests/RegistryServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using MafDoctor.Data;
 using Xunit;
 
@@ -22,8 +23,13 @@ public class RegistryServiceTests
     public void Load_FromEmbeddedResource_PopulatesEntries()
     {
         Assert.NotEmpty(_registry.AllIds);
-        Assert.Equal("1.3.0", _registry.TargetVersion);
-        Assert.False(string.IsNullOrWhiteSpace(_registry.LastUpdated));
+        Assert.Matches(@"^\d+\.\d+\.\d+$", _registry.TargetVersion);
+        Assert.True(DateOnly.TryParseExact(
+            _registry.LastUpdated,
+            "yyyy-MM-dd",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out _));
     }
 
     [Fact]


### PR DESCRIPTION
## What changed

- resolve the watcher target branch once and reuse it for immutable obligations and the final push
- preserve retained closed-PR branches by selecting a run-suffixed successor on collision
- treat only an open PR with the exact head branch as current, and never force-update historical branches
- update `target_maf_version` and `last_updated` before recording scaffold obligations
- validate registry target/date metadata in the obligations builder
- normalize the merged 1.14 registry metadata to `1.14.0` / `2026-08-17`

## Why

The closed 1.15 and 1.17 watcher branches are intentionally retained for audit history. The later watcher guard treated branch existence as proof that a PR was still open, which would block the sequential release chain. Separately, the registry root still advertised MAF 1.3.0; because scaffold obligations hash root metadata as historical content, it must be corrected before each contract is generated.

## Impact

The next 1.15 watcher run can preserve the historical 1.15 branch and open a fresh collision-safe successor. Future scaffolds freeze correct release metadata and fail closed if it is missing or malformed.

## Validation

- focused helper/workflow/obligations tests: 38 passed
- complete `.github/scripts/tests` suite: 313 passed
- `verify_crossfile_consistency.py`: passed
- `maf-doctor verify-registry`: passed (87 active entries)
- Python compile checks: passed
- watcher workflow YAML parse: passed
- `git diff --cached --check`: passed