### PR TITLE
chore: release maf-doctor v1.15.0

### DIFF
--- a/.github/instructions/maf-constraints.instructions.md
+++ b/.github/instructions/maf-constraints.instructions.md
@@ -1,83 +1,115 @@
 ---
-description: "Always-loaded compact reference for MAF 1.3.0 migrations. Contains the breaking changes table, hard constraints, and quick-reference rules. Applies to all files when the MAF migration or auditor agents are active."
+description: "Always-loaded, version-aware MAF migration constraints. Contains durable security rules, release-path invariants, and verification gates for every tracked Microsoft Agent Framework version."
 applyTo: "**"
 ---
 
-# MAF 1.3.0 — Constraints & Breaking Changes Reference
+# MAF Migration Constraints
+
+These rules apply across the tracked MAF release chain. Version-specific API
+recipes belong in the ordered per-version guides and registry; do not promote a
+single release's syntax into a timeless global rule.
 
 ## Hard Constraints (Never Violate)
 
-- **NEVER** introduce patterns not present in MAF 1.3.0
-- **NEVER** store session-specific state in `AIContextProvider` or `ChatHistoryProvider` instance fields — always use `ProviderSessionState<T>`
-- **NEVER** add `[StreamsMessage]` or `[YieldsMessage]` attributes — removed in 1.3.0, causes `CS0246`
-- **NEVER** use `DefaultAzureCredential` in production code — prefer `ManagedIdentityCredential`
-- **NEVER** enable `EnableSensitiveData = true` in non-development environments
-- **ALWAYS** pin `dotnet-inspect` to exact v0.9.1. v0.7.8 was the first release to surface `[Obsolete]` in listings; versions ≤ v0.7.7 miss obsoletions at the overload level. For ground-truth on what your project actually triggers, run `cs0618-hunter` (compiler-based) — it catches transitive obsoletions, overload-resolution surprises, and project-local `[Obsolete]` attributes that static inspection cannot see.
-- **ALWAYS** update `src/docs/migration-plan.md` tracking table after each task is completed and build-verified
+- **ALWAYS identify the exact source and target package versions** and call
+  `MafMigrationPath(currentVer, targetVer)` for a multi-version upgrade. Apply
+  every returned step in ascending order.
+- **NEVER store session-specific state in `AIContextProvider` or
+  `ChatHistoryProvider` instance fields.** Use the framework's session-state
+  mechanism for the selected version, such as `ProviderSessionState<T>`, and
+  persist the session when continuity must outlive a process or top-level call.
+- **NEVER use `DefaultAzureCredential` in production code.** Prefer an explicit
+  production credential such as `ManagedIdentityCredential`; keep developer
+  credential chains in development-only composition.
+- **NEVER enable `EnableSensitiveData = true` outside a development-only,
+  access-controlled diagnostic boundary.** Provider errors, prompts, tool
+  arguments, session state, and model output can contain secrets or personal
+  data.
+- **NEVER treat model-generated code or shell commands as sandboxed.**
+  `LocalCodeAct`, Python child processes, and `Tools.Shell` require a real
+  container/VM boundary, minimal filesystem mounts, restricted credentials and
+  egress, resource limits, and explicit tool/policy composition.
+- **NEVER derive file-memory roots, shell paths, callback destinations, or
+  tenant storage folders directly from untrusted input.** Validate and
+  authorize them against an application-owned boundary.
+- **NEVER expose raw hosted-provider failure detail by default.** Preserve
+  server-side diagnostics in access-controlled telemetry; enable exception
+  details only for trusted callers.
+- **ALWAYS pin `dotnet-inspect` to exact v0.9.1** in this repository. Reject a
+  missing, mismatched, truncated, or structurally invalid report. Use
+  `MafRunCs0618Hunt` and the compiler as ground truth for overload resolution,
+  transitive obsoletions, and project-local `[Obsolete]` attributes.
+- **ALWAYS preserve the published maturity/version of each package.** Stable,
+  preview, RC, and alpha packages in one train are not interchangeable. Do not
+  invent an aligned version for an externalized or independently shipped
+  package.
+- **ALWAYS restore, build, and run focused behavior tests after migration.** An
+  empty public API diff cannot detect persistence, streaming, checkpoint,
+  redaction, tool-approval, or workflow-routing behavior changes.
 
-## Fan-out / Fan-in Rules (Silent Failure Risk)
+## Version-Scoped Compatibility Checkpoints
 
-```
-Fan-out executor handlers MUST return ValueTask<T> where T is the message type.
-A void or non-generic ValueTask return produces NO output message.
-The fan-in barrier then starves silently — the workflow exits cleanly but incompletely.
-This is NOT a build error. The only detection is runtime or maf-fan-out-validator skill.
-```
+| Target step | Mandatory review |
+|---|---|
+| 1.3.0 | Removed executor attributes/types, async sessions, response/streaming changes, source generation, and fan-out/fan-in behavior. |
+| 1.4.0 / 1.5.0 | These per-version guides still contain unfilled human analysis; verify exact assemblies and official tags before applying their evidence. |
+| 1.14.0 | Agent/session and approval lifecycle, Harness opt-in file/shell providers, AG-UI split, Copilot declarations, and `ShellPolicy` binary/deny-first semantics. |
+| 1.15.0 | Preview Hosting `sessionStoreId` named arguments, abstract `DeleteSessionAsync`, session isolation, checkpoint ordering, and declarative/hosted behavior. |
+| 1.16.0 | `Microsoft.Extensions.VectorData.Abstractions` 9.7→10.7 migration, provider rebuilds, history ownership, approval sessions, FileMemory scope, and code-execution boundaries. |
+| 1.17.0 | Declarative top-level `ErrorContent` is terminal; Foundry raw failure payloads are redacted; Durable Task/Azure Functions packages follow an independent extension cadence. |
 
-```
-AddFanInBarrierEdge argument order:
-  CORRECT:   AddFanInBarrierEdge(IEnumerable<ExecutorBinding> sources, ExecutorBinding target)
-  OBSOLETE:  AddFanInBarrierEdge(ExecutorBinding target, IEnumerable<ExecutorBinding> sources)
-  The obsolete overload compiles and runs but triggers CS0618.
-```
+Read the exact target guide before changing code. Existing repositories may
+need several rows, not only the final target row.
 
-## Key Breaking Changes
+## Workflow Rules That Remain Active
 
-| Area | Old (broken) | New (correct) |
-|------|-------------|---------------|
-| Executors | `ReflectingExecutor<T>` | `sealed partial class : Executor` + `[MessageHandler]` |
-| Executors | `IMessageHandler<TIn,TOut>` | `[MessageHandler]` on handler methods |
-| Executors | `[StreamsMessage]`, `[YieldsMessage]` | **Removed** — delete these attributes |
-| Source gen | *(missing package)* | Add `Microsoft.Agents.AI.Workflows.Generators 1.3.0` |
-| Sessions | `AgentThread` | `AgentSession` via `await agent.CreateSessionAsync()` |
-| Sessions | `GetNewThread()` | `await agent.CreateSessionAsync(ct)` |
-| Sessions | `agent.SerializeSession(session)` | `await agent.SerializeSessionAsync(session)` |
-| Response | `AgentResponse.Deserialize<T>()` | `RunAsync<T>()` + `.Result` |
-| Streaming | `InProcessExecution.StreamAsync()` | `RunStreamingAsync()` |
-| Events | `AgentRunUpdateEvent` | `AgentResponseUpdateEvent` |
-| A2A DI | `AIAgentExtensions` | `services.AddA2AServer(agent, new A2AServerRegistrationOptions { AgentCard = ... })` |
-| A2A endpoint | `app.MapA2A(...)` | `app.MapA2AHttpJson(path)` or `app.MapA2AJsonRpc(path)` |
-| Agent options | `Instructions` / `Tools` at top-level | Must be inside `ChatClientAgentOptions.ChatOptions` |
-| DevUI/Hosting | `Microsoft.Agents.AI.DevUI` / `.Hosting` | No 1.3.0 equivalent — guard with `#if DEVUI_ENABLED` |
-| Fan-in | `AddFanInBarrierEdge(target, sources)` | `AddFanInBarrierEdge(sources, target)` — sources first |
-| Fan-out | `async ValueTask HandleAsync(...)` returning void | `async ValueTask<T> HandleAsync(...)` returning the message |
+For 1.3-and-later workflow patterns, fan-out handlers that produce a downstream
+message must return that message from `ValueTask<T>` (or the exact supported
+generic async shape for the selected version). A void/non-generic return can
+starve fan-in without a build error. Validate the real topology with
+`MafValidateFanOut` or `MafSimulateWorkflow` and a runtime completion test.
 
-## Known Misalignments (Official Docs vs. Reality)
+For versions where the registry marks the target-first
+`AddFanInBarrierEdge(target, sources)` overload obsolete, use the applicable
+sources-first recipe and confirm with `MafRunCs0618Hunt`. Do not rely on this
+summary instead of the registry: overload sets can change between releases.
 
-- `SerializeSession` in official docs is **wrong** — use `await agent.SerializeSessionAsync(session)` (async)
-- `FunctionApprovalRequestContent` vs `ToolApprovalRequestContent` — verify with `dotnet-inspect` for your exact version
-- `RunAsync<T>` exists on `ChatClientAgent` but NOT on `AIAgent` interface — cast may be needed
-- `ChatClientAgentOptions` has undocumented properties: `UseProvidedChatClientAsIs`, `RequirePerServiceCallChatHistoryPersistence`, `ClearOnChatHistoryProviderConflict`
-- `AddFanInBarrierEdge(target, params sources[])` is `[Obsolete]` in 1.3.0 — surfaced by `dotnet-inspect member` as of v0.7.8; older `dotnet-inspect` versions miss it and require the compiler
+`[StreamsMessage]` and `[YieldsMessage]` were removed on the 1.3 path. Delete
+them when that step applies; do not add them to a current target merely to make
+old sample code look familiar.
 
-## dotnet-inspect — Required Version
+## Security Boundaries Added by Later Releases
 
-**Pin to exact `dotnet-inspect@0.9.1`.** v0.7.8 ([release notes](https://github.com/richlander/dotnet-inspect/releases/tag/v0.7.8), 2026-05-04) was the first release to surface `[Obsolete]` members in listings (PR #318 closes issue #316); v0.9.1 is the repository-supported release and fixes the redirected-output corruption seen with v0.7.8 on Linux.
+- MAF 1.14 Shell policies evaluate deny rules first, and a non-null allow list
+  is exclusive. Rebuild binary consumers of the constructor and test denied,
+  allowed, and unmatched commands.
+- Harness file access and shell execution are explicit opt-ins. Do not register
+  them merely because a sample does.
+- File memory with an empty working folder can share the file-store root. Assign
+  an authorized tenant/user folder or a unique per-session folder deliberately.
+- A2A request configuration and metadata are untrusted request input. Server
+  execution policy remains authoritative; validate any value before acting on
+  it, especially push/callback destinations.
+- Declarative/Foundry failures must remain failures. Do not turn an
+  `ExecutorFailedEvent` or `ErrorContent` back into an empty success, and do not
+  leak provider detail by bypassing the host's exception-detail policy.
+- `LocalCodeAct` defense-in-depth checks are not a Python sandbox. External
+  process, network, filesystem, and credential isolation remains mandatory.
 
-**Always run** `dotnet build 2>&1 | Select-String "warning CS0618"` as the final gate — the compiler is ground-truth and catches transitive / overload-resolution / project-local `[Obsolete]` cases that no static inspector can see. `dotnet-inspect@0.9.1` is the fast pre-build path; the compiler is the verification path. Use both.
+## Verification Tools
 
-## How to verify each constraint (use the MCP tools)
+| Concern | Verification |
+|---|---|
+| Ordered multi-version path | `MafMigrationPath(currentVer, targetVer)` |
+| Exact package/framework compatibility | `MafCompatibility(targetVersion)` and `docs/compatibility-matrix.md` |
+| Obsolete/removed API usage | `MafRunCs0618Hunt(projectPath)` plus `MafRegistryLookup` |
+| Session state in provider fields | `MafScanAntiPatterns(repoPath)` → `MAF-AP-CONC-001` |
+| `DefaultAzureCredential` in production | `MafScanAntiPatterns(repoPath)` → `MAF-AP-SEC-001` |
+| Sensitive-data logging outside development | `MafScanAntiPatterns(repoPath)` → `MAF-AP-SEC-003` |
+| Fan-out/fan-in topology | `MafValidateFanOut(repoPath)` and `MafSimulateWorkflow` |
+| Public package API delta | `MafDiffPackage` with exact old/new artifact versions |
+| End-to-end repository state | `MafDoctor(repoPath)`; surface `scan_truncated` as incomplete evidence |
 
-The `maf-autopilot` MCP server provides executable tools that enforce most constraints. Tool names are PascalCase.
-
-| Constraint above                               | Verify by calling                                  |
-|------------------------------------------------|----------------------------------------------------|
-| NEVER instance state in `AIContextProvider`    | `MafScanAntiPatterns(repoPath)` → rule `MAF-AP-CONC-001` |
-| NEVER `DefaultAzureCredential` in production   | `MafScanAntiPatterns(repoPath)` → rule `MAF-AP-SEC-001`  |
-| NEVER `EnableSensitiveData = true` outside dev | `MafScanAntiPatterns(repoPath)` → rule `MAF-AP-SEC-003`  |
-| Fan-out handler must return `Task<T>`          | `MafValidateFanOut(repoPath)` (or `MafSimulateWorkflow` for full topology) |
-| `AddFanInBarrierEdge` argument order           | `MafRunCs0618Hunt(projectPath)` (CS0618 path)            |
-| No `[StreamsMessage]` / `[YieldsMessage]`      | `MafRunCs0618Hunt(projectPath)` (CS0246 path)            |
-| Always run tracking-table updates              | (process — agents enforce this)                     |
-
-Also useful: `MafApiSafety(apiName)` for a quick SAFE/UNSAFE check on any MAF API, `MafExplain(snippet)` to annotate a code fragment with guide citations, and the `maf-doctor.Analyzers` NuGet package for write-time IDE squigglies (`MAF001`/`MAF002`/`MAF003`).
+Finish with the real solution's restore/build/test commands. Treat a successful
+static scan as necessary evidence, not proof that behavior and security
+boundaries are correct.

--- a/.github/scripts/tests/test_release_artifact_workflows.py
+++ b/.github/scripts/tests/test_release_artifact_workflows.py
@@ -1,0 +1,38 @@
+"""Static security contracts for release artifact publication workflows."""
+
+from pathlib import Path
+
+
+WORKFLOWS = Path(__file__).resolve().parents[2] / "workflows"
+
+
+def test_release_verifies_exact_packages_before_attestation_and_publish() -> None:
+    text = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+    verify = text.index("verify_release_packages.py")
+    attest = text.index("actions/attest-build-provenance@")
+    publish = text.index("dotnet nuget push")
+    assert verify < attest < publish
+    assert '--dist src/dist --version "$VERSION"' in text
+    assert "subject-path: 'src/dist/*nupkg'" in text
+    assert "files: src/dist/*nupkg" in text
+
+
+def test_analyzer_symbol_package_is_created_without_publishing_duplicate_dll_layout() -> None:
+    text = (WORKFLOWS / "release.yml").read_text(encoding="utf-8")
+    analyzer = text.split("- name: Pack analyzer package", 1)[1].split("- name: Verify release", 1)[0]
+    assert "-p:IncludeBuildOutput=true" in analyzer
+    assert "--no-build" in analyzer
+    assert 'cp "$SYMBOL_PACKAGE" src/dist/' in analyzer
+    assert 'cp "$SYMBOL_DIR"/*.nupkg' not in analyzer
+
+
+def test_docker_tag_ancestry_guard_precedes_login_and_push() -> None:
+    text = (WORKFLOWS / "docker-publish.yml").read_text(encoding="utf-8")
+    guard = text.index("Guard — tag commit must be on main")
+    login = text.index("Log in to GHCR")
+    push = text.index("Build and push")
+    assert guard < login < push
+    assert "is_tag=$IS_TAG" in text
+    assert "if: steps.version.outputs.is_tag == 'true'" in text[guard:login]
+    assert 'git merge-base --is-ancestor "$GITHUB_SHA" origin/main' in text[guard:login]
+    assert "fetch-depth: 0" in text[:guard]

--- a/.github/scripts/tests/test_verify_release_packages.py
+++ b/.github/scripts/tests/test_verify_release_packages.py
@@ -1,0 +1,148 @@
+"""Tests for the fail-closed release package verifier."""
+
+from __future__ import annotations
+
+import importlib.util
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "verify_release_packages.py"
+SPEC = importlib.util.spec_from_file_location("verify_release_packages", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+VERSION = "1.15.0"
+
+
+def _nuspec(package_id: str, version: str, *, content: bool) -> bytes:
+    readme = "<readme>NUGET_README.md</readme><icon>MAFDoctorIcon.png</icon>" if content else ""
+    package_type = (
+        '<packageTypes><packageType name="DotnetTool" /></packageTypes>'
+        if package_id == "maf-doctor"
+        else ""
+    )
+    return (
+        '<?xml version="1.0"?><package><metadata>'
+        f"<id>{package_id}</id><version>{version}</version>{readme}{package_type}"
+        "</metadata></package>"
+    ).encode()
+
+
+def _write_package(path: Path, package_id: str, members: dict[str, bytes], *, content: bool) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(f"{package_id}.nuspec", _nuspec(package_id, VERSION, content=content))
+        for name, data in members.items():
+            archive.writestr(name, data)
+
+
+def _valid_set(dist: Path) -> None:
+    tool_members = {"NUGET_README.md": b"readme", "MAFDoctorIcon.png": b"icon"}
+    tool_symbols: dict[str, bytes] = {}
+    settings = (
+        b'<DotNetCliTool Version="1"><Commands><Command Name="maf-doctor" '
+        b'EntryPoint="maf-doctor.dll" Runner="dotnet" /></Commands></DotNetCliTool>'
+    )
+    for tfm in MODULE.TOOL_TFMS:
+        root = f"tools/{tfm}/any"
+        tool_members[f"{root}/maf-doctor.dll"] = b"dll"
+        tool_members[f"{root}/maf-doctor.deps.json"] = b"{}"
+        tool_members[f"{root}/maf-doctor.runtimeconfig.json"] = b"{}"
+        tool_members[f"{root}/DotnetToolSettings.xml"] = settings
+        tool_symbols[f"{root}/maf-doctor.pdb"] = b"pdb"
+
+    _write_package(dist / f"maf-doctor.{VERSION}.nupkg", "maf-doctor", tool_members, content=True)
+    _write_package(
+        dist / f"maf-doctor.Analyzers.{VERSION}.nupkg",
+        "maf-doctor.Analyzers",
+        {
+            "NUGET_README.md": b"readme",
+            "MAFDoctorIcon.png": b"icon",
+            "analyzers/dotnet/cs/maf-doctor.Analyzers.dll": b"dll",
+        },
+        content=True,
+    )
+    _write_package(
+        dist / f"maf-doctor.{VERSION}.snupkg", "maf-doctor", tool_symbols, content=False
+    )
+    _write_package(
+        dist / f"maf-doctor.Analyzers.{VERSION}.snupkg",
+        "maf-doctor.Analyzers",
+        {"analyzers/dotnet/cs/netstandard2.0/maf-doctor.Analyzers.pdb": b"pdb"},
+        content=False,
+    )
+
+
+def test_accepts_exact_release_payload(tmp_path: Path) -> None:
+    _valid_set(tmp_path)
+    MODULE.verify_release_packages(tmp_path, VERSION)
+
+
+@pytest.mark.parametrize(
+    "filename",
+    [
+        f"maf-doctor.{VERSION}.nupkg",
+        f"maf-doctor.Analyzers.{VERSION}.nupkg",
+        f"maf-doctor.{VERSION}.snupkg",
+        f"maf-doctor.Analyzers.{VERSION}.snupkg",
+    ],
+)
+def test_rejects_each_missing_artifact(tmp_path: Path, filename: str) -> None:
+    _valid_set(tmp_path)
+    (tmp_path / filename).unlink()
+    with pytest.raises(MODULE.VerificationError, match="artifact set mismatch"):
+        MODULE.verify_release_packages(tmp_path, VERSION)
+
+
+def test_rejects_unexpected_package(tmp_path: Path) -> None:
+    _valid_set(tmp_path)
+    _write_package(tmp_path / "unexpected.1.0.0.nupkg", "unexpected", {}, content=False)
+    with pytest.raises(MODULE.VerificationError, match="unexpected"):
+        MODULE.verify_release_packages(tmp_path, VERSION)
+
+
+def test_rejects_wrong_nuspec_identity(tmp_path: Path) -> None:
+    _valid_set(tmp_path)
+    target = tmp_path / f"maf-doctor.{VERSION}.nupkg"
+    with zipfile.ZipFile(target, "w") as archive:
+        archive.writestr("wrong.nuspec", _nuspec("wrong", VERSION, content=True))
+    with pytest.raises(MODULE.VerificationError, match="package id"):
+        MODULE.verify_release_packages(tmp_path, VERSION)
+
+
+def test_rejects_missing_tool_tfm(tmp_path: Path) -> None:
+    _valid_set(tmp_path)
+    target = tmp_path / f"maf-doctor.{VERSION}.nupkg"
+    with zipfile.ZipFile(target, "r") as source:
+        members = {name: source.read(name) for name in source.namelist() if "net10.0" not in name}
+    with zipfile.ZipFile(target, "w") as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+    with pytest.raises(MODULE.VerificationError, match="tool TFMs"):
+        MODULE.verify_release_packages(tmp_path, VERSION)
+
+
+def test_rejects_duplicate_analyzer_dll(tmp_path: Path) -> None:
+    _valid_set(tmp_path)
+    target = tmp_path / f"maf-doctor.Analyzers.{VERSION}.nupkg"
+    with zipfile.ZipFile(target, "a") as archive:
+        archive.writestr("analyzers/dotnet/cs/netstandard2.0/maf-doctor.Analyzers.dll", b"dll")
+    with pytest.raises(MODULE.VerificationError, match="analyzer DLL payload"):
+        MODULE.verify_release_packages(tmp_path, VERSION)
+
+
+def test_rejects_wrong_tool_command(tmp_path: Path) -> None:
+    _valid_set(tmp_path)
+    target = tmp_path / f"maf-doctor.{VERSION}.nupkg"
+    with zipfile.ZipFile(target, "r") as source:
+        members = {name: source.read(name) for name in source.namelist()}
+    settings = "tools/net8.0/any/DotnetToolSettings.xml"
+    members[settings] = members[settings].replace(b'Name="maf-doctor"', b'Name="wrong"')
+    with zipfile.ZipFile(target, "w") as archive:
+        for name, data in members.items():
+            archive.writestr(name, data)
+    with pytest.raises(MODULE.VerificationError, match="command is"):
+        MODULE.verify_release_packages(tmp_path, VERSION)

--- a/.github/scripts/verify_release_packages.py
+++ b/.github/scripts/verify_release_packages.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Fail closed unless the release directory contains the intended NuGet payload."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+TOOL_ID = "maf-doctor"
+ANALYZER_ID = "maf-doctor.Analyzers"
+TOOL_TFMS = ("net8.0", "net9.0", "net10.0")
+README = "NUGET_README.md"
+ICON = "MAFDoctorIcon.png"
+
+
+class VerificationError(RuntimeError):
+    """A release artifact violates the expected package contract."""
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _child_text(parent: ET.Element, name: str) -> str | None:
+    for child in parent:
+        if _local_name(child.tag) == name:
+            return (child.text or "").strip()
+    return None
+
+
+class Package:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        try:
+            self.archive = zipfile.ZipFile(path)
+        except (OSError, zipfile.BadZipFile) as exc:
+            raise VerificationError(f"{path.name}: invalid ZIP archive: {exc}") from exc
+
+        names = self.archive.namelist()
+        folded = [name.casefold() for name in names]
+        if len(folded) != len(set(folded)):
+            raise VerificationError(f"{path.name}: duplicate ZIP member name")
+
+        for name in names:
+            member = PurePosixPath(name)
+            if "\\" in name or member.is_absolute() or ".." in member.parts:
+                raise VerificationError(f"{path.name}: unsafe ZIP member {name!r}")
+
+        self.names = set(names)
+
+    def close(self) -> None:
+        self.archive.close()
+
+    def read(self, name: str) -> bytes:
+        if name not in self.names:
+            raise VerificationError(f"{self.path.name}: missing {name}")
+        data = self.archive.read(name)
+        if not data:
+            raise VerificationError(f"{self.path.name}: {name} is empty")
+        return data
+
+    def metadata(self) -> ET.Element:
+        nuspecs = [name for name in self.names if name.endswith(".nuspec") and "/" not in name]
+        if len(nuspecs) != 1:
+            raise VerificationError(
+                f"{self.path.name}: expected exactly one root .nuspec, found {len(nuspecs)}"
+            )
+        try:
+            root = ET.fromstring(self.read(nuspecs[0]))
+        except ET.ParseError as exc:
+            raise VerificationError(f"{self.path.name}: invalid nuspec XML: {exc}") from exc
+        metadata = next((item for item in root.iter() if _local_name(item.tag) == "metadata"), None)
+        if metadata is None:
+            raise VerificationError(f"{self.path.name}: nuspec has no metadata element")
+        return metadata
+
+
+def _verify_identity(package: Package, package_id: str, version: str) -> ET.Element:
+    metadata = package.metadata()
+    actual_id = _child_text(metadata, "id")
+    actual_version = _child_text(metadata, "version")
+    if actual_id != package_id:
+        raise VerificationError(
+            f"{package.path.name}: package id is {actual_id!r}, expected {package_id!r}"
+        )
+    if actual_version != version:
+        raise VerificationError(
+            f"{package.path.name}: package version is {actual_version!r}, expected {version!r}"
+        )
+    return metadata
+
+
+def _verify_common_content(package: Package, metadata: ET.Element) -> None:
+    if _child_text(metadata, "readme") != README:
+        raise VerificationError(f"{package.path.name}: nuspec readme must be {README}")
+    if _child_text(metadata, "icon") != ICON:
+        raise VerificationError(f"{package.path.name}: nuspec icon must be {ICON}")
+    package.read(README)
+    package.read(ICON)
+
+
+def _verify_tool_settings(package: Package, path: str) -> None:
+    try:
+        root = ET.fromstring(package.read(path))
+    except ET.ParseError as exc:
+        raise VerificationError(f"{package.path.name}: invalid {path}: {exc}") from exc
+
+    commands = [item for item in root.iter() if _local_name(item.tag) == "Command"]
+    if len(commands) != 1:
+        raise VerificationError(f"{package.path.name}: {path} must declare exactly one command")
+    command = commands[0]
+    expected = {"Name": TOOL_ID, "EntryPoint": f"{TOOL_ID}.dll", "Runner": "dotnet"}
+    actual = {key: command.attrib.get(key) for key in expected}
+    if actual != expected:
+        raise VerificationError(
+            f"{package.path.name}: {path} command is {actual!r}, expected {expected!r}"
+        )
+
+
+def _verify_tool(package: Package, version: str) -> None:
+    metadata = _verify_identity(package, TOOL_ID, version)
+    _verify_common_content(package, metadata)
+
+    package_types = [
+        item.attrib.get("name")
+        for item in metadata.iter()
+        if _local_name(item.tag) == "packageType"
+    ]
+    if package_types != ["DotnetTool"]:
+        raise VerificationError(
+            f"{package.path.name}: expected one DotnetTool package type, found {package_types!r}"
+        )
+
+    tfms = {
+        match.group(1)
+        for name in package.names
+        if (match := re.match(r"^tools/([^/]+)/any/", name))
+    }
+    if tfms != set(TOOL_TFMS):
+        raise VerificationError(
+            f"{package.path.name}: tool TFMs are {sorted(tfms)!r}, expected {list(TOOL_TFMS)!r}"
+        )
+    for tfm in TOOL_TFMS:
+        root = f"tools/{tfm}/any"
+        package.read(f"{root}/{TOOL_ID}.dll")
+        package.read(f"{root}/{TOOL_ID}.deps.json")
+        package.read(f"{root}/{TOOL_ID}.runtimeconfig.json")
+        _verify_tool_settings(package, f"{root}/DotnetToolSettings.xml")
+
+
+def _verify_analyzer(package: Package, version: str) -> None:
+    metadata = _verify_identity(package, ANALYZER_ID, version)
+    _verify_common_content(package, metadata)
+    expected_dll = f"analyzers/dotnet/cs/{ANALYZER_ID}.dll"
+    package.read(expected_dll)
+    analyzer_dlls = {
+        name
+        for name in package.names
+        if name.startswith("analyzers/dotnet/cs/") and name.lower().endswith(".dll")
+    }
+    if analyzer_dlls != {expected_dll}:
+        raise VerificationError(
+            f"{package.path.name}: analyzer DLL payload is {sorted(analyzer_dlls)!r}, "
+            f"expected only {expected_dll!r}"
+        )
+
+
+def _verify_tool_symbols(package: Package, version: str) -> None:
+    _verify_identity(package, TOOL_ID, version)
+    expected = {f"tools/{tfm}/any/{TOOL_ID}.pdb" for tfm in TOOL_TFMS}
+    actual = {
+        name
+        for name in package.names
+        if name.startswith("tools/") and name.lower().endswith(".pdb")
+    }
+    if actual != expected:
+        raise VerificationError(
+            f"{package.path.name}: symbol payload is {sorted(actual)!r}, expected {sorted(expected)!r}"
+        )
+    for name in expected:
+        package.read(name)
+
+
+def _verify_analyzer_symbols(package: Package, version: str) -> None:
+    _verify_identity(package, ANALYZER_ID, version)
+    expected = f"analyzers/dotnet/cs/netstandard2.0/{ANALYZER_ID}.pdb"
+    package.read(expected)
+    actual = {
+        name
+        for name in package.names
+        if name.startswith("analyzers/dotnet/cs/") and name.lower().endswith(".pdb")
+    }
+    if actual != {expected}:
+        raise VerificationError(
+            f"{package.path.name}: analyzer symbol payload is {sorted(actual)!r}, "
+            f"expected only {expected!r}"
+        )
+
+
+def verify_release_packages(dist: Path, version: str) -> None:
+    if not dist.is_dir():
+        raise VerificationError(f"release directory does not exist: {dist}")
+
+    expected = {
+        f"{TOOL_ID}.{version}.nupkg": _verify_tool,
+        f"{ANALYZER_ID}.{version}.nupkg": _verify_analyzer,
+        f"{TOOL_ID}.{version}.snupkg": _verify_tool_symbols,
+        f"{ANALYZER_ID}.{version}.snupkg": _verify_analyzer_symbols,
+    }
+    actual = {
+        path.name
+        for path in dist.iterdir()
+        if path.is_file() and path.name.lower().endswith((".nupkg", ".snupkg"))
+    }
+    if actual != set(expected):
+        missing = sorted(set(expected) - actual)
+        extra = sorted(actual - set(expected))
+        raise VerificationError(
+            f"release artifact set mismatch; missing={missing!r}, unexpected={extra!r}"
+        )
+
+    for filename, verifier in expected.items():
+        package = Package(dist / filename)
+        try:
+            verifier(package, version)
+        finally:
+            package.close()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dist", type=Path, required=True, help="Directory containing packed artifacts")
+    parser.add_argument("--version", required=True, help="Resolved release version")
+    args = parser.parse_args(argv)
+
+    try:
+        verify_release_packages(args.dist, args.version)
+    except VerificationError as exc:
+        print(f"release package verification failed: {exc}", file=sys.stderr)
+        return 1
+    print(f"Verified release package set for {args.version}: two packages and two symbol packages")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/skills/maf-migration-guide/SKILL.md
+++ b/.github/skills/maf-migration-guide/SKILL.md
@@ -1,170 +1,114 @@
 ---
 name: maf-migration-guide
-description: "Full MAF 1.3.0 migration reference guide, navigated by section. Load this skill when you need API signatures, before/after code patterns, or detailed explanations of MAF 1.3.0 changes. The guide lives at guides/maf-1.3.0-migration-guide.md — this skill is the smart index that tells you which section to read for a given question."
+description: "Version-aware navigator for Microsoft Agent Framework migrations. Load this skill for ordered upgrade paths, exact package versions, breaking API recipes, behavioral changes, or guide citations across every tracked MAF release."
 ---
 
-# MAF 1.3.0 Migration Guide — Navigator
+# MAF Migration Guide — Version-Aware Navigator
 
-The full guide is at **`guides/maf-1.3.0-migration-guide.md`**.
+MAF migrations are cumulative. Never jump directly to the newest guide and
+assume it contains earlier changes. Determine the source and target versions,
+then apply every intervening per-version guide in ascending order.
 
-This SKILL.md is the **index** — use it to find the right section for your question, then read only that section of the guide with `read_file`. This keeps context efficient.
+## Start Here
 
----
+1. Read `maf://constraints` before proposing code changes.
+2. Identify the exact installed MAF package versions from the project and its
+   resolved dependency graph. Do not infer them from a solution name or a bare
+   release-train number.
+3. Call `MafMigrationPath(currentVer, targetVer)`. Its ordered result is the
+   authoritative set of per-version guide sections for the migration.
+4. Read each returned `guides/maf-X.Y.Z-migration-guide.md` file in order. For a
+   single-step upgrade, read that target version's file directly.
+5. Use `MafRegistryLookup` or `MafRunCs0618Hunt` for an exact symbol recipe, then
+   restore, build, and run the relevant behavior tests.
 
-## Section Index
+The tracked target is recorded in `.maf-version`; do not hard-code the newest
+version into automation. `guides/maf-current-migration-guide.md` is the generated
+cumulative reading copy. Edit a per-version source guide, never the cumulative
+file, and regenerate it with:
 
-| Section | Title | Read when… |
-|---------|-------|-----------|
-| 1 | Introduction & scope | You need to understand what changed at a high level |
-| 2 | Package matrix | Looking up the correct version of any MAF/Extensions.AI package |
-| 3 | Agent creation — `.AsAIAgent()` | Migrating agent instantiation patterns |
-| 4 | `ChatClientAgentOptions` — Instructions placement | `Instructions` or `Tools` at wrong level |
-| 5 | A2A agent registration | Migrating `AIAgentExtensions` or `app.MapA2A` |
-| 6 | Sessions — `AgentSession` | Migrating `AgentThread`, `GetNewThread()`, session serialization |
-| 7 | Memory and context providers | `ChatHistoryProvider`, `AIContextProvider`, `ProviderSessionState<T>` |
-| 8 | Middleware | `.AsBuilder().Use().Build()` pattern |
-| 9 | Executors and workflows | `ReflectingExecutor` → `partial class : Executor` + `[MessageHandler]`, fan-out/fan-in |
-| 10 | Response processing | `AgentResponse.Text`, `.Messages`, streaming updates |
-| 11 | Structured output | `RunAsync<T>()` returning `AgentResponse<T>` |
-| 12 | Tool approval | `ApprovalRequiredAIFunction`, `FunctionApprovalRequestContent` |
-| 13 | Observability | `.UseOpenTelemetry(sourceName:)` |
-| 14 | DevUI and Hosting | `#if DEVUI_ENABLED` guard pattern |
-| 15 | Source generator setup | `Microsoft.Agents.AI.Workflows.Generators`, `EmitCompilerGeneratedFiles` |
-| 16 | `[StreamsMessage]` / `[YieldsMessage]` removal | These attributes are gone; what to do instead |
-| 17 | Streaming — `RunStreamingAsync()` | `InProcessExecution.StreamAsync()` → `RunStreamingAsync()` |
-| 18 | Event rename | `AgentRunUpdateEvent` → `AgentResponseUpdateEvent` |
-| 19 | Namespace changes | Old vs. new namespace mappings |
-| 20 | Migration checklist | End-to-end verification steps |
-| 21 | Obsolete API Registry (CS0618) | Known `[Obsolete]` APIs, why dotnet-inspect misses them |
-
----
-
-## Quick Lookup by Symptom
-
-| Symptom / Error | Read sections |
-|-----------------|---------------|
-| `CS0246: Type 'ReflectingExecutor' not found` | 9 |
-| `CS0246: [StreamsMessage] not found` | 9, 16 |
-| `CS0618: AddFanInBarrierEdge is obsolete` | 9, 21 |
-| Fan-in never reached, workflow exits silently | 9 |
-| `AgentThread` not found | 6 |
-| `GetNewThread()` not found | 6 |
-| `Deserialize<T>()` not found on `AgentResponse` | 11 |
-| `StreamAsync()` not found | 17 |
-| `AgentRunUpdateEvent` not found | 18 |
-| `AIAgentExtensions` not found | 5 |
-| `MapA2A` not found | 5 |
-| `Instructions =` compiles but has no effect | 4 |
-| Source generator not generating `ExecuteCoreAsync` | 15 |
-| IDE shows `CS0534` on executor class | 15 |
-| `DefaultAzureCredential` in production | Any — constraint violation, use `ManagedIdentityCredential` |
-
----
-
-## How to Read Sections
-
-```
-read_file(
-  filePath: "guides/maf-1.3.0-migration-guide.md",
-  startLine: <section start line>,
-  endLine: <section end line>
-)
+```text
+python .github/scripts/gen_guide_section.py --cumulative-only
 ```
 
-If you don't know the line numbers, read the guide's table of contents first (typically the first 50 lines) to find section headings, then read the specific section.
+## Guide Inventory
 
----
+| Target version | Source guide | Status / primary purpose |
+|---|---|---|
+| 1.3.0 | `guides/maf-1.3.0-migration-guide.md` | Complete foundational guide: agents, sessions, executors, workflows, streaming, hosting, and source generation. |
+| 1.4.0 | `guides/maf-1.4.0-migration-guide.md` | Draft evidence; verify unfilled human analysis before relying on it. |
+| 1.5.0 | `guides/maf-1.5.0-migration-guide.md` | Draft evidence; verify unfilled human analysis before relying on it. |
+| 1.6.1 | `guides/maf-1.6.1-migration-guide.md` | Reviewed 1.5-to-1.6.1 delta. |
+| 1.10.0 | `guides/maf-1.10.0-migration-guide.md` | Reviewed 1.6.1-to-1.10 delta. |
+| 1.11.0 | `guides/maf-1.11.0-migration-guide.md` | Reviewed 1.10-to-1.11 delta. |
+| 1.11.1 | `guides/maf-1.11.1-migration-guide.md` | Reviewed servicing delta. |
+| 1.12.0 | `guides/maf-1.12.0-migration-guide.md` | Reviewed 1.11.1-to-1.12 delta. |
+| 1.13.0 | `guides/maf-1.13.0-migration-guide.md` | Reviewed file-store and file-access migration. |
+| 1.14.0 | `guides/maf-1.14.0-migration-guide.md` | Reviewed agent/session, approval, Harness, AG-UI, Copilot, and Shell migration. |
+| 1.15.0 | `guides/maf-1.15.0-migration-guide.md` | Reviewed Hosting session-store and workflow behavior migration. |
+| 1.16.0 | `guides/maf-1.16.0-migration-guide.md` | Reviewed VectorData 10.7, Magentic, persistence, hosting, and security-boundary migration. |
+| 1.17.0 | `guides/maf-1.17.0-migration-guide.md` | Reviewed declarative failure/redaction and durable-extension lifecycle migration. |
 
-## Section 9 Subsections (Executors — Most Complex)
+If a requested path crosses 1.4 or 1.5, surface the draft status and verify those
+steps against the exact assemblies and official tag before applying them. Do
+not silently omit those versions.
 
-Section 9 is the largest. Key subsections:
+## How Each Per-Version Guide Is Organized
 
-| Subsection | Topic |
-|------------|-------|
-| 9.1 | `partial class : Executor` + `[MessageHandler]` pattern |
-| 9.2 | Source generator setup and `sealed partial` requirement |
-| 9.3 | Agent `.BindAsExecutor(emitEvents: true)` |
-| 9.4 | Fan-out executor — **must return `ValueTask<T>`** |
-| 9.5 | Fan-in barrier — `AddFanInBarrierEdge(sources, target)` correct argument order |
-| 9.6 | Complete working example — full workflow with fan-out and fan-in |
+Every watcher-generated guide has protected package/release evidence followed
+by four reviewed analysis sections:
 
-When diagnosing a fan-out/fan-in issue, read 9.4 and 9.5 first.
+- **Breaking Changes** — source, binary, dependency, and behavior compatibility
+  work required for that step.
+- **New Patterns** — exact package versions, lifecycle transitions, and current
+  usage recipes.
+- **Obsolete APIs Added** — new compiler-warning migrations for that release.
+- **Known Misalignments** — release-note, package, source, or documentation gaps
+  that an API diff alone cannot explain.
 
----
+Treat package maturity as part of the contract. Stable, preview, release
+candidate, and alpha packages in one MAF train can have different exact
+versions. A package split, externalization, or independent release cadence is
+not permission to invent a coordinated version or rename a package reference.
 
-## Key Patterns at a Glance
+## Route by Question
 
-### Executor (was: ReflectingExecutor)
-```csharp
-// BEFORE
-public class MyExecutor : ReflectingExecutor<MyInput>
-{
-    public async Task<MyOutput> HandleAsync(MyInput input) { ... }
-}
+| Question or symptom | Use |
+|---|---|
+| “What do I read from A to B?” | `MafMigrationPath(A, B)`, then the returned guides in order. |
+| CS0618, CS0246, CS1503, or a removed member | `MafRunCs0618Hunt`, then `MafRegistryLookup` for the matching entry. |
+| Exact package/framework compatibility | `MafCompatibility(targetVersion)` plus `docs/compatibility-matrix.md`. |
+| Public API change between two artifacts | `MafDiffPackage` with the exact published versions. |
+| Empty response, hung workflow, lost state, or changed failure behavior | The target guide's Breaking Changes, New Patterns, and Known Misalignments; add a runtime regression test. |
+| A security-sensitive fix | `maf://constraints`, `docs/security.md`, and the relevant guide's trust-boundary notes. |
+| A 1.2-to-1.3 executor/session migration | The full 1.3 guide's sections 6, 9, 15, 17, and 20. |
 
-// AFTER
-public sealed partial class MyExecutor : Executor
-{
-    [MessageHandler]
-    public async ValueTask<MyOutput> HandleAsync(MyInput input, ExecutorContext context) { ... }
-}
-```
+## Current High-Risk Checkpoints
 
-### Session (was: AgentThread)
-```csharp
-// BEFORE
-var thread = agent.GetNewThread();
-var response = await agent.RunAsync(input, thread);
+- **1.14:** agent/session lifecycle changes, approval semantics, explicit Harness
+  file/shell composition, AG-UI package split, Copilot function declarations,
+  and the binary-breaking `ShellPolicy` constructor.
+- **1.15:** preview Hosting `conversationId:` named arguments become
+  `sessionStoreId:`, custom stores implement `DeleteSessionAsync`, and session
+  snapshots/checkpoints have stronger isolation and ordering contracts.
+- **1.16:** the VectorData floor moves from 9.7 to 10.7; first-party MAF API
+  diffs remain mostly additive, but transitive source/provider migrations and
+  several persistence/hosting behavior checks are required.
+- **1.17:** public APIs and dependency floors are clean, while declarative agent
+  errors become terminal and Foundry failure detail remains subject to host
+  redaction. Durable Task and Azure Functions retain their package IDs but move
+  to an independently versioned extension repository.
 
-// AFTER
-var session = await agent.CreateSessionAsync(cancellationToken);
-var response = await agent.RunAsync(input, session);
-```
+## Verification Contract
 
-### Fan-out handler (must return the message)
-```csharp
-// BEFORE (wrong — void return starves fan-in)
-[MessageHandler]
-public async ValueTask HandleAsync(ClaimData claim, ExecutorContext context)
-{
-    var result = await ProcessAsync(claim);
-    await context.SendMessageAsync(result);  // ← wrong in 1.3.0
-}
-
-// AFTER (correct — return value IS the fan-out message)
-[MessageHandler]
-public async ValueTask<ValidationResult> HandleAsync(ClaimData claim, ExecutorContext context)
-{
-    return await ProcessAsync(claim);
-}
-```
-
----
-
-## Version-Keyed Section Metadata
-
-Every section in `guides/maf-1.3.0-migration-guide.md` carries a machine-readable metadata comment:
-
-```html
-<!-- introduced: 1.3.0 | applies-to: 1.2.x → 1.3.x | deprecated-in: none -->
-## Section N — Title
-```
-
-**What the fields mean:**
-
-| Field | Values | Purpose |
-|-------|--------|---------|
-| `introduced` | MAF version | When this section's content first became relevant |
-| `applies-to` | Source → target range | Which migration paths need this section |
-| `deprecated-in` | MAF version or `none` | When this section's patterns became obsolete |
-
-**How to use these metadata tags:**
-
-When migrating from version A to version B, load only sections where:
-- `applies-to` includes the A → B path
-- `deprecated-in` is `none` OR is a version later than B
-
-Example: Migrating 1.2.0 → 1.3.0 → load sections with `applies-to: 1.2.x → 1.3.x` and `deprecated-in: none`.  
-Example: Migrating 1.3.0 → 1.4.0 → skip sections tagged `introduced: 1.3.0` (already applied) and load sections tagged `introduced: 1.4.0`.
-
-When the `maf-release-watcher` adds new sections for future MAF versions, they will carry updated `introduced` and `applies-to` tags so agents automatically load the right sections for the active migration path.
+- Pin repository-supported `dotnet-inspect` exactly as required by
+  `maf://constraints`; reject truncated or structurally invalid diff output.
+- Build the real solution with warnings visible. The compiler is authoritative
+  for overload resolution and project-local or transitive obsolete usage.
+- Run targeted runtime tests for session continuity, checkpoint restore,
+  streaming completion/error paths, tool approval, fan-out/fan-in, and hosting
+  boundaries touched by the selected guides.
+- Re-run MAF Doctor after edits and report `scan_truncated` or other incomplete
+  evidence rather than presenting a partial scan as clean.
+- Keep before/after recipes scoped to the exact release where they apply. A
+  correct 1.3 replacement can itself require migration in a later step.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -91,13 +91,16 @@ jobs:
         env:
           INPUT_VERSION: ${{ inputs.version }}
         run: |
+          IS_TAG=false
           if [ -n "$INPUT_VERSION" ]; then
             VERSION="$INPUT_VERSION"
           elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
+            IS_TAG=true
           elif [[ "$GITHUB_REF" == refs/tags/[0-9]* ]]; then
             # SEC-14: unprefixed numeric tag (mirrors release.yml + the trigger above).
             VERSION="${GITHUB_REF#refs/tags/}"
+            IS_TAG=true
           else
             # WM-33: blank-version manual dispatch — use the latest git tag, as the
             # input description promises (the old else-branch aborted here instead).
@@ -109,6 +112,7 @@ jobs:
             echo "Using latest git tag: $VERSION"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "is_tag=$IS_TAG" >> $GITHUB_OUTPUT
 
           # Mark prereleases — they don't get the `latest` tag. SEC-28-aligned: ANY
           # hyphen is a SemVer prerelease label (-dev/-nightly/… too), not just four.
@@ -118,6 +122,18 @@ jobs:
             echo "is_prerelease=false" >> $GITHUB_OUTPUT
           fi
           echo "Building image for version: $VERSION"
+
+      - name: Guard — tag commit must be on main (SEC-13)
+        # Keep tag-triggered GHCR publishing on reviewed history, matching release.yml.
+        # Manual dispatch remains an explicit maintainer action and is not tag-gated.
+        if: steps.version.outputs.is_tag == 'true'
+        run: |
+          git fetch --no-tags --depth=2147483647 origin main
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag commit $GITHUB_SHA is not an ancestor of origin/main — refusing to publish an image from a commit that isn't on the reviewed main branch."
+            exit 1
+          fi
+          echo "✅ Tag commit is on main."
 
       - name: Log in to GHCR
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,8 +189,13 @@ jobs:
         # an error on .NET SDK 10.0.300+ (Linux runner) but as a warning with exit 0
         # on 10.0.102 (Windows local). The nupkg IS produced correctly in both cases
         # (verified by `unzip -l` showing analyzers/dotnet/cs/*.dll present).
-        # Workaround: tolerate the pack exit code; verify success by nupkg presence.
+        # Workaround: tolerate the first pack's exit code and verify the main nupkg.
+        # A second no-build pack enables the SDK build-output path only in an isolated
+        # directory so NuGet can create the analyzer .snupkg. We copy only that symbol
+        # package; the canonical main nupkg retains its single analyzer DLL layout.
         shell: bash
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           set +e
           dotnet pack src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj \
@@ -198,12 +203,34 @@ jobs:
             --no-restore \
             --output src/dist/
           PACK_EXIT=$?
-          if ls src/dist/maf-doctor.Analyzers*.nupkg >/dev/null 2>&1; then
-            echo "Packed: $(ls src/dist/maf-doctor.Analyzers*.nupkg)"
-            exit 0
+          set -e
+          MAIN_PACKAGE="src/dist/maf-doctor.Analyzers.${VERSION}.nupkg"
+          if [ ! -f "$MAIN_PACKAGE" ]; then
+            echo "::error::Analyzer nupkg was not produced (pack exit code was $PACK_EXIT)"
+            exit 1
           fi
-          echo "::error::Analyzer nupkg was not produced (pack exit code was $PACK_EXIT)"
-          exit "$PACK_EXIT"
+
+          SYMBOL_DIR="$RUNNER_TEMP/maf-doctor-analyzer-symbols-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          mkdir -p "$SYMBOL_DIR"
+          dotnet pack src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj \
+            --configuration Release \
+            --no-build \
+            --no-restore \
+            --output "$SYMBOL_DIR" \
+            -p:IncludeBuildOutput=true \
+            -p:BuildOutputTargetFolder=analyzers/dotnet/cs
+          SYMBOL_PACKAGE="$SYMBOL_DIR/maf-doctor.Analyzers.${VERSION}.snupkg"
+          if [ ! -f "$SYMBOL_PACKAGE" ]; then
+            echo "::error::Analyzer symbol package was not produced"
+            exit 1
+          fi
+          cp "$SYMBOL_PACKAGE" src/dist/
+          echo "Packed: $MAIN_PACKAGE and src/dist/$(basename "$SYMBOL_PACKAGE")"
+
+      - name: Verify release package artifacts
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: python3 .github/scripts/verify_release_packages.py --dist src/dist --version "$VERSION"
 
       - name: Attest build provenance (SEC-13)
         # Signed provenance over the exact packages this run produced — makes a
@@ -212,7 +239,7 @@ jobs:
         # (v4.1.1) per the repo-wide supply-chain hardening.
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
-          subject-path: 'src/dist/*.nupkg'
+          subject-path: 'src/dist/*nupkg'
 
       - name: Publish to NuGet
         # SEC-13: the API key is read from env: (not ${{ }}-templated into the run
@@ -241,5 +268,5 @@ jobs:
         # arbitrary code into our release workflow with NUGET_API_KEY in scope.
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b  # v3.0.1
         with:
-          files: src/dist/*.nupkg
+          files: src/dist/*nupkg
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+_No unreleased changes yet._
+
+## [1.15.0] - 2026-08-17
+
+**Sequential MAF release intelligence, deterministic package evidence, and a
+repaired CI/self-update path.** MAF Doctor now tracks each Microsoft Agent
+Framework release in order instead of collapsing a backlog into the newest tag.
+
+### Microsoft Agent Framework lifecycle intelligence
+
+- Added reviewed, ordered migration intelligence for MAF **1.14 → 1.15 → 1.16
+  → 1.17**, including exact package maturity/version resolution, public API and
+  dependency-floor evidence, behavioral compatibility checkpoints, registry
+  recipes, and regenerated cumulative guidance.
+- Captured the 1.14 agent/session, approval, Harness, AG-UI, GitHub Copilot, and
+  Shell breaks; the 1.15 preview Hosting session-store contract; the 1.16
+  VectorData 10.7 and runtime-lifecycle changes; and the 1.17 declarative
+  failure/redaction behavior plus Durable Task/Azure Functions externalization.
+
 ### Fixed
 
+- **Installed migration knowledge is cumulative and ordered.** `maf://guide`
+  now embeds the checked-in 1.3→1.17 cumulative guide instead of the stale
+  1.3-only document. `MafMigrationPath` accepts both legacy and current metadata
+  shapes, excludes the already-applied source step, and returns each intervening
+  release in order.
+- **Release artifacts are verified before publication.** The release workflow
+  now validates both NuGet packages and both symbol packages, including package
+  identity, version, TFMs, tool settings, analyzer layout, README, icon, and
+  symbol payloads. Symbol artifacts are attested and attached to the GitHub
+  release, and tag-triggered GHCR publishing now rejects commits outside `main`.
 - **Semantic review restored after GitHub Models retirement.** The workflow now
   uses GitHub Copilot CLI with the short-lived `GITHUB_TOKEN`, an exact-pinned
   CLI, no enabled Copilot tools, and the seat's supported default model rather
@@ -797,7 +826,10 @@ Internal alpha; superseded by `1.3.0-alpha-3`. Not announced.
 
 Initial MCP server prototype. Three tools (`MafApiSafety`, `MafRegistryLookup`, `MafRegistryList`), 11 skills, 2 agents, 10 registry entries. Validated against one real migration (`maf-claims-fraud-guardian` 1.2.0 → 1.3.0). Internal alpha; not announced.
 
-[Unreleased]: https://github.com/joslat/maf-doctor/compare/v1.12.0...HEAD
+[Unreleased]: https://github.com/joslat/maf-doctor/compare/v1.15.0...HEAD
+[1.15.0]: https://github.com/joslat/maf-doctor/compare/v1.14.0...v1.15.0
+[1.14.0]: https://github.com/joslat/maf-doctor/compare/v1.13.0...v1.14.0
+[1.13.0]: https://github.com/joslat/maf-doctor/compare/v1.12.0...v1.13.0
 [1.12.0]: https://github.com/joslat/maf-doctor/releases/tag/v1.12.0
 [1.11.0]: https://github.com/joslat/maf-doctor/releases/tag/v1.11.0
 [1.10.0]: https://github.com/joslat/maf-doctor/releases/tag/v1.10.0

--- a/guides/maf-1.10.0-migration-guide.md
+++ b/guides/maf-1.10.0-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.10.0 Migration Guide (draft)
+# MAF 1.10.0 Migration Guide
 
 <!-- introduced: 1.10.0 | applies-to: 1.6.1.x → 1.10.0.x | deprecated-in: none -->
 

--- a/guides/maf-1.11.0-migration-guide.md
+++ b/guides/maf-1.11.0-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.11.0 Migration Guide (draft)
+# MAF 1.11.0 Migration Guide
 
 <!-- introduced: 1.11.0 | applies-to: 1.10.0.x → 1.11.0.x | deprecated-in: none -->
 

--- a/guides/maf-1.11.1-migration-guide.md
+++ b/guides/maf-1.11.1-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.11.1 Migration Guide (draft)
+# MAF 1.11.1 Migration Guide
 
 <!-- introduced: 1.11.1 | applies-to: 1.11.0.x → 1.11.1.x | deprecated-in: none -->
 

--- a/guides/maf-1.12.0-migration-guide.md
+++ b/guides/maf-1.12.0-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.12.0 Migration Guide (draft)
+# MAF 1.12.0 Migration Guide
 
 <!-- introduced: 1.12.0 | applies-to: 1.11.1.x → 1.12.0.x | deprecated-in: none -->
 

--- a/guides/maf-1.13.0-migration-guide.md
+++ b/guides/maf-1.13.0-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.13.0 Migration Guide (draft)
+# MAF 1.13.0 Migration Guide
 
 <!-- introduced: 1.13.0 | applies-to: 1.12.0.x → 1.13.0.x | deprecated-in: none -->
 

--- a/guides/maf-1.14.0-migration-guide.md
+++ b/guides/maf-1.14.0-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.14.0 Migration Guide (draft)
+# MAF 1.14.0 Migration Guide
 
 <!-- introduced: 1.14.0 | applies-to: 1.13.0.x → 1.14.0.x | deprecated-in: none -->
 

--- a/guides/maf-1.15.0-migration-guide.md
+++ b/guides/maf-1.15.0-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.15.0 Migration Guide (draft)
+# MAF 1.15.0 Migration Guide
 
 <!-- introduced: 1.15.0 | applies-to: 1.14.0.x → 1.15.0.x | deprecated-in: none -->
 

--- a/guides/maf-1.16.0-migration-guide.md
+++ b/guides/maf-1.16.0-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.16.0 Migration Guide (draft)
+# MAF 1.16.0 Migration Guide
 
 <!-- introduced: 1.16.0 | applies-to: 1.15.0.x → 1.16.0.x | deprecated-in: none -->
 

--- a/guides/maf-1.17.0-migration-guide.md
+++ b/guides/maf-1.17.0-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.17.0 Migration Guide (draft)
+# MAF 1.17.0 Migration Guide
 
 <!-- introduced: 1.17.0 | applies-to: 1.16.0.x → 1.17.0.x | deprecated-in: none -->
 

--- a/guides/maf-1.6.1-migration-guide.md
+++ b/guides/maf-1.6.1-migration-guide.md
@@ -1,4 +1,4 @@
-# MAF 1.6.1 Migration Guide (draft)
+# MAF 1.6.1 Migration Guide
 
 <!-- introduced: 1.6.1 | applies-to: 1.5.0.x → 1.6.1.x | deprecated-in: none -->
 

--- a/guides/maf-current-migration-guide.md
+++ b/guides/maf-current-migration-guide.md
@@ -2633,7 +2633,7 @@ stem.IDisposable' was added
 
 <small>Source: [`guides/maf-1.6.1-migration-guide.md`](./maf-1.6.1-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.6.1 Migration Guide (draft)
+# MAF 1.6.1 Migration Guide
 
 <!-- introduced: 1.6.1 | applies-to: 1.5.0.x → 1.6.1.x | deprecated-in: none -->
 
@@ -2769,7 +2769,7 @@ The `expectedOutput` parameter is optional and defaults to `null`. When provided
 
 <small>Source: [`guides/maf-1.10.0-migration-guide.md`](./maf-1.10.0-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.10.0 Migration Guide (draft)
+# MAF 1.10.0 Migration Guide
 
 <!-- introduced: 1.10.0 | applies-to: 1.6.1.x → 1.10.0.x | deprecated-in: none -->
 
@@ -2959,7 +2959,7 @@ The following APIs were removed (CS0246) or their signatures changed (CS0618) in
 
 <small>Source: [`guides/maf-1.11.0-migration-guide.md`](./maf-1.11.0-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.11.0 Migration Guide (draft)
+# MAF 1.11.0 Migration Guide
 
 <!-- introduced: 1.11.0 | applies-to: 1.10.0.x → 1.11.0.x | deprecated-in: none -->
 
@@ -3170,7 +3170,7 @@ This list of changes was [auto generated](https://msdata.visualstudio.com/Vienna
 
 <small>Source: [`guides/maf-1.11.1-migration-guide.md`](./maf-1.11.1-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.11.1 Migration Guide (draft)
+# MAF 1.11.1 Migration Guide
 
 <!-- introduced: 1.11.1 | applies-to: 1.11.0.x → 1.11.1.x | deprecated-in: none -->
 
@@ -3311,7 +3311,7 @@ The `dotnet-inspect` public-surface diff did **not** surface the "approval by de
 
 <small>Source: [`guides/maf-1.12.0-migration-guide.md`](./maf-1.12.0-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.12.0 Migration Guide (draft)
+# MAF 1.12.0 Migration Guide
 
 <!-- introduced: 1.12.0 | applies-to: 1.11.1.x → 1.12.0.x | deprecated-in: none -->
 
@@ -3417,7 +3417,7 @@ No `[Obsolete]` deprecations. One hard **removal** (a compile error, not a warni
 
 <small>Source: [`guides/maf-1.13.0-migration-guide.md`](./maf-1.13.0-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.13.0 Migration Guide (draft)
+# MAF 1.13.0 Migration Guide
 
 <!-- introduced: 1.13.0 | applies-to: 1.12.0.x → 1.13.0.x | deprecated-in: none -->
 
@@ -3527,7 +3527,7 @@ No known misalignments at generation time. The `dotnet-inspect diff Microsoft.Ag
 
 <small>Source: [`guides/maf-1.14.0-migration-guide.md`](./maf-1.14.0-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.14.0 Migration Guide (draft)
+# MAF 1.14.0 Migration Guide
 
 <!-- introduced: 1.14.0 | applies-to: 1.13.0.x → 1.14.0.x | deprecated-in: none -->
 
@@ -4014,7 +4014,7 @@ None detected in the validated public API diffs.
 
 <small>Source: [`guides/maf-1.15.0-migration-guide.md`](./maf-1.15.0-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.15.0 Migration Guide (draft)
+# MAF 1.15.0 Migration Guide
 
 <!-- introduced: 1.15.0 | applies-to: 1.14.0.x → 1.15.0.x | deprecated-in: none -->
 
@@ -4629,7 +4629,7 @@ migration-guide entries.
 
 <small>Source: [`guides/maf-1.16.0-migration-guide.md`](./maf-1.16.0-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.16.0 Migration Guide (draft)
+# MAF 1.16.0 Migration Guide
 
 <!-- introduced: 1.16.0 | applies-to: 1.15.0.x → 1.16.0.x | deprecated-in: none -->
 
@@ -5291,7 +5291,7 @@ Those failures are dependency migration work, not newly obsolete MAF APIs.
 
 <small>Source: [`guides/maf-1.17.0-migration-guide.md`](./maf-1.17.0-migration-guide.md) — edit there for changes to this section.</small>
 
-# MAF 1.17.0 Migration Guide (draft)
+# MAF 1.17.0 Migration Guide
 
 <!-- introduced: 1.17.0 | applies-to: 1.16.0.x → 1.17.0.x | deprecated-in: none -->
 

--- a/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
+++ b/src/maf-autopilot.Analyzers/maf-autopilot.Analyzers.csproj
@@ -14,7 +14,7 @@
 
     <!-- NuGet packaging -->
     <PackageId>maf-doctor.Analyzers</PackageId>
-    <Version>1.14.0</Version>
+    <Version>1.15.0</Version>
     <Authors>joslat</Authors>
     <Description>Roslyn analyzers for Microsoft Agent Framework (MAF) — write-time enforcement of fan-out safety, secure credentials, and observability defaults (MAF001-MAF003). Companion to the maf-doctor .NET global tool / MCP server.</Description>
     <PackageTags>maf;agent-framework;analyzer;roslyn;dotnet</PackageTags>

--- a/src/maf-autopilot.Tests/MafResourcesTests.cs
+++ b/src/maf-autopilot.Tests/MafResourcesTests.cs
@@ -33,13 +33,18 @@ public class MafResourcesTests
     }
 
     [Fact]
-    public void GetGuide_ReturnsNonEmptyMarkdown()
+    public void GetGuide_MatchesCheckedInCumulativeGuideAndCurrentTrackedVersion()
     {
-        var body = MafResources.GetGuide();
-        Assert.False(string.IsNullOrWhiteSpace(body));
-        // The guide opens with a top-level heading; assert a generic property
-        // rather than exact wording so cosmetic edits don't break the test.
-        Assert.Contains("MAF", body);
+        var root = ResolveRepoRoot();
+        var expected = File.ReadAllText(Path.Combine(root, "guides", "maf-current-migration-guide.md"));
+        var trackedVersion = File.ReadAllText(Path.Combine(root, ".maf-version")).Trim();
+        var actual = MafResources.GetGuide();
+
+        Assert.False(string.IsNullOrWhiteSpace(actual));
+        Assert.Equal(expected, actual);
+        Assert.Contains("# MAF Migration Guide — Cumulative", actual, StringComparison.Ordinal);
+        Assert.Contains($"## Migrating to MAF {trackedVersion}", actual, StringComparison.Ordinal);
+        Assert.Contains($"introduced: {trackedVersion}", actual, StringComparison.Ordinal);
     }
 
     // -------------------------------------------------------------------------
@@ -89,12 +94,17 @@ public class MafResourcesTests
     }
 
     private static string ResolveSkillsDir()
+        => Path.Combine(ResolveRepoRoot(), ".github", "skills");
+
+    private static string ResolveRepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".github", "skills")))
+        while (dir is not null
+            && (!File.Exists(Path.Combine(dir.FullName, ".maf-version"))
+                || !File.Exists(Path.Combine(dir.FullName, "guides", "maf-current-migration-guide.md"))))
             dir = dir.Parent;
         Assert.NotNull(dir);
-        return Path.Combine(dir!.FullName, ".github", "skills");
+        return dir!.FullName;
     }
 
     [Theory]

--- a/src/maf-autopilot.Tests/MigrationPathToolTests.cs
+++ b/src/maf-autopilot.Tests/MigrationPathToolTests.cs
@@ -54,6 +54,18 @@ public class MigrationPathToolTests
         Assert.NotNull(result);
     }
 
+    [Fact]
+    public void ParseMetadata_PatchQualifiedWildcards_Extracts()
+    {
+        const string line = "<!-- introduced: 1.17.0 | applies-to: 1.16.0.x → 1.17.0.x | deprecated-in: none -->";
+        var result = MigrationPathTool.ParseMetadata(line);
+
+        Assert.NotNull(result);
+        Assert.Equal(new SemVer(1, 17, 0), result!.Value.Introduced);
+        Assert.Equal(new SemVer(1, 16, 0), result.Value.AppliesFrom);
+        Assert.Equal(new SemVer(1, 17, 0), result.Value.AppliesTo);
+    }
+
     // -------------------------------------------------------------------------
     // Section extraction
     // -------------------------------------------------------------------------
@@ -89,6 +101,36 @@ public class MigrationPathToolTests
         var sections = MigrationPathTool.ExtractSections(md);
         Assert.Single(sections);
         Assert.Equal("Section with metadata", sections[0].Title);
+    }
+
+    [Fact]
+    public void ExtractSections_MetadataBeforeHeading_IsExtracted()
+    {
+        const string md = """
+            # Top
+            <!-- introduced: 1.3.0 | applies-to: 1.2.x → 1.3.x -->
+            ## Legacy section
+            Body content.
+            """;
+
+        var section = Assert.Single(MigrationPathTool.ExtractSections(md));
+        Assert.Equal("Legacy section", section.Title);
+        Assert.Equal(new SemVer(1, 3, 0), section.IntroducedAt);
+    }
+
+    [Fact]
+    public void ExtractSections_DoesNotStealMetadataFromFollowingHeading()
+    {
+        const string md = """
+            ## Section without metadata
+            Body content.
+            <!-- introduced: 1.4.0 | applies-to: 1.3.0.x → 1.4.0.x -->
+            ## Section with leading metadata
+            More body.
+            """;
+
+        var section = Assert.Single(MigrationPathTool.ExtractSections(md));
+        Assert.Equal("Section with leading metadata", section.Title);
     }
 
     // -------------------------------------------------------------------------
@@ -142,6 +184,22 @@ public class MigrationPathToolTests
         Assert.DoesNotContain(result, r => r.Title == "Future");
     }
 
+    [Fact]
+    public void SelectApplicable_ExcludesAlreadyAppliedSourceVersion()
+    {
+        var sections = new[]
+        {
+            new GuideSection("Current", 1, new SemVer(1, 13, 0), new SemVer(1, 12, 0), new SemVer(1, 13, 0)),
+            new GuideSection("Next", 5, new SemVer(1, 14, 0), new SemVer(1, 13, 0), new SemVer(1, 14, 0)),
+        };
+
+        var result = MigrationPathTool.SelectApplicable(
+            sections, new SemVer(1, 13, 0), new SemVer(1, 14, 0));
+
+        var section = Assert.Single(result);
+        Assert.Equal("Next", section.Title);
+    }
+
     // -------------------------------------------------------------------------
     // MCP tool entry — input validation
     // -------------------------------------------------------------------------
@@ -165,13 +223,34 @@ public class MigrationPathToolTests
     }
 
     [Fact]
-    public void MafMigrationPath_RealGuide_RunsCleanly()
+    public void MafMigrationPath_RealGuide_LegacyMetadataProducesGuidance()
     {
         var tool = new MigrationPathTool();
-        var result = tool.MafMigrationPath("1.0.0", "1.3.0");
-        // The embedded guide has version-keyed sections; we expect a non-error
-        // report with the migration-path heading.
+        var result = tool.MafMigrationPath("1.2.0", "1.3.0");
+
         Assert.Contains("migration path", result, StringComparison.OrdinalIgnoreCase);
         Assert.DoesNotContain("Error", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("No version-keyed guide sections", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Package References & Dependencies", result, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MafMigrationPath_RealGuide_1_13To1_17_ContainsEveryStepInOrder()
+    {
+        var result = new MigrationPathTool().MafMigrationPath("1.13.0", "1.17.0");
+
+        Assert.DoesNotContain("Error", result, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("No version-keyed guide sections", result, StringComparison.OrdinalIgnoreCase);
+
+        var v14 = result.IndexOf("MAF 1.14.0 Migration Guide", StringComparison.Ordinal);
+        var v15 = result.IndexOf("MAF 1.15.0 Migration Guide", StringComparison.Ordinal);
+        var v16 = result.IndexOf("MAF 1.16.0 Migration Guide", StringComparison.Ordinal);
+        var v17 = result.IndexOf("MAF 1.17.0 Migration Guide", StringComparison.Ordinal);
+
+        Assert.True(v14 >= 0, "The 1.14 migration step was missing.");
+        Assert.True(v14 < v15, "The 1.15 migration step was missing or out of order.");
+        Assert.True(v15 < v16, "The 1.16 migration step was missing or out of order.");
+        Assert.True(v16 < v17, "The 1.17 migration step was missing or out of order.");
+        Assert.DoesNotContain("MAF 1.13.0 Migration Guide", result, StringComparison.Ordinal);
     }
 }

--- a/src/maf-autopilot/Prompts/MafPrompts.cs
+++ b/src/maf-autopilot/Prompts/MafPrompts.cs
@@ -402,7 +402,7 @@ public static class MafPrompts
         sb.AppendLine();
         sb.AppendLine("**Compiler errors (CS0618 / CS0246 / CS1061):**");
         sb.AppendLine("- `MafRunCs0618Hunt(projectPath)` — full-build scan; joins each diagnostic to the obsolete-API registry with deterministic fix.");
-        sb.AppendLine("- `MafApiSafety(apiName)` — is this specific symbol obsolete in 1.3.0?");
+        sb.AppendLine("- `MafApiSafety(apiName)` — is this specific symbol obsolete in the current tracked MAF release?");
         sb.AppendLine("- `MafRegistryLookup(id)` — full registry entry once you have the ID.");
         sb.AppendLine();
         sb.AppendLine("**Silent runtime failures (workflow completes, output empty/wrong):**");

--- a/src/maf-autopilot/Resources/MafResources.cs
+++ b/src/maf-autopilot/Resources/MafResources.cs
@@ -12,10 +12,10 @@ namespace MafDoctor.Resources;
 /// Static resources (no parameters):
 ///   maf://constraints  — hard constraints, always read before any migration task
 ///   maf://registry     — CS0618 obsolete API registry (YAML)
-///   maf://guide        — full MAF migration guide
+///   maf://guide        — cumulative, version-keyed MAF migration guide
 ///
 /// Template resource (one per skill):
-///   maf://skills?name=&lt;skillName&gt;  — any of the 14 skill SKILL.md files
+///   maf://skills?name=&lt;skillName&gt;  — any of the 15 skill SKILL.md files
 ///</summary>
 [McpServerResourceType]
 public static class MafResources
@@ -43,8 +43,8 @@ public static class MafResources
     [McpServerResource(UriTemplate = "maf://guide",
         MimeType = "text/markdown",
         Name = "maf-guide",
-        Title = "MAF Migration Guide")]
-    [Description("Full MAF migration reference guide with API signatures, before/after code patterns, and section-by-section explanations.")]
+        Title = "MAF Cumulative Migration Guide")]
+    [Description("Cumulative, version-keyed MAF migration reference with API signatures, before/after code patterns, and every reviewed upgrade step through the current tracked release.")]
     public static string GetGuide() => ReadEmbedded("guide.md");
 
     [McpServerResource(UriTemplate = "maf://migrate-from{?source}",

--- a/src/maf-autopilot/Tools/MigrationPathTool.cs
+++ b/src/maf-autopilot/Tools/MigrationPathTool.cs
@@ -12,8 +12,8 @@ namespace MafDoctor.Tools;
 /// Walks the embedded MAF migration guide's version-keyed section metadata
 /// (the <c>&lt;!-- introduced: X.Y.Z | applies-to: A.B.x → C.D.x --&gt;</c> comments)
 /// and emits an ordered list of sections that apply to a user's specific
-/// version range — so 1.0.0 → 1.3.0 migrations get every intermediate step
-/// surfaced in one pass instead of being treated as a 1.2 → 1.3 hop only.
+/// version range — so 1.13.0 → 1.17.0 migrations get every intermediate step
+/// surfaced in one pass instead of being treated as a direct hop only.
 /// </summary>
 [McpServerToolType]
 public sealed class MigrationPathTool
@@ -23,13 +23,13 @@ public sealed class MigrationPathTool
         Build an ordered, version-keyed migration plan for a specific version range.
 
         Walks every section of the embedded MAF migration guide, reads its
-        `applies-to: A.B.x → C.D.x` metadata, and selects sections whose range
-        overlaps the user's requested `currentVersion → targetVersion`. Returns
-        them in introduced-version order — the canonical step sequence.
+        `applies-to: A.B.x → C.D.x` metadata, and selects sections introduced
+        after `currentVersion` and no later than `targetVersion`. Returns them in
+        introduced-version order — the canonical step sequence.
 
         Input:
           - currentVersion: the MAF version your code is on today (e.g. "1.0.0").
-          - targetVersion: the MAF version you want to reach (e.g. "1.3.0").
+          - targetVersion: the MAF version you want to reach (e.g. "1.17.0").
 
         Returns a markdown report listing each matching section's title,
         introduced version, applies-to range, and section path so the migration
@@ -37,7 +37,7 @@ public sealed class MigrationPathTool
         """)]
     public string MafMigrationPath(
         [Description("Source MAF version, e.g. 1.0.0")] string currentVersion,
-        [Description("Target MAF version, e.g. 1.3.0")] string targetVersion)
+        [Description("Target MAF version, e.g. 1.17.0")] string targetVersion)
     {
         if (!TryParseVersion(currentVersion, out var fromVer))
             return $"Error: '{currentVersion}' is not a valid SemVer.";
@@ -60,7 +60,8 @@ public sealed class MigrationPathTool
     /// <summary>
     /// Parses every heading + version-metadata comment from the migration guide.
     /// Returns one entry per heading that has an `applies-to:` metadata comment
-    /// somewhere within the next ~6 lines of body text.
+    /// immediately before it (the original 1.3 guide shape) or near the start of
+    /// its body (the generated per-version guide shape).
     /// </summary>
     public static IReadOnlyList<GuideSection> ExtractSections(string guideMarkdown)
     {
@@ -74,20 +75,7 @@ public sealed class MigrationPathTool
             var headingMatch = Regex.Match(line, @"^(#{1,3})\s+(?<title>.+?)\s*$");
             if (!headingMatch.Success) continue;
 
-            // Search the next 6 lines for a metadata comment — but STOP if we
-            // hit another heading, so we don't accidentally attribute a later
-            // section's metadata to this one.
-            string? metadataLine = null;
-            for (var j = i + 1; j < Math.Min(i + 7, lines.Length); j++)
-            {
-                if (Regex.IsMatch(lines[j], @"^#{1,3}\s"))
-                    break;
-                if (lines[j].Contains("applies-to:", StringComparison.Ordinal))
-                {
-                    metadataLine = lines[j];
-                    break;
-                }
-            }
+            var metadataLine = FindMetadataForHeading(lines, i);
             if (metadataLine is null) continue;
 
             var meta = ParseMetadata(metadataLine);
@@ -104,8 +92,68 @@ public sealed class MigrationPathTool
     }
 
     /// <summary>
-    /// Returns every section whose [AppliesFrom, AppliesTo] range overlaps the
-    /// user's [fromVer, toVer] migration path, ordered by introduced version.
+    /// Associates metadata only when it is adjacent to the heading boundary.
+    /// This supports both checked-in guide conventions without stealing the
+    /// metadata that precedes a later heading in a short section.
+    /// </summary>
+    private static string? FindMetadataForHeading(string[] lines, int headingIndex)
+    {
+        // The hand-authored 1.3 guide puts metadata immediately before each
+        // section heading. Permit blank lines and a horizontal rule between the
+        // two, but stop at body text or another heading.
+        for (var j = headingIndex - 1; j >= Math.Max(headingIndex - 6, 0); j--)
+        {
+            var candidate = lines[j].Trim();
+            if (candidate.Contains("applies-to:", StringComparison.Ordinal))
+                return candidate;
+            if (candidate.Length == 0 || candidate == "---")
+                continue;
+            break;
+        }
+
+        // Generated per-version guides put metadata at the beginning of the
+        // heading body. Stop at the first real body line or following heading so
+        // a later section's leading metadata cannot be attributed here.
+        for (var j = headingIndex + 1; j < Math.Min(headingIndex + 7, lines.Length); j++)
+        {
+            var candidate = lines[j].Trim();
+            if (Regex.IsMatch(candidate, @"^#{1,3}\s"))
+                break;
+            if (candidate.Contains("applies-to:", StringComparison.Ordinal))
+            {
+                // A metadata comment immediately followed by another heading
+                // belongs to that following section (the original 1.3 shape),
+                // not to the current heading whose body happened to be short.
+                if (MetadataPrecedesAnotherHeading(lines, j))
+                    break;
+                return candidate;
+            }
+            if (candidate.Length == 0 || candidate == "---")
+                continue;
+            break;
+        }
+
+        return null;
+    }
+
+    private static bool MetadataPrecedesAnotherHeading(string[] lines, int metadataIndex)
+    {
+        for (var j = metadataIndex + 1; j < lines.Length; j++)
+        {
+            var candidate = lines[j].Trim();
+            if (candidate.Length == 0 || candidate == "---")
+                continue;
+            return Regex.IsMatch(candidate, @"^#{1,3}\s");
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Returns every section introduced strictly after the installed source
+    /// version and no later than the target. The metadata range must also overlap
+    /// the requested path. This makes the source boundary exclusive: a 1.13 →
+    /// 1.17 plan starts with the 1.14 step, not the already-applied 1.13 step.
     /// </summary>
     public static IReadOnlyList<GuideSection> SelectApplicable(
         IReadOnlyList<GuideSection> sections,
@@ -113,7 +161,9 @@ public sealed class MigrationPathTool
         SemVer toVer)
     {
         return sections
-            .Where(s => RangesOverlap(s.AppliesFrom, s.AppliesTo, fromVer, toVer))
+            .Where(s => s.IntroducedAt > fromVer
+                && s.IntroducedAt <= toVer
+                && RangesOverlap(s.AppliesFrom, s.AppliesTo, fromVer, toVer))
             .OrderBy(s => s.IntroducedAt)
             .ToList();
     }
@@ -123,20 +173,29 @@ public sealed class MigrationPathTool
 
     /// <summary>
     /// Parses metadata of the form:
-    /// <c>&lt;!-- introduced: 1.3.0 | applies-to: 1.0.x → 1.3.x | deprecated-in: ... --&gt;</c>
+    /// <c>&lt;!-- introduced: 1.17.0 | applies-to: 1.16.0.x → 1.17.0.x | deprecated-in: ... --&gt;</c>
+    /// Legacy two-component wildcards such as <c>1.2.x</c> are also accepted.
     /// Returns null if the comment doesn't have the expected shape.
     /// </summary>
     internal static (SemVer Introduced, SemVer AppliesFrom, SemVer AppliesTo)? ParseMetadata(string line)
     {
         var intro = Regex.Match(line, @"introduced:\s*([0-9]+\.[0-9]+\.[0-9]+)");
-        var applies = Regex.Match(line, @"applies-to:\s*([0-9]+\.[0-9]+)\.x\s*(?:→|->)\s*([0-9]+\.[0-9]+)\.x");
+        var applies = Regex.Match(
+            line,
+            @"applies-to:\s*([0-9]+\.[0-9]+(?:\.[0-9]+)?)\.x\s*(?:→|->)\s*([0-9]+\.[0-9]+(?:\.[0-9]+)?)\.x");
         if (!intro.Success || !applies.Success) return null;
 
         if (!TryParseVersion(intro.Groups[1].Value, out var introVer)) return null;
-        if (!TryParseVersion(applies.Groups[1].Value + ".0", out var fromVer)) return null;
-        if (!TryParseVersion(applies.Groups[2].Value + ".0", out var toVer)) return null;
+        if (!TryParseWildcardBase(applies.Groups[1].Value, out var fromVer)) return null;
+        if (!TryParseWildcardBase(applies.Groups[2].Value, out var toVer)) return null;
 
         return (introVer, fromVer, toVer);
+    }
+
+    private static bool TryParseWildcardBase(string value, out SemVer version)
+    {
+        var dotCount = value.Count(c => c == '.');
+        return TryParseVersion(dotCount == 1 ? value + ".0" : value, out version);
     }
 
     internal static bool TryParseVersion(string s, out SemVer version)
@@ -175,13 +234,13 @@ public sealed class MigrationPathTool
         var i = 1;
         foreach (var s in sections)
         {
-            sb.AppendLine($"| {i} | `{s.Title}` (guide line {s.LineNumber}) | `{s.IntroducedAt}` | `{s.AppliesFrom.Major}.{s.AppliesFrom.Minor}.x → {s.AppliesTo.Major}.{s.AppliesTo.Minor}.x` |");
+            sb.AppendLine($"| {i} | `{s.Title}` (guide line {s.LineNumber}) | `{s.IntroducedAt}` | `{s.AppliesFrom}.x → {s.AppliesTo}.x` |");
             i++;
         }
 
         sb.AppendLine();
         sb.AppendLine("### How to use this");
-        sb.AppendLine("Hand this list to `@maf-auditor` — it will load each section in order via the `maf-migration-guide` skill and generate a single consolidated migration plan covering every intermediate step.");
+        sb.AppendLine("Use this ordered list with the `maf-audit` MCP prompt to generate one consolidated migration plan covering every intermediate step. If the optional Copilot specialist agents are installed, `@maf-auditor` provides the equivalent guided flow.");
         return sb.ToString();
     }
 }

--- a/src/maf-autopilot/Tools/TourTool.cs
+++ b/src/maf-autopilot/Tools/TourTool.cs
@@ -145,7 +145,7 @@ public sealed class TourTool
     internal static readonly IReadOnlyList<(string Uri, string Description)> ResourceCatalogue = new[]
     {
         ("maf://constraints", "Hard constraints + breaking-changes table. Always-loaded by every agent."),
-        ("maf://guide", "Full MAF migration guide (21 sections). Read on demand."),
+        ("maf://guide", "Cumulative, version-keyed MAF migration guide through the current tracked release. Read on demand."),
         ("maf://registry", "Machine-readable obsolete-API registry YAML."),
         ("maf://rules", "Live rule catalogue — anti-pattern + prompt-lint + analyzer + cross-references. Auto-generated from runtime data."),
         ("maf://help", "Same content as `MafTour()` but as a resource — useful for static discovery without a tool call."),

--- a/src/maf-autopilot/maf-autopilot.csproj
+++ b/src/maf-autopilot/maf-autopilot.csproj
@@ -17,7 +17,7 @@
          release.yml overrides this from the pushed tag and keeps the analyzer
          package in lockstep, so the canonical version is the git tag (`vX.Y.Z`).
          This value is the local/dev default. -->
-    <Version>1.14.0</Version>
+    <Version>1.15.0</Version>
     <Authors>joslat</Authors>
     <Description>MAF Doctor — a .NET global tool and MCP server for Microsoft Agent Framework (MAF). Diagnoses, explains, and auto-fixes MAF agents and workflows: A-F health grades, deterministic Roslyn rewriters, anti-pattern and fan-out scanning, and a self-updating obsolete-API registry. Use it from Copilot / Claude / Cursor via MCP, or standalone as a CLI.</Description>
     <PackageTags>maf;migration;mcp;dotnet;agents</PackageTags>
@@ -80,14 +80,14 @@
     <EmbeddedResource Include="..\..\.github\instructions\maf-constraints.instructions.md"
                       LogicalName="constraints.md" />
 
-    <!-- Full migration guide — served at maf://guide -->
-    <EmbeddedResource Include="..\..\guides\maf-1.3.0-migration-guide.md"
+    <!-- Cumulative, version-keyed migration guide — served at maf://guide -->
+    <EmbeddedResource Include="..\..\guides\maf-current-migration-guide.md"
                       LogicalName="guide.md" />
     <!-- Cross-framework migration guide — served at maf://migrate-from?source=semantic-kernel -->
     <EmbeddedResource Include="..\..\docs\migration\from-semantic-kernel-to-maf.md"
                       LogicalName="migrate-from/semantic-kernel.md" />
 
-    <!-- All 14 skill SKILL.md files — served at maf://skills?name=<skill-name> -->
+    <!-- All 15 skill SKILL.md files — served at maf://skills?name=<skill-name> -->
     <EmbeddedResource Include="..\..\.github\skills\cs0618-hunter\SKILL.md"
                       LogicalName="skills/cs0618-hunter.md" />
     <EmbeddedResource Include="..\..\.github\skills\maf-from-semantic-kernel\SKILL.md"


### PR DESCRIPTION
## Summary

- publish reviewed migration intelligence for the sequential MAF 1.14 → 1.15 → 1.16 → 1.17 chain
- bump `maf-doctor` and `maf-doctor.Analyzers` to 1.15.0 in lockstep
- embed the cumulative 1.3→1.17 guide and fix `MafMigrationPath` metadata/source-boundary handling
- finalize reviewed guide titles while retaining the genuinely incomplete 1.4/1.5 guides as drafts
- fail closed on malformed NuGet/symbol artifacts and keep tag-triggered GHCR publishing on reviewed `main`

## Validation

- 326 Python helper tests passed
- 3,861 .NET tests passed across net8.0, net9.0, and net10.0
- registry and cross-file consistency gates passed
- local pack produced exactly two `.nupkg` and two `.snupkg` artifacts; strict package verification passed
- isolated install reported `maf-doctor 1.15.0`; empty-directory doctor smoke returned grade A
- installed assembly resource inspection confirmed the cumulative guide and MAF 1.17 content are embedded

## Release sequence

After this PR is green and merged, create the curated `v1.15.0` draft release at the merge SHA, push the annotated tag, and verify the NuGet, GitHub Release, provenance, and GHCR workflows.
